### PR TITLE
Fix copy and paste not working

### DIFF
--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -22,7 +22,7 @@
     ],
     "file.saveAs":  [
         "Ctrl-Shift-S"
-    ],    
+    ],
     "file.liveFilePreview":  [
         "Ctrl-Alt-P"
     ],
@@ -48,15 +48,6 @@
             "key": "Cmd-Shift-Z",
             "platform": "mac"
         }
-    ],
-    "edit.cut": [
-        "Ctrl-X"
-    ],
-    "edit.copy": [
-        "Ctrl-C"
-    ],
-    "edit.paste": [
-        "Ctrl-V"
     ],
     "edit.selectAll":  [
         "Ctrl-A"
@@ -221,7 +212,7 @@
         }
     ],
     "view.toggleSidebar":  [
-        {   
+        {
             "key" : "Ctrl-Alt-H"
         },
         {

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -1188,7 +1188,23 @@ define(function (require, exports, module) {
         _execCommand("copy");
     }
     function _execCommandPaste() {
-        _execCommand("paste");
+        if(window.navigator && window.navigator.clipboard){
+            window.navigator.clipboard.readText().then(function (text) {
+                var editor = EditorManager.getFocusedEditor();
+                if(editor){
+                    var doc = editor._codeMirror.getDoc();
+                    var selection = doc.getSelection();
+                    var cursor = doc.getCursor();
+                    if(selection){
+                        doc.replaceSelection(text);
+                    } else {
+                        doc.replaceRange(text, cursor);
+                    }
+                }
+            });
+        } else {
+            _execCommand("paste");
+        }
     }
 
     // Register commands


### PR DESCRIPTION
## Fixes
* copy+paste works via shortcuts
* works via right-click menus. We integrated with the new clipboard API to have direct access to clipboard text.
* Tested working in chrome, edge, and firefox.

## known issues
* Firefox does not support js initiated clipboard paste other than via extensions. Ctrl-c, Ctrl-V works though.
https://github.com/aicore/phoenix/issues/51