### PR TITLE
Fix double prompt on opening a native project folder. 

### DIFF
--- a/src/phoenix/fslib_mounts.js
+++ b/src/phoenix/fslib_mounts.js
@@ -230,7 +230,7 @@ async function _findLeafNode(currentNode, pathArray, currentIndex, callback) {
 
 async function _verifyOrRequestPermission(fileHandle, callback) {
     const options = {
-        mode: 'readwrite'
+        mode: 'read'
     };
 
     // Check if permission was already granted. If so, return true.


### PR DESCRIPTION
## Fix double prompt on opening a native project folder. 

* Write permission will be automatically prompted when a file is opened in write mode. 

https://github.com/aicore/phoenix/issues/124