### PR TITLE
fix: drag and drop working in editor

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -172,7 +172,7 @@ define(function (require, exports, module) {
             }
         }
     });
-    PreferencesManager.definePreference(DRAG_DROP,          "boolean", false, {
+    PreferencesManager.definePreference(DRAG_DROP,          "boolean", true, {
         description: Strings.DESCRIPTION_DRAG_DROP_TEXT
     });
     PreferencesManager.definePreference(HIGHLIGHT_MATCHES,  "boolean", false, {


### PR DESCRIPTION
![dragdrop](https://user-images.githubusercontent.com/5336369/156320795-ccb1fafc-7e28-43f0-8503-11ca6f04f116.gif)

* Verified that the code mirror integration fixed the original issue that forced brackets to disable drag-drop: details here: https://github.com/adobe/brackets/issues/10590
* Files can now be dragged dropped any where in phoenix, but have to fix bug relating to file processing