### PR TITLE
fix: live preview collapse to min size when clicking toolbar icon twice

### DIFF
--- a/src/utils/Resizer.js
+++ b/src/utils/Resizer.js
@@ -360,6 +360,8 @@ define(function (require, exports, module) {
             adjustSibling(elementSize);
 
             $element.trigger(EVENT_PANEL_EXPANDED, [elementSize]);
+            elementPrefs.size = elementSize;
+            elementPrefs.contentSize = contentSize;
             PreferencesManager.setViewState(elementID, elementPrefs, null, isResizing);
         });
 


### PR DESCRIPTION
We were not saving the panel size on collapse of live preview. now we save it .