### PR TITLE
chore: removing phoenix markdown extension till we have better ux

### DIFF
--- a/src/extensions/default/DefaultExtensions.json
+++ b/src/extensions/default/DefaultExtensions.json
@@ -33,6 +33,5 @@
   "LightTheme",
   "HealthData",
   "Phoenix-extension-store",
-  "Phoenix-live-preview",
-  "Phoenix-Markdown"
+  "Phoenix-live-preview"
 ]


### PR DESCRIPTION
We will most likely moving markdown into live preview. so removing the current markdown extension as it is not confirming to phoenix UX.