### PR TITLE
fix: keyboard shortcuts and removed unavailable menu items

### DIFF
--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -1,21 +1,21 @@
 {
-    "file.newDoc":  [
-        "Ctrl-N"
+    "file.newFile":  [
+        "Alt-N"
     ],
     "file.open":  [
         "Ctrl-O"
     ],
     "file.close":  [
-        "Ctrl-W"
+        "Alt-W"
     ],
     "file.openFolder": [
         "Ctrl-Alt-O"
     ],
     "file.close_all":  [
-        "Ctrl-Shift-W"
+        "Alt-Shift-W"
     ],
     "file.save":  [
-        "Ctrl-s"
+        "Ctrl-S"
     ],
     "file.saveAll":  [
         "Ctrl-Alt-S"

--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -74,12 +74,12 @@ define(function (require, exports, module) {
         menu.addMenuDivider();
         menu.addMenuItem(Commands.FILE_SAVE);
         menu.addMenuItem(Commands.FILE_SAVE_ALL);
-        menu.addMenuItem(Commands.FILE_SAVE_AS);
+        // menu.addMenuItem(Commands.FILE_SAVE_AS); not yet available in phoenix
         menu.addMenuDivider();
-        //menu.addMenuItem(Commands.TOGGLE_LIVE_PREVIEW_MB_MODE);
-        menu.addMenuItem(Commands.FILE_PROJECT_SETTINGS);
-        menu.addMenuDivider();
-        menu.addMenuItem(Commands.FILE_EXTENSION_MANAGER);
+        //menu.addMenuItem(Commands.TOGGLE_LIVE_PREVIEW_MB_MODE); remove this mode as its not in phcode
+        // menu.addMenuItem(Commands.FILE_PROJECT_SETTINGS); not yet available in phoenix
+        //menu.addMenuDivider(); not yet available in phoenix
+        // menu.addMenuItem(Commands.FILE_EXTENSION_MANAGER); not yet available in phoenix
 
         /*
          * Edit  menu

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -511,7 +511,16 @@ define(function (require, exports, module) {
             key = "Insert";
         } else if (event.keyCode === KeyEvent.DOM_VK_DELETE) {
             key = "Delete";
-        } else {
+        } else if (key === "ArrowUp") {
+            key = "Up";
+        } else if (key === "ArrowDown") {
+            key = "Down";
+        } else if (key === "ArrowLeft") {
+            key = "Left";
+        } else if (key === "ArrowRight") {
+            key = "Right";
+        }
+        else {
             key = _mapKeycodeToKey(event.keyCode, key);
         }
 


### PR DESCRIPTION
* Since https://github.com/phcode-dev/phoenix/pull/406, modifying shortcut framework to identify arrow keys
* Browser doesn't allow to overwrite tab management shortcuts like `ctrl-w`. Changed it to `alt-w` instead.
* Remove menu items that is not available in phoenix