### PR TITLE
fix: safari overlay visible over image previews

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -39,6 +39,7 @@ define(function (require, exports, module) {
 
     function _removePhoenixLoadingOverlay() {
         document.getElementById('phoenix-loading-splash-screen-overlay').remove();
+        document.getElementById('safari_splash_screen').remove();
     }
 
     // Load dependent non-module scripts


### PR DESCRIPTION
fix:
![image](https://user-images.githubusercontent.com/5336369/163714629-34e2a0b4-b7f8-4869-add9-efa3ad271cf6.png)
