### PR TITLE
chore: performance improvement with large folders in file tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "phoenix",
             "version": "2.0.0-0",
             "dependencies": {
-                "@phcode/fs": "^1.0.9",
+                "@phcode/fs": "^1.0.10",
                 "browser-mime": "^1.0.1",
                 "jszip": "^3.7.1",
                 "marked": "^4.0.14",
@@ -592,9 +592,9 @@
             }
         },
         "node_modules/@phcode/fs": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/@phcode/fs/-/fs-1.0.9.tgz",
-            "integrity": "sha512-GreSz+HnHObqX+lM7TYfspjDRVZZNQB72wnIZE7KUtTzgw+eOG5DXxUOeOfB2iuRV833cGUDagl+8rJMCwlJ1Q=="
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/@phcode/fs/-/fs-1.0.10.tgz",
+            "integrity": "sha512-R1w68I04XUoJ8KrwqZHPXLgXMjlcS8QksiS7FIeU/xZZw0xvPtYqlG44zpHH5xt21d9iS74FZp4K0wJckoWw9Q=="
         },
         "node_modules/@tsconfig/node10": {
             "version": "1.0.8",
@@ -11056,9 +11056,9 @@
             }
         },
         "@phcode/fs": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/@phcode/fs/-/fs-1.0.9.tgz",
-            "integrity": "sha512-GreSz+HnHObqX+lM7TYfspjDRVZZNQB72wnIZE7KUtTzgw+eOG5DXxUOeOfB2iuRV833cGUDagl+8rJMCwlJ1Q=="
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/@phcode/fs/-/fs-1.0.10.tgz",
+            "integrity": "sha512-R1w68I04XUoJ8KrwqZHPXLgXMjlcS8QksiS7FIeU/xZZw0xvPtYqlG44zpHH5xt21d9iS74FZp4K0wJckoWw9Q=="
         },
         "@tsconfig/node10": {
             "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         }
     ],
     "dependencies": {
-        "@phcode/fs": "^1.0.9",
+        "@phcode/fs": "^1.0.10",
         "browser-mime": "^1.0.1",
         "jszip": "^3.7.1",
         "marked": "^4.0.14",


### PR DESCRIPTION
When reading dirs with fs.readdir in phoenix, we were subsequently queuing fs.stat for every sub entry. This causes large fs read queues.

To mitigate this, fs.readdir can be specified with an optional `withFileTypes` parameter that will return the file stat along with the readdir API reducing fs calls significantly. filer already supports this option. We added the option to phoenix fs native API with this commit: https://github.com/phcode-dev/phoenix-fs/commit/1c808c4dbf5bd6af0c3f076281be689a0c393e13

Updating phoenix to use latest phoenix fs api with  `withFileTypes` support and related handler changes.

## Result
Folder open in file tree times improved significantly from more than 25 seconds with 1000 files in a dir to under 1 second.