### PR TITLE
fix: pin live preview not working

### DIFF
--- a/src/extensions/default/Phoenix-live-preview/main.js
+++ b/src/extensions/default/Phoenix-live-preview/main.js
@@ -229,7 +229,7 @@ define(function (require, exports, module) {
                     }
                 }
             };
-            if(currentSrc !== newSrc || force){
+            if(currentSrc !== newSrc || force === true){
                 $iframe.src = newSrc;
                 _renderPreview(previewDetails, newSrc);
             }


### PR DESCRIPTION
We have attached certain event handlers to the _loadPreview method (Eg. `MainViewManager.on("currentFileChange", _loadPreview);` ) . The event handler will trigger _loadPreview with event args, which was being treated as `force = true` as we did not explicitly check for true. This resulted in inconsistent live preview renders even when live preview was pinned.