### PR TITLE
chore: remove project related health data as it uses node

### DIFF
--- a/src/extensions/default/HealthData/HealthDataManager.js
+++ b/src/extensions/default/HealthData/HealthDataManager.js
@@ -32,6 +32,7 @@ define(function (require, exports, module) {
         PreferencesManager  = brackets.getModule("preferences/PreferencesManager"),
         UrlParams           = brackets.getModule("utils/UrlParams").UrlParams,
         Strings             = brackets.getModule("strings"),
+        Metrics             = brackets.getModule("utils/Metrics"),
         HealthDataUtils     = require("HealthDataUtils"),
         SendToAnalytics     = require("SendToAnalytics"),
         prefs               = PreferencesManager.getExtensionPrefs("healthData"),
@@ -232,6 +233,8 @@ define(function (require, exports, module) {
     });
 
     prefs.on("change", "healthDataTracking", function () {
+        let healthDataDisabled = !prefs.get("healthDataTracking");
+        Metrics.setDisabled(healthDataDisabled);
         checkHealthDataSend();
     });
 
@@ -246,6 +249,9 @@ define(function (require, exports, module) {
     });
 
     AppInit.appReady(function () {
+        Metrics.init();
+        let healthDataDisabled = !prefs.get("healthDataTracking");
+        Metrics.setDisabled(healthDataDisabled);
         checkHealthDataSend();
     });
 

--- a/src/extensions/default/HealthData/SendToAnalytics.js
+++ b/src/extensions/default/HealthData/SendToAnalytics.js
@@ -93,24 +93,6 @@ define(function (require, exports, module) {
         }
     }
 
-    function _sendProjectMetrics(data) {
-        let NUM_FILES = "numFiles",
-            NUM_PROJECTS_OPENED = "numProjectsOpened",
-            CACHE_SIZE= "cacheSize",
-            numProjects = 0,
-            projectDetails = data["ProjectDetails"] || {};
-        for(let projectName in projectDetails) {
-            let project = projectDetails[projectName];
-            numProjects++;
-            let numFiles = project[NUM_FILES] || 0;
-            sendEvent(CATEGORY_PROJECT, NUM_FILES, null, numFiles);
-            let cacheSize = project[CACHE_SIZE] || 0;
-            sendEvent(CATEGORY_PROJECT, CACHE_SIZE, null, cacheSize);
-        }
-        sendEvent(CATEGORY_PROJECT, NUM_PROJECTS_OPENED, null, numProjects);
-        _sendProjectLoadTimeMetrics(data);
-    }
-
     function _sendFileMetrics(data) {
         let CATEGORY_FILE = "FILE_STATS",
             ACTION_OPENED_FILES_EXT = "openedFileExt",
@@ -152,7 +134,6 @@ define(function (require, exports, module) {
 
     function sendHealthDataToGA(healthData) {
         _sendPlatformMetrics(healthData);
-        _sendProjectMetrics(healthData);
         _sendFileMetrics(healthData);
         _sendThemesMetrics(healthData);
         _sendExtensionMetrics(healthData);

--- a/src/extensions/default/HealthData/main.js
+++ b/src/extensions/default/HealthData/main.js
@@ -26,7 +26,6 @@ define(function (require, exports, module) {
 
     var AppInit                 = brackets.getModule("utils/AppInit"),
         HealthLogger            = brackets.getModule("utils/HealthLogger"),
-        Metrics                 = brackets.getModule("utils/Metrics"),
         Menus                   = brackets.getModule("command/Menus"),
         CommandManager          = brackets.getModule("command/CommandManager"),
         Strings                 = brackets.getModule("strings"),
@@ -65,7 +64,6 @@ define(function (require, exports, module) {
 
     AppInit.appReady(function () {
         initTest();
-        Metrics.init();
         HealthLogger.init();
     });
 

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -40,8 +40,7 @@ define(function (require, exports, module) {
         PerfUtils             = require("utils/PerfUtils"),
         NodeDomain            = require("utils/NodeDomain"),
         FileUtils             = require("file/FileUtils"),
-        FindUtils             = require("search/FindUtils"),
-        HealthLogger          = require("utils/HealthLogger");
+        FindUtils             = require("search/FindUtils");
 
     var _bracketsPath   = FileUtils.getNativeBracketsDirectoryPath(),
         _modulePath     = FileUtils.getNativeModuleDirectoryPath(module),
@@ -122,7 +121,6 @@ define(function (require, exports, module) {
         // we re-enable node search. If a search fails, node search will be switched off eventually.
         FindUtils.setNodeSearchDisabled(false);
         FindUtils.notifyIndexingFinished();
-        HealthLogger.setProjectDetail(projectName, numFiles, cacheSize);
     }
 
     /**

--- a/src/utils/HealthLogger.js
+++ b/src/utils/HealthLogger.js
@@ -256,26 +256,6 @@ define(function (require, exports, module) {
         });
     }
 
-    /**
-     * Sets the project details(a probably unique prjID, number of files in the project and the node cache size) in the health log
-     * The name of the project is never saved into the health data log, only the hash(name) is for privacy requirements.
-     * @param {string} projectName The name of the project
-     * @param {number} numFiles    The number of file in the project
-     * @param {number} cacheSize   The node file cache memory consumed by the project
-     */
-    function setProjectDetail(projectName, numFiles, cacheSize) {
-        var projectNameHash = StringUtils.hashCode(projectName),
-            FIFLog = getHealthDataLog("ProjectDetails");
-        if (!FIFLog) {
-            FIFLog = {};
-        }
-        FIFLog["prj" + projectNameHash] = {
-            numFiles: numFiles,
-            cacheSize: cacheSize
-        };
-        setHealthDataLog("ProjectDetails", FIFLog);
-    }
-
     // Define public API
     exports.getHealthDataLog          = getHealthDataLog;
     exports.setHealthDataLog          = setHealthDataLog;
@@ -284,7 +264,6 @@ define(function (require, exports, module) {
     exports.fileOpened                = fileOpened;
     exports.fileSaved                 = fileSaved;
     exports.fileClosed                = fileClosed;
-    exports.setProjectDetail          = setProjectDetail;
     exports.setHealthLogsEnabled      = setHealthLogsEnabled;
     exports.shouldLogHealthData       = shouldLogHealthData;
     exports.init                      = init;


### PR DESCRIPTION
* remove project stats health as these were generated with node file indexer which is not available in phoenix. To be considered later. https://github.com/phcode-dev/phoenix/issues/444
* Wire  in preference `healthDataTracking` to enable/disable analytics