### PR TITLE
Auto generate API docs in markdown format

### DIFF
--- a/docs/utils/Metrics.md
+++ b/docs/utils/Metrics.md
@@ -1,0 +1,38 @@
+
+
+# Metrics API
+The Metrics API can be used to send analytics data to track feature usage in accordance with users privacy settings.
+
+`Status: Internal - Not to be used by third party extensions.`
+
+## Import
+```js
+// usage within core:
+const Metrics = require("utils/Metrics");
+
+// usage within default extensions:
+const Metrics = brackets.getModule("utils/Metrics");
+```
+
+## APIs
+Two main APIs are available
+
+### Metrics.countEvent
+log a numeric count >=0
+
+@param {string} eventType The kind of Event Type that needs to be logged- should be a js var compatible string
+@param {string} eventCategory The kind of Event Category that
+needs to be logged- should be a js var compatible string
+@param {string} eventSubCategory The kind of Event Sub Category that
+needs to be logged- should be a js var compatible string
+@param {number} count >=0
+
+### Metrics.valueEvent
+log a numeric value (number).
+
+@param {string} eventType The kind of Event Type that needs to be logged- should be a js var compatible string
+@param {string} eventCategory The kind of Event Category that
+needs to be logged- should be a js var compatible string
+@param {string} eventSubCategory The kind of Event Sub Category that
+needs to be logged- should be a js var compatible string
+@param {number} value

--- a/gulpfile.js/index.js
+++ b/gulpfile.js/index.js
@@ -1,3 +1,23 @@
+/*
+ * GNU AGPL-3.0 License
+ *
+ * Copyright (c) 2022 - present core.ai . All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
+ *
+ */
+
 /* eslint-env node */
 
 const del = require('del');

--- a/gulpfile.js/jsDocGenerate.js
+++ b/gulpfile.js/jsDocGenerate.js
@@ -1,19 +1,85 @@
+/*
+ * GNU AGPL-3.0 License
+ *
+ * Copyright (c) 2022 - present core.ai . All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
+ *
+ */
+
 /* eslint-env node */
+const Comments = require('parse-comments');
+
+const TAG_INCLUDE_IN_API_DOCS = "INCLUDE_IN_API_DOCS",
+    TAG_PRIVATE ="private";
 
 /**
- * Generate markdown documentation for all files labelled with @INCLUDE_IN_PHOENIX_API_DOCS into the docs folder.
+ * Generate markdown documentation for all files labelled with @INCLUDE_IN_API_DOCS into the docs folder.
  * @param file
  * @returns {*}
  */
 function processFile(file) {
     // For file properties https://gulpjs.com/docs/en/api/vinyl/
     const code = file.contents.toString();
-    if(code.includes("@INCLUDE_IN_PHOENIX_API_DOCS")){
+    if(code.includes("@"+ TAG_INCLUDE_IN_API_DOCS)){
         console.log("Generating Doc for: ", file.relative);
-        file.contents = Buffer.from("hello");
+        file.contents = Buffer.from(getAPIDoc(code));
         file.extname = ".md";
         return file;
     }
+}
+
+/**
+ * TODO:
+ * @param {string} eventType
+ * @param {string} [eventType="df"]
+ * @param {string} [eventType]
+ * @param {string?} [eventType]
+ * @param {string!} [eventType]
+ * @return
+ * @returns
+ * @arg - same as param
+ * @argument - same as param
+ */
+
+function isCommentIncludesTag(comment, tagName) {
+    for(let tag of comment.tags){
+        if(tag.title === tagName){
+            return true;
+        }
+    }
+    return false;
+}
+
+function processComment(comment) {
+    if(comment.type !== 'BlockComment' || isCommentIncludesTag(comment, TAG_PRIVATE)){
+        return '';
+    }
+    let output = "\n";
+    let commentStr = comment.value;
+    // console.log(comment);
+    return output+ commentStr;
+}
+
+function getAPIDoc(srcCode) {
+    const comments = new Comments();
+    const ast = comments.parse(srcCode);
+    let apiDocMarkDown = "";
+    for(let comment of ast){
+        apiDocMarkDown += processComment(comment);
+    }
+    return apiDocMarkDown;
 }
 
 exports.processFile = processFile;

--- a/gulpfile.js/jsDocGenerate.js
+++ b/gulpfile.js/jsDocGenerate.js
@@ -1,0 +1,19 @@
+/* eslint-env node */
+
+/**
+ * Generate markdown documentation for all files labelled with @INCLUDE_IN_PHOENIX_API_DOCS into the docs folder.
+ * @param file
+ * @returns {*}
+ */
+function processFile(file) {
+    // For file properties https://gulpjs.com/docs/en/api/vinyl/
+    const code = file.contents.toString();
+    if(code.includes("@INCLUDE_IN_PHOENIX_API_DOCS")){
+        console.log("Generating Doc for: ", file.relative);
+        file.contents = Buffer.from("hello");
+        file.extname = ".md";
+        return file;
+    }
+}
+
+exports.processFile = processFile;

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
                 "gulp": "^4.0.2",
                 "gulp-concat": "^2.6.1",
                 "gulp-cssnano": "^2.1.3",
+                "gulp-flatten": "^0.4.0",
                 "gulp-if": "^3.0.0",
                 "gulp-rename": "^2.0.0",
                 "gulp-uglify": "^3.0.2",
@@ -34,7 +35,8 @@
                 "husky": "^7.0.4",
                 "lodash": "^4.17.21",
                 "merge-stream": "^2.0.0",
-                "readable-stream": "^3.6.0"
+                "readable-stream": "^3.6.0",
+                "through2": "^4.0.2"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -732,10 +734,34 @@
                 "node": ">=6"
             }
         },
+        "node_modules/ansi-cyan": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
+            "integrity": "sha512-eCjan3AVo/SxZ0/MyIYRtkpxIu/H3xZN7URr1vXVrISxeyz8fUFz0FJziamK4sS8I+t35y4rHg1b2PklyBe/7A==",
+            "dev": true,
+            "dependencies": {
+                "ansi-wrap": "0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/ansi-gray": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
             "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+            "dev": true,
+            "dependencies": {
+                "ansi-wrap": "0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/ansi-red": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+            "integrity": "sha512-ewaIr5y+9CUTGFwZfpECUbFlGcC0GCw1oqR9RI6h1gQCd9Aj2GxSckCnPsVJnmfMZbwFYE+leZGASgkWl06Jow==",
             "dev": true,
             "dependencies": {
                 "ansi-wrap": "0.1.0"
@@ -2523,15 +2549,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/conventional-commits-parser/node_modules/through2": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
-            "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
-            "dev": true,
-            "dependencies": {
-                "readable-stream": "3"
-            }
-        },
         "node_modules/conventional-commits-parser/node_modules/trim-newlines": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
@@ -4175,6 +4192,31 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/fs-mkdirp-stream/node_modules/readable-stream": {
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "dev": true,
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/fs-mkdirp-stream/node_modules/through2": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+            "dev": true,
+            "dependencies": {
+                "readable-stream": "~2.3.6",
+                "xtend": "~4.0.1"
+            }
+        },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4565,15 +4607,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/git-raw-commits/node_modules/through2": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
-            "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
-            "dev": true,
-            "dependencies": {
-                "readable-stream": "3"
-            }
-        },
         "node_modules/git-raw-commits/node_modules/trim-newlines": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
@@ -4851,6 +4884,31 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/gulp-concat/node_modules/readable-stream": {
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "dev": true,
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/gulp-concat/node_modules/through2": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+            "dev": true,
+            "dependencies": {
+                "readable-stream": "~2.3.6",
+                "xtend": "~4.0.1"
+            }
+        },
         "node_modules/gulp-cssnano": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/gulp-cssnano/-/gulp-cssnano-2.1.3.tgz",
@@ -4862,6 +4920,112 @@
                 "object-assign": "^4.0.1",
                 "plugin-error": "^1.0.1",
                 "vinyl-sourcemaps-apply": "^0.2.1"
+            }
+        },
+        "node_modules/gulp-flatten": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/gulp-flatten/-/gulp-flatten-0.4.0.tgz",
+            "integrity": "sha512-eg4spVTAiv1xXmugyaCxWne1oPtNG0UHEtABx5W8ScLiqAYceyYm6GYA36x0Qh8KOIXmAZV97L2aYGnKREG3Sg==",
+            "dev": true,
+            "dependencies": {
+                "plugin-error": "^0.1.2",
+                "through2": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/gulp-flatten/node_modules/arr-diff": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+            "integrity": "sha512-OQwDZUqYaQwyyhDJHThmzId8daf4/RFNLaeh3AevmSeZ5Y7ug4Ga/yKc6l6kTZOBW781rCj103ZuTh8GAsB3+Q==",
+            "dev": true,
+            "dependencies": {
+                "arr-flatten": "^1.0.1",
+                "array-slice": "^0.2.3"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/gulp-flatten/node_modules/arr-union": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+            "integrity": "sha512-t5db90jq+qdgk8aFnxEkjqta0B/GHrM1pxzuuZz2zWsOXc5nKu3t+76s/PQBA8FTcM/ipspIH9jWG4OxCBc2eA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/gulp-flatten/node_modules/array-slice": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+            "integrity": "sha512-rlVfZW/1Ph2SNySXwR9QYkChp8EkOEiTMO5Vwx60usw04i4nWemkm9RXmQqgkQFaLHsqLuADvjp6IfgL9l2M8Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/gulp-flatten/node_modules/extend-shallow": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+            "integrity": "sha512-L7AGmkO6jhDkEBBGWlLtftA80Xq8DipnrRPr0pyi7GQLXkaq9JYA4xF4z6qnadIC6euiTDKco0cGSU9muw+WTw==",
+            "dev": true,
+            "dependencies": {
+                "kind-of": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/gulp-flatten/node_modules/kind-of": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+            "integrity": "sha512-aUH6ElPnMGon2/YkxRIigV32MOpTVcoXQ1Oo8aYn40s+sJ3j+0gFZsT8HKDcxNy7Fi9zuquWtGaGAahOdv5p/g==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/gulp-flatten/node_modules/plugin-error": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
+            "integrity": "sha512-WzZHcm4+GO34sjFMxQMqZbsz3xiNEgonCskQ9v+IroMmYgk/tas8dG+Hr2D6IbRPybZ12oWpzE/w3cGJ6FJzOw==",
+            "dev": true,
+            "dependencies": {
+                "ansi-cyan": "^0.1.1",
+                "ansi-red": "^0.1.1",
+                "arr-diff": "^1.0.1",
+                "arr-union": "^2.0.1",
+                "extend-shallow": "^1.1.2"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/gulp-flatten/node_modules/readable-stream": {
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "dev": true,
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/gulp-flatten/node_modules/through2": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+            "dev": true,
+            "dependencies": {
+                "readable-stream": "~2.3.6",
+                "xtend": "~4.0.1"
             }
         },
         "node_modules/gulp-if": {
@@ -4921,6 +5085,31 @@
                 "vinyl-sourcemaps-apply": "^0.2.0"
             }
         },
+        "node_modules/gulp-uglify/node_modules/readable-stream": {
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "dev": true,
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/gulp-uglify/node_modules/through2": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+            "dev": true,
+            "dependencies": {
+                "readable-stream": "~2.3.6",
+                "xtend": "~4.0.1"
+            }
+        },
         "node_modules/gulp-useref": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/gulp-useref/-/gulp-useref-5.0.0.tgz",
@@ -4939,15 +5128,6 @@
             },
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/gulp-useref/node_modules/through2": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
-            "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
-            "dev": true,
-            "dependencies": {
-                "readable-stream": "3"
             }
         },
         "node_modules/gulp-util": {
@@ -8507,6 +8687,31 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/remove-bom-stream/node_modules/readable-stream": {
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "dev": true,
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/remove-bom-stream/node_modules/through2": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+            "dev": true,
+            "dependencies": {
+                "readable-stream": "~2.3.6",
+                "xtend": "~4.0.1"
+            }
+        },
         "node_modules/remove-trailing-separator": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -9626,13 +9831,12 @@
             "dev": true
         },
         "node_modules/through2": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+            "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
             "dev": true,
             "dependencies": {
-                "readable-stream": "~2.3.6",
-                "xtend": "~4.0.1"
+                "readable-stream": "3"
             }
         },
         "node_modules/through2-filter": {
@@ -9645,7 +9849,7 @@
                 "xtend": "~4.0.0"
             }
         },
-        "node_modules/through2/node_modules/readable-stream": {
+        "node_modules/through2-filter/node_modules/readable-stream": {
             "version": "2.3.7",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
             "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
@@ -9658,6 +9862,16 @@
                 "safe-buffer": "~5.1.1",
                 "string_decoder": "~1.1.1",
                 "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/through2-filter/node_modules/through2": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+            "dev": true,
+            "dependencies": {
+                "readable-stream": "~2.3.6",
+                "xtend": "~4.0.1"
             }
         },
         "node_modules/time-stamp": {
@@ -9765,6 +9979,31 @@
             },
             "engines": {
                 "node": ">= 0.10"
+            }
+        },
+        "node_modules/to-through/node_modules/readable-stream": {
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "dev": true,
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/to-through/node_modules/through2": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+            "dev": true,
+            "dependencies": {
+                "readable-stream": "~2.3.6",
+                "xtend": "~4.0.1"
             }
         },
         "node_modules/toidentifier": {
@@ -10282,6 +10521,16 @@
                 "safe-buffer": "~5.1.1",
                 "string_decoder": "~1.1.1",
                 "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/vinyl-fs/node_modules/through2": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+            "dev": true,
+            "dependencies": {
+                "readable-stream": "~2.3.6",
+                "xtend": "~4.0.1"
             }
         },
         "node_modules/vinyl-sourcemap": {
@@ -11172,10 +11421,28 @@
             "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
             "dev": true
         },
+        "ansi-cyan": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
+            "integrity": "sha512-eCjan3AVo/SxZ0/MyIYRtkpxIu/H3xZN7URr1vXVrISxeyz8fUFz0FJziamK4sS8I+t35y4rHg1b2PklyBe/7A==",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
         "ansi-gray": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
             "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
+        "ansi-red": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+            "integrity": "sha512-ewaIr5y+9CUTGFwZfpECUbFlGcC0GCw1oqR9RI6h1gQCd9Aj2GxSckCnPsVJnmfMZbwFYE+leZGASgkWl06Jow==",
             "dev": true,
             "requires": {
                 "ansi-wrap": "0.1.0"
@@ -12624,15 +12891,6 @@
                         "min-indent": "^1.0.0"
                     }
                 },
-                "through2": {
-                    "version": "4.0.2",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
-                    "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": "3"
-                    }
-                },
                 "trim-newlines": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
@@ -13978,6 +14236,33 @@
             "requires": {
                 "graceful-fs": "^4.1.11",
                 "through2": "^2.0.3"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "through2": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+                    "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "~2.3.6",
+                        "xtend": "~4.0.1"
+                    }
+                }
             }
         },
         "fs.realpath": {
@@ -14272,15 +14557,6 @@
                         "min-indent": "^1.0.0"
                     }
                 },
-                "through2": {
-                    "version": "4.0.2",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
-                    "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": "3"
-                    }
-                },
                 "trim-newlines": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
@@ -14533,6 +14809,33 @@
                 "concat-with-sourcemaps": "^1.0.0",
                 "through2": "^2.0.0",
                 "vinyl": "^2.0.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "through2": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+                    "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "~2.3.6",
+                        "xtend": "~4.0.1"
+                    }
+                }
             }
         },
         "gulp-cssnano": {
@@ -14546,6 +14849,93 @@
                 "object-assign": "^4.0.1",
                 "plugin-error": "^1.0.1",
                 "vinyl-sourcemaps-apply": "^0.2.1"
+            }
+        },
+        "gulp-flatten": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/gulp-flatten/-/gulp-flatten-0.4.0.tgz",
+            "integrity": "sha512-eg4spVTAiv1xXmugyaCxWne1oPtNG0UHEtABx5W8ScLiqAYceyYm6GYA36x0Qh8KOIXmAZV97L2aYGnKREG3Sg==",
+            "dev": true,
+            "requires": {
+                "plugin-error": "^0.1.2",
+                "through2": "^2.0.0"
+            },
+            "dependencies": {
+                "arr-diff": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+                    "integrity": "sha512-OQwDZUqYaQwyyhDJHThmzId8daf4/RFNLaeh3AevmSeZ5Y7ug4Ga/yKc6l6kTZOBW781rCj103ZuTh8GAsB3+Q==",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "^1.0.1",
+                        "array-slice": "^0.2.3"
+                    }
+                },
+                "arr-union": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+                    "integrity": "sha512-t5db90jq+qdgk8aFnxEkjqta0B/GHrM1pxzuuZz2zWsOXc5nKu3t+76s/PQBA8FTcM/ipspIH9jWG4OxCBc2eA==",
+                    "dev": true
+                },
+                "array-slice": {
+                    "version": "0.2.3",
+                    "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+                    "integrity": "sha512-rlVfZW/1Ph2SNySXwR9QYkChp8EkOEiTMO5Vwx60usw04i4nWemkm9RXmQqgkQFaLHsqLuADvjp6IfgL9l2M8Q==",
+                    "dev": true
+                },
+                "extend-shallow": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+                    "integrity": "sha512-L7AGmkO6jhDkEBBGWlLtftA80Xq8DipnrRPr0pyi7GQLXkaq9JYA4xF4z6qnadIC6euiTDKco0cGSU9muw+WTw==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^1.1.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+                    "integrity": "sha512-aUH6ElPnMGon2/YkxRIigV32MOpTVcoXQ1Oo8aYn40s+sJ3j+0gFZsT8HKDcxNy7Fi9zuquWtGaGAahOdv5p/g==",
+                    "dev": true
+                },
+                "plugin-error": {
+                    "version": "0.1.2",
+                    "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
+                    "integrity": "sha512-WzZHcm4+GO34sjFMxQMqZbsz3xiNEgonCskQ9v+IroMmYgk/tas8dG+Hr2D6IbRPybZ12oWpzE/w3cGJ6FJzOw==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-cyan": "^0.1.1",
+                        "ansi-red": "^0.1.1",
+                        "arr-diff": "^1.0.1",
+                        "arr-union": "^2.0.1",
+                        "extend-shallow": "^1.1.2"
+                    }
+                },
+                "readable-stream": {
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "through2": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+                    "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "~2.3.6",
+                        "xtend": "~4.0.1"
+                    }
+                }
             }
         },
         "gulp-if": {
@@ -14602,6 +14992,33 @@
                 "through2": "^2.0.0",
                 "uglify-js": "^3.0.5",
                 "vinyl-sourcemaps-apply": "^0.2.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "through2": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+                    "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "~2.3.6",
+                        "xtend": "~4.0.1"
+                    }
+                }
             }
         },
         "gulp-useref": {
@@ -14619,17 +15036,6 @@
                 "through2": "^4.0.2",
                 "useref": "^1.4.3",
                 "vinyl-fs": "^3.0.3"
-            },
-            "dependencies": {
-                "through2": {
-                    "version": "4.0.2",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
-                    "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": "3"
-                    }
-                }
             }
         },
         "gulp-util": {
@@ -17480,6 +17886,33 @@
                 "remove-bom-buffer": "^3.0.0",
                 "safe-buffer": "^5.1.0",
                 "through2": "^2.0.3"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "through2": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+                    "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "~2.3.6",
+                        "xtend": "~4.0.1"
+                    }
+                }
             }
         },
         "remove-trailing-separator": {
@@ -18390,13 +18823,22 @@
             "dev": true
         },
         "through2": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+            "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
             "dev": true,
             "requires": {
-                "readable-stream": "~2.3.6",
-                "xtend": "~4.0.1"
+                "readable-stream": "3"
+            }
+        },
+        "through2-filter": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
+            "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
+            "dev": true,
+            "requires": {
+                "through2": "~2.0.0",
+                "xtend": "~4.0.0"
             },
             "dependencies": {
                 "readable-stream": {
@@ -18413,17 +18855,17 @@
                         "string_decoder": "~1.1.1",
                         "util-deprecate": "~1.0.1"
                     }
+                },
+                "through2": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+                    "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "~2.3.6",
+                        "xtend": "~4.0.1"
+                    }
                 }
-            }
-        },
-        "through2-filter": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
-            "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
-            "dev": true,
-            "requires": {
-                "through2": "~2.0.0",
-                "xtend": "~4.0.0"
             }
         },
         "time-stamp": {
@@ -18511,6 +18953,33 @@
             "dev": true,
             "requires": {
                 "through2": "^2.0.3"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "through2": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+                    "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "~2.3.6",
+                        "xtend": "~4.0.1"
+                    }
+                }
             }
         },
         "toidentifier": {
@@ -18907,6 +19376,16 @@
                         "safe-buffer": "~5.1.1",
                         "string_decoder": "~1.1.1",
                         "util-deprecate": "~1.0.1"
+                    }
+                },
+                "through2": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+                    "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "~2.3.6",
+                        "xtend": "~4.0.1"
                     }
                 }
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
                 "husky": "^7.0.4",
                 "lodash": "^4.17.21",
                 "merge-stream": "^2.0.0",
+                "parse-comments": "^1.0.0",
                 "readable-stream": "^3.6.0",
                 "through2": "^4.0.2"
             }
@@ -725,6 +726,138 @@
             "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
             "dev": true
         },
+        "node_modules/ansi-bgblack": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-bgblack/-/ansi-bgblack-0.1.1.tgz",
+            "integrity": "sha512-tp8M/NCmSr6/skdteeo9UgJ2G1rG88X3ZVNZWXUxFw4Wh0PAGaAAWQS61sfBt/1QNcwMTY3EBKOMPujwioJLaw==",
+            "dev": true,
+            "dependencies": {
+                "ansi-wrap": "0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/ansi-bgblue": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-bgblue/-/ansi-bgblue-0.1.1.tgz",
+            "integrity": "sha512-R8JmX2Xv3+ichUQE99oL+LvjsyK+CDWo/BtVb4QUz3hOfmf2bdEmiDot3fQcpn2WAHW3toSRdjSLm6bgtWRDlA==",
+            "dev": true,
+            "dependencies": {
+                "ansi-wrap": "0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/ansi-bgcyan": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-bgcyan/-/ansi-bgcyan-0.1.1.tgz",
+            "integrity": "sha512-6SByK9q2H978bmqzuzA5NPT1lRDXl3ODLz/DjC4URO5f/HqK7dnRKfoO/xQLx/makOz7zWIbRf6+Uf7bmaPSkQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-wrap": "0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/ansi-bggreen": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-bggreen/-/ansi-bggreen-0.1.1.tgz",
+            "integrity": "sha512-8TRtOKmIPOuxjpklrkhUbqD2NnVb4WZQuIjXrT+TGKFKzl7NrL7wuNvEap3leMt2kQaCngIN1ZzazSbJNzF+Aw==",
+            "dev": true,
+            "dependencies": {
+                "ansi-wrap": "0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/ansi-bgmagenta": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-bgmagenta/-/ansi-bgmagenta-0.1.1.tgz",
+            "integrity": "sha512-UZYhobiGAlV4NiwOlKAKbkCyxOl1PPZNvdIdl/Ce5by45vwiyNdBetwHk/AjIpo1Ji9z+eE29PUBAjjfVmz5SA==",
+            "dev": true,
+            "dependencies": {
+                "ansi-wrap": "0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/ansi-bgred": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-bgred/-/ansi-bgred-0.1.1.tgz",
+            "integrity": "sha512-BpPHMnYmRBhcjY5knRWKjQmPDPvYU7wrgBSW34xj7JCH9+a/SEIV7+oSYVOgMFopRIadOz9Qm4zIy+mEBvUOPA==",
+            "dev": true,
+            "dependencies": {
+                "ansi-wrap": "0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/ansi-bgwhite": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-bgwhite/-/ansi-bgwhite-0.1.1.tgz",
+            "integrity": "sha512-KIF19t+HOYOorUnHTOhZpeZ3bJsjzStBG2hSGM0WZ8YQQe4c7lj9CtwnucscJDPrNwfdz6GBF+pFkVfvHBq6uw==",
+            "dev": true,
+            "dependencies": {
+                "ansi-wrap": "0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/ansi-bgyellow": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-bgyellow/-/ansi-bgyellow-0.1.1.tgz",
+            "integrity": "sha512-WyRoOFSIvOeM7e7YdlSjfAV82Z6K1+VUVbygIQ7C/VGzWYuO/d30F0PG7oXeo4uSvSywR0ozixDQvtXJEorq4Q==",
+            "dev": true,
+            "dependencies": {
+                "ansi-wrap": "0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/ansi-black": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-black/-/ansi-black-0.1.1.tgz",
+            "integrity": "sha512-hl7re02lWus7lFOUG6zexhoF5gssAfG5whyr/fOWK9hxNjUFLTjhbU/b4UHWOh2dbJu9/STSUv+80uWYzYkbTQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-wrap": "0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/ansi-blue": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-blue/-/ansi-blue-0.1.1.tgz",
+            "integrity": "sha512-8Um59dYNDdQyoczlf49RgWLzYgC2H/28W3JAIyOAU/+WkMcfZmaznm+0i1ikrE0jME6Ypk9CJ9CY2+vxbPs7Fg==",
+            "dev": true,
+            "dependencies": {
+                "ansi-wrap": "0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/ansi-bold": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-bold/-/ansi-bold-0.1.1.tgz",
+            "integrity": "sha512-wWKwcViX1E28U6FohtWOP4sHFyArELHJ2p7+3BzbibqJiuISeskq6t7JnrLisUngMF5zMhgmXVw8Equjzz9OlA==",
+            "dev": true,
+            "dependencies": {
+                "ansi-wrap": "0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/ansi-colors": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -746,10 +879,94 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/ansi-dim": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-dim/-/ansi-dim-0.1.1.tgz",
+            "integrity": "sha512-zAfb1fokXsq4BoZBkL0eK+6MfFctbzX3R4UMcoWrL1n2WHewFKentTvOZv2P11u6P4NtW/V47hVjaN7fJiefOg==",
+            "dev": true,
+            "dependencies": {
+                "ansi-wrap": "0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/ansi-gray": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
             "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+            "dev": true,
+            "dependencies": {
+                "ansi-wrap": "0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/ansi-green": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
+            "integrity": "sha512-WJ70OI4jCaMy52vGa/ypFSKFb/TrYNPaQ2xco5nUwE0C5H8piume/uAZNNdXXiMQ6DbRmiE7l8oNBHu05ZKkrw==",
+            "dev": true,
+            "dependencies": {
+                "ansi-wrap": "0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/ansi-grey": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-grey/-/ansi-grey-0.1.1.tgz",
+            "integrity": "sha512-+J1nM4lC+whSvf3T4jsp1KR+C63lypb+VkkwtLQMc1Dlt+nOvdZpFT0wwFTYoSlSwCcLUAaOpHF6kPkYpSa24A==",
+            "dev": true,
+            "dependencies": {
+                "ansi-wrap": "0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/ansi-hidden": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-hidden/-/ansi-hidden-0.1.1.tgz",
+            "integrity": "sha512-8gB1bo9ym9qZ/Obvrse1flRsfp2RE+40B23DhQcKxY+GSeaOJblLnzBOxzvmLTWbi5jNON3as7wd9rC0fNK73Q==",
+            "dev": true,
+            "dependencies": {
+                "ansi-wrap": "0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/ansi-inverse": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-inverse/-/ansi-inverse-0.1.1.tgz",
+            "integrity": "sha512-Kq8Z0dBRhQhDMN/Rso1Nu9niwiTsRkJncfJZXiyj7ApbfJrGrrubHXqXI37feJZkYcIx6SlTBdNCeK0OQ6X6ag==",
+            "dev": true,
+            "dependencies": {
+                "ansi-wrap": "0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/ansi-italic": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-italic/-/ansi-italic-0.1.1.tgz",
+            "integrity": "sha512-jreCxifSAqbaBvcibeQxcwhQDbEj7gF69XnpA6x83qbECEBaRBD1epqskrmov1z4B+zzQuEdwbWxgzvhKa+PkA==",
+            "dev": true,
+            "dependencies": {
+                "ansi-wrap": "0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/ansi-magenta": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-magenta/-/ansi-magenta-0.1.1.tgz",
+            "integrity": "sha512-A1Giu+HRwyWuiXKyXPw2AhG1yWZjNHWO+5mpt+P+VWYkmGRpLPry0O5gmlJQEvpjNpl4RjFV7DJQ4iozWOmkbQ==",
             "dev": true,
             "dependencies": {
                 "ansi-wrap": "0.1.0"
@@ -779,6 +996,30 @@
                 "node": ">=8"
             }
         },
+        "node_modules/ansi-reset": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-reset/-/ansi-reset-0.1.1.tgz",
+            "integrity": "sha512-n+D0qD3B+h/lP0dSwXX1SZMoXufdUVotLMwUuvXa50LtBAh3f+WV8b5nFMfLL/hgoPBUt+rG/pqqzF8krlZKcw==",
+            "dev": true,
+            "dependencies": {
+                "ansi-wrap": "0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/ansi-strikethrough": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-strikethrough/-/ansi-strikethrough-0.1.1.tgz",
+            "integrity": "sha512-gWkLPDvHH2pC9YEKqp8dIl0mg3sRglMPvioqGDIOXiwxjxUwIJ1gF86E2o4R5yLNh8IAkwHbaMtASkJfkQ2hIA==",
+            "dev": true,
+            "dependencies": {
+                "ansi-wrap": "0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/ansi-styles": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -791,11 +1032,47 @@
                 "node": ">=4"
             }
         },
+        "node_modules/ansi-underline": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-underline/-/ansi-underline-0.1.1.tgz",
+            "integrity": "sha512-D+Bzwio/0/a0Fu5vJzrIT6bFk43TW46vXfSvzysOTEHcXOAUJTVMHWDbELIzGU4AVxVw2rCTb7YyWS4my2cSKQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-wrap": "0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/ansi-white": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-white/-/ansi-white-0.1.1.tgz",
+            "integrity": "sha512-DJHaF2SRzBb9wZBgqIJNjjTa7JUJTO98sHeTS1sDopyKKRopL1KpaJ20R6W2f/ZGras8bYyIZDtNwYOVXNgNFg==",
+            "dev": true,
+            "dependencies": {
+                "ansi-wrap": "0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/ansi-wrap": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
             "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
             "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/ansi-yellow": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-yellow/-/ansi-yellow-0.1.1.tgz",
+            "integrity": "sha512-6E3D4BQLXHLl3c/NwirWVZ+BCkMq2qsYxdeAGGOijKrx09FaqU+HktFL6QwAwNvgJiMLnv6AQ2C1gFZx0h1CBg==",
+            "dev": true,
+            "dependencies": {
+                "ansi-wrap": "0.1.0"
+            },
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3192,6 +3469,15 @@
                 "is-arrayish": "^0.2.1"
             }
         },
+        "node_modules/error-symbol": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/error-symbol/-/error-symbol-0.1.0.tgz",
+            "integrity": "sha512-VyjaKxUmeDX/m2lxm/aknsJ1GWDWUO2Ze2Ad8S1Pb9dykAm9TjSKp5CjrNyltYqZ5W/PO6TInAmO2/BfwMyT1g==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/es5-ext": {
             "version": "0.10.53",
             "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
@@ -3406,6 +3692,18 @@
             "bin": {
                 "esparse": "bin/esparse.js",
                 "esvalidate": "bin/esvalidate.js"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/esprima-extract-comments": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/esprima-extract-comments/-/esprima-extract-comments-1.1.0.tgz",
+            "integrity": "sha512-sBQUnvJwpeE9QnPrxh7dpI/dp67erYG4WXEAreAMoelPRpMR7NWb4YtwRPn9b+H1uLQKl/qS8WYmyaljTpjIsw==",
+            "dev": true,
+            "dependencies": {
+                "esprima": "^4.0.0"
             },
             "engines": {
                 "node": ">=4"
@@ -3730,6 +4028,19 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/extract-comments": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/extract-comments/-/extract-comments-1.1.0.tgz",
+            "integrity": "sha512-dzbZV2AdSSVW/4E7Ti5hZdHWbA+Z80RJsJhr5uiL10oyjl/gy7/o+HI1HwK4/WSZhlq4SNKU3oUzXlM13Qx02Q==",
+            "dev": true,
+            "dependencies": {
+                "esprima-extract-comments": "^1.1.0",
+                "parse-code-context": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/fancy-log": {
@@ -4065,6 +4376,15 @@
             "integrity": "sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==",
             "deprecated": "flatten is deprecated in favor of utility frameworks such as lodash.",
             "dev": true
+        },
+        "node_modules/floating-point-regex": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/floating-point-regex/-/floating-point-regex-0.1.0.tgz",
+            "integrity": "sha512-4X7v7J8G3pw2iBJgAC+l3FaFVM0zLre9dk1PNnCM2/fDLVzuKP84b1YhtGw6BBCmlq60ABoK9Tg43UYpOHEqQw==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/flush-write-stream": {
             "version": "1.1.1",
@@ -5793,6 +6113,15 @@
             "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
             "dev": true
         },
+        "node_modules/inflection": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.13.2.tgz",
+            "integrity": "sha512-cmZlljCRTBFouT8UzMzrGcVEvkv6D/wBdcdKG7J1QH5cXjtU75Dm+P27v9EKu/Y43UYyCJd1WC4zLebRrC8NBw==",
+            "dev": true,
+            "engines": [
+                "node >= 0.4.0"
+            ]
+        },
         "node_modules/inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -5801,6 +6130,15 @@
             "dependencies": {
                 "once": "^1.3.0",
                 "wrappy": "1"
+            }
+        },
+        "node_modules/info-symbol": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/info-symbol/-/info-symbol-0.1.0.tgz",
+            "integrity": "sha512-qkc9wjLDQ+dYYZnY5uJXGNNHyZ0UOMDUnhvy0SEZGVVYmQ5s4i8cPAin2MbU6OxJgi8dfj/AnwqPx0CJE6+Lsw==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/inherits": {
@@ -6087,6 +6425,15 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-primitive": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+            "integrity": "sha512-N3w1tFaRfk3UrPfqeRyD+GYDASU3W5VinKhlORy8EWVf/sIdDL9GAcew85XmktCfH+ngG7SRXEVDoO18WMdB/Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/is-relative": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
@@ -6322,6 +6669,18 @@
             },
             "engines": {
                 "node": ">= 0.10"
+            }
+        },
+        "node_modules/lazy-cache": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+            "integrity": "sha512-7vp2Acd2+Kz4XkzxGxaB1FWOi8KjWIWsgdfD5MCb86DWvlLqhRPM+d6Pro3iNEL5VT9mstz5hKAlcd+QR6H3aA==",
+            "dev": true,
+            "dependencies": {
+                "set-getter": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/lazystream": {
@@ -6615,6 +6974,84 @@
                 "lodash.keys": "~2.4.1"
             }
         },
+        "node_modules/log-ok": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/log-ok/-/log-ok-0.1.1.tgz",
+            "integrity": "sha512-cc8VrkS6C+9TFuYAwuHpshrcrGRAv7d0tUJ0GdM72ZBlKXtlgjUZF84O+OhQUdiVHoF7U/nVxwpjOdwUJ8d3Vg==",
+            "dev": true,
+            "dependencies": {
+                "ansi-green": "^0.1.1",
+                "success-symbol": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/log-utils": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/log-utils/-/log-utils-0.2.1.tgz",
+            "integrity": "sha512-udyegKoMz9eGfpKAX//Khy7sVAZ8b1F7oLDnepZv/1/y8xTvsyPgqQrM94eG8V0vcc2BieYI2kVW4+aa6m+8Qw==",
+            "dev": true,
+            "dependencies": {
+                "ansi-colors": "^0.2.0",
+                "error-symbol": "^0.1.0",
+                "info-symbol": "^0.1.0",
+                "log-ok": "^0.1.1",
+                "success-symbol": "^0.1.0",
+                "time-stamp": "^1.0.1",
+                "warning-symbol": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/log-utils/node_modules/ansi-colors": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-0.2.0.tgz",
+            "integrity": "sha512-ScRNUT0TovnYw6+Xo3iKh6G+VXDw2Ds7ZRnMIuKBgHY02DgvT2T2K22/tc/916Fi0W/5Z1RzDaHQwnp75hqdbA==",
+            "dev": true,
+            "dependencies": {
+                "ansi-bgblack": "^0.1.1",
+                "ansi-bgblue": "^0.1.1",
+                "ansi-bgcyan": "^0.1.1",
+                "ansi-bggreen": "^0.1.1",
+                "ansi-bgmagenta": "^0.1.1",
+                "ansi-bgred": "^0.1.1",
+                "ansi-bgwhite": "^0.1.1",
+                "ansi-bgyellow": "^0.1.1",
+                "ansi-black": "^0.1.1",
+                "ansi-blue": "^0.1.1",
+                "ansi-bold": "^0.1.1",
+                "ansi-cyan": "^0.1.1",
+                "ansi-dim": "^0.1.1",
+                "ansi-gray": "^0.1.1",
+                "ansi-green": "^0.1.1",
+                "ansi-grey": "^0.1.1",
+                "ansi-hidden": "^0.1.1",
+                "ansi-inverse": "^0.1.1",
+                "ansi-italic": "^0.1.1",
+                "ansi-magenta": "^0.1.1",
+                "ansi-red": "^0.1.1",
+                "ansi-reset": "^0.1.1",
+                "ansi-strikethrough": "^0.1.1",
+                "ansi-underline": "^0.1.1",
+                "ansi-white": "^0.1.1",
+                "ansi-yellow": "^0.1.1",
+                "lazy-cache": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/longest": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+            "integrity": "sha512-k+yt5n3l48JU4k8ftnKG6V7u32wyH2NfKzeMto9F/QRE0amxy/LayxwlvjjkZEIzqR+19IrtFO8p5kB9QaYUFg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/loud-rejection": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
@@ -6681,6 +7118,170 @@
             "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
             "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
             "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/map-schema": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/map-schema/-/map-schema-0.2.4.tgz",
+            "integrity": "sha512-1sgduImleUF+8NiS1wlqDJ8uhmJtFbLRjVW3PZP5IZJd1n+11eV91AnHI4jOYT2UCirriivNUgh6DG73V+G9QQ==",
+            "dev": true,
+            "dependencies": {
+                "arr-union": "^3.1.0",
+                "collection-visit": "^0.2.3",
+                "component-emitter": "^1.2.1",
+                "debug": "^2.6.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "get-value": "^2.0.6",
+                "is-primitive": "^2.0.0",
+                "kind-of": "^3.1.0",
+                "lazy-cache": "^2.0.2",
+                "log-utils": "^0.2.1",
+                "longest": "^1.0.1",
+                "mixin-deep": "^1.1.3",
+                "object.omit": "^2.0.1",
+                "object.pick": "^1.2.0",
+                "omit-empty": "^0.4.1",
+                "pad-right": "^0.2.2",
+                "set-value": "^0.4.0",
+                "sort-object-arrays": "^0.1.1",
+                "union-value": "^0.2.3"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/map-schema/node_modules/collection-visit": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-0.2.3.tgz",
+            "integrity": "sha512-V88PJOCqJfsZS45YBELDgmhQkECokQAAr9XR4hT6eFkFsAPsCsk3EoDHSuBPYzygjquGM/0KF4vdwTiQO6lbdw==",
+            "dev": true,
+            "dependencies": {
+                "lazy-cache": "^2.0.1",
+                "map-visit": "^0.1.5",
+                "object-visit": "^0.3.4"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/map-schema/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/map-schema/node_modules/define-property": {
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+            "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+            "dev": true,
+            "dependencies": {
+                "is-descriptor": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/map-schema/node_modules/extend-shallow": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+            "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+            "dev": true,
+            "dependencies": {
+                "is-extendable": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/map-schema/node_modules/isobject": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
+            "dev": true,
+            "dependencies": {
+                "isarray": "1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/map-schema/node_modules/kind-of": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+            "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+            "dev": true,
+            "dependencies": {
+                "is-buffer": "^1.1.5"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/map-schema/node_modules/map-visit": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-0.1.5.tgz",
+            "integrity": "sha512-zdmJBFvvVR/H5wCfsCP7XxSLp+346yAZ30Wy2OsQLcH19OVGMWa3Ms9quO00lj9ybsySu3gKOINNgICb4Zqauw==",
+            "dev": true,
+            "dependencies": {
+                "lazy-cache": "^2.0.1",
+                "object-visit": "^0.3.4"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/map-schema/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "dev": true
+        },
+        "node_modules/map-schema/node_modules/object-visit": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-0.3.4.tgz",
+            "integrity": "sha512-6QNyX7uTuwqxP7pmDBqgBDKdmZws1rXriUyXM5KG6+7J0aYRuuAGoc636IGdLzgOL77WUwL+EpoTJrEHwWsyOA==",
+            "dev": true,
+            "dependencies": {
+                "isobject": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/map-schema/node_modules/set-value": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+            "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+            "deprecated": "Critical bug fixed in v3.0.1, please upgrade to the latest version.",
+            "dev": true,
+            "dependencies": {
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.1",
+                "to-object-path": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/map-schema/node_modules/union-value": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/union-value/-/union-value-0.2.4.tgz",
+            "integrity": "sha1-c3UVJ4ZnkFfns3qmdug0aPwCdPA=",
+            "dev": true,
+            "dependencies": {
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^0.4.3"
+            },
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -7363,6 +7964,31 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/object.omit": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+            "integrity": "sha512-UiAM5mhmIuKLsOvrL+B0U2d1hXHF3bFYWIuH1LMpuV2EJEHG1Ntz06PgLEHjm6VFd87NpH8rastvPoyv6UW2fA==",
+            "dev": true,
+            "dependencies": {
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/object.omit/node_modules/for-own": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+            "integrity": "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==",
+            "dev": true,
+            "dependencies": {
+                "for-in": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/object.pick": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
@@ -7383,6 +8009,41 @@
             "dependencies": {
                 "for-own": "^1.0.0",
                 "make-iterator": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/omit-empty": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/omit-empty/-/omit-empty-0.4.1.tgz",
+            "integrity": "sha512-NwnVOAaLwUEYmvvwLKKqvG6BkSG0pu0yKhKc6uYbWerkIXe6Wi2HQ1qoL+Wksj3DCauRuNKIjZUsLyjLj1/lrw==",
+            "dev": true,
+            "dependencies": {
+                "has-values": "^0.1.4",
+                "kind-of": "^3.0.3",
+                "reduce-object": "^0.1.3"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/omit-empty/node_modules/has-values": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+            "integrity": "sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/omit-empty/node_modules/kind-of": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+            "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+            "dev": true,
+            "dependencies": {
+                "is-buffer": "^1.1.5"
             },
             "engines": {
                 "node": ">=0.10.0"
@@ -7549,6 +8210,18 @@
                 "node": ">=6"
             }
         },
+        "node_modules/pad-right": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/pad-right/-/pad-right-0.2.2.tgz",
+            "integrity": "sha512-4cy8M95ioIGolCoMmm2cMntGR1lPLEbOMzOKu8bzjuJP6JpzEMQcDHmh7hHLYGgob+nKe1YHFMaG4V59HQa89g==",
+            "dev": true,
+            "dependencies": {
+                "repeat-string": "^1.5.2"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/pako": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -7564,6 +8237,55 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/parse-code-context": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/parse-code-context/-/parse-code-context-1.0.0.tgz",
+            "integrity": "sha512-OZQaqKaQnR21iqhlnPfVisFjBWjhnMl5J9MgbP8xC+EwoVqbXrq78lp+9Zb3ahmLzrIX5Us/qbvBnaS3hkH6OA==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/parse-comments": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/parse-comments/-/parse-comments-1.0.0.tgz",
+            "integrity": "sha512-GHM62374TgaGFoDYzDqd0CQSEUmUl9g99Af+EY2aaXB8tfp8AFgEzRqlxFMJRa8b4OEktLuGle9P+ZQukmXEVA==",
+            "dev": true,
+            "dependencies": {
+                "extract-comments": "^1.1.0",
+                "floating-point-regex": "^0.1.0",
+                "get-value": "^3.0.1",
+                "inflection": "^1.12.0",
+                "map-schema": "^0.2.4",
+                "snapdragon-node": "^3.0.0",
+                "snapdragon-parser": "^1.0.0",
+                "tokenize-comment": "^3.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/parse-comments/node_modules/get-value": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/get-value/-/get-value-3.0.1.tgz",
+            "integrity": "sha512-mKZj9JLQrwMBtj5wxi6MH8Z5eSKaERpAwjg43dPtlGI1ZVEgH/qC7T8/6R2OBSUA+zzHBZgICsVJaEIV2tKTDA==",
+            "dev": true,
+            "dependencies": {
+                "isobject": "^3.0.1"
+            },
+            "engines": {
+                "node": ">=6.0"
+            }
+        },
+        "node_modules/parse-comments/node_modules/snapdragon-node": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-3.0.0.tgz",
+            "integrity": "sha512-8fmjo9AOZXFBWxHS9kOdqA4Mq9x1ldbnPLXjz1voBCmDuQcVBySjlekv4+QnKj0LdNc3hEF19xUrTBQJ2zPyCw==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/parse-filepath": {
@@ -8635,6 +9357,30 @@
                 "balanced-match": "^1.0.0"
             }
         },
+        "node_modules/reduce-object": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/reduce-object/-/reduce-object-0.1.3.tgz",
+            "integrity": "sha1-1UnUCmwpNvpOPpt4yonJMxRZQhg=",
+            "dev": true,
+            "dependencies": {
+                "for-own": "^0.1.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/reduce-object/node_modules/for-own": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+            "integrity": "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==",
+            "dev": true,
+            "dependencies": {
+                "for-in": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/regex-not": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -9104,6 +9850,18 @@
             "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
             "dev": true
         },
+        "node_modules/set-getter": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.1.tgz",
+            "integrity": "sha512-9sVWOy+gthr+0G9DzqqLaYNA7+5OKkSmcqjL9cBpDEaZrr3ShQlyX2cZ/O/ozE41oxn/Tt0LGEM/w4Rub3A3gw==",
+            "dev": true,
+            "dependencies": {
+                "to-object-path": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/set-immediate-shim": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
@@ -9264,6 +10022,15 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/snapdragon-lexer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/snapdragon-lexer/-/snapdragon-lexer-4.0.0.tgz",
+            "integrity": "sha512-ddXT9cpKI0PUrs3xeoQVKEjequr0UyW9w281dzu8RTgWtqdIGZSvoWDsnIMPCc8Fupk4dByatSodhwYEGgrdSg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/snapdragon-node": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
@@ -9326,6 +10093,28 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/snapdragon-parser": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/snapdragon-parser/-/snapdragon-parser-1.0.0.tgz",
+            "integrity": "sha512-2sVQqqieRb2MbPAL+eIbkMjNQ3XhrMNiJZlznC3AdD9Hli+N769XHO6vDYTTgAhwDg8VX8Qt7aHBhLalnMhgZQ==",
+            "dev": true,
+            "dependencies": {
+                "snapdragon-lexer": "^4.0.0",
+                "snapdragon-node": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/snapdragon-parser/node_modules/snapdragon-node": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-3.0.0.tgz",
+            "integrity": "sha512-8fmjo9AOZXFBWxHS9kOdqA4Mq9x1ldbnPLXjz1voBCmDuQcVBySjlekv4+QnKj0LdNc3hEF19xUrTBQJ2zPyCw==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/snapdragon-util": {
@@ -9398,6 +10187,30 @@
             "dev": true,
             "dependencies": {
                 "is-plain-obj": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/sort-object-arrays": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/sort-object-arrays/-/sort-object-arrays-0.1.1.tgz",
+            "integrity": "sha1-mfVc8gWkkd3h9S8Jajaiawm0gy8=",
+            "dev": true,
+            "dependencies": {
+                "kind-of": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/sort-object-arrays/node_modules/kind-of": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+            "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+            "dev": true,
+            "dependencies": {
+                "is-buffer": "^1.1.5"
             },
             "engines": {
                 "node": ">=0.10.0"
@@ -9665,6 +10478,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/success-symbol": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz",
+            "integrity": "sha1-JAIuSG878c3KCUKDt2nEctO3KJc=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/supports-color": {
@@ -10013,6 +10835,18 @@
             "dev": true,
             "engines": {
                 "node": ">=0.6"
+            }
+        },
+        "node_modules/tokenize-comment": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/tokenize-comment/-/tokenize-comment-3.0.1.tgz",
+            "integrity": "sha512-of5j9zCooBZxcE1EQ9PCjXcuFUPU/h8GxhWqF86cQ3muHQQreIWgY40ZNfuPQUSXyTa6i7oAWqWX4QivzZh26Q==",
+            "dev": true,
+            "dependencies": {
+                "snapdragon-lexer": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/trim-newlines": {
@@ -10570,6 +11404,15 @@
             "dev": true,
             "dependencies": {
                 "source-map": "^0.5.1"
+            }
+        },
+        "node_modules/warning-symbol": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/warning-symbol/-/warning-symbol-0.1.0.tgz",
+            "integrity": "sha1-uzHdEbeg+dZ6su2V9Fe2WCW7rSE=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/watch": {
@@ -11415,6 +12258,105 @@
             "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
             "dev": true
         },
+        "ansi-bgblack": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-bgblack/-/ansi-bgblack-0.1.1.tgz",
+            "integrity": "sha512-tp8M/NCmSr6/skdteeo9UgJ2G1rG88X3ZVNZWXUxFw4Wh0PAGaAAWQS61sfBt/1QNcwMTY3EBKOMPujwioJLaw==",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
+        "ansi-bgblue": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-bgblue/-/ansi-bgblue-0.1.1.tgz",
+            "integrity": "sha512-R8JmX2Xv3+ichUQE99oL+LvjsyK+CDWo/BtVb4QUz3hOfmf2bdEmiDot3fQcpn2WAHW3toSRdjSLm6bgtWRDlA==",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
+        "ansi-bgcyan": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-bgcyan/-/ansi-bgcyan-0.1.1.tgz",
+            "integrity": "sha512-6SByK9q2H978bmqzuzA5NPT1lRDXl3ODLz/DjC4URO5f/HqK7dnRKfoO/xQLx/makOz7zWIbRf6+Uf7bmaPSkQ==",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
+        "ansi-bggreen": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-bggreen/-/ansi-bggreen-0.1.1.tgz",
+            "integrity": "sha512-8TRtOKmIPOuxjpklrkhUbqD2NnVb4WZQuIjXrT+TGKFKzl7NrL7wuNvEap3leMt2kQaCngIN1ZzazSbJNzF+Aw==",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
+        "ansi-bgmagenta": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-bgmagenta/-/ansi-bgmagenta-0.1.1.tgz",
+            "integrity": "sha512-UZYhobiGAlV4NiwOlKAKbkCyxOl1PPZNvdIdl/Ce5by45vwiyNdBetwHk/AjIpo1Ji9z+eE29PUBAjjfVmz5SA==",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
+        "ansi-bgred": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-bgred/-/ansi-bgred-0.1.1.tgz",
+            "integrity": "sha512-BpPHMnYmRBhcjY5knRWKjQmPDPvYU7wrgBSW34xj7JCH9+a/SEIV7+oSYVOgMFopRIadOz9Qm4zIy+mEBvUOPA==",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
+        "ansi-bgwhite": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-bgwhite/-/ansi-bgwhite-0.1.1.tgz",
+            "integrity": "sha512-KIF19t+HOYOorUnHTOhZpeZ3bJsjzStBG2hSGM0WZ8YQQe4c7lj9CtwnucscJDPrNwfdz6GBF+pFkVfvHBq6uw==",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
+        "ansi-bgyellow": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-bgyellow/-/ansi-bgyellow-0.1.1.tgz",
+            "integrity": "sha512-WyRoOFSIvOeM7e7YdlSjfAV82Z6K1+VUVbygIQ7C/VGzWYuO/d30F0PG7oXeo4uSvSywR0ozixDQvtXJEorq4Q==",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
+        "ansi-black": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-black/-/ansi-black-0.1.1.tgz",
+            "integrity": "sha512-hl7re02lWus7lFOUG6zexhoF5gssAfG5whyr/fOWK9hxNjUFLTjhbU/b4UHWOh2dbJu9/STSUv+80uWYzYkbTQ==",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
+        "ansi-blue": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-blue/-/ansi-blue-0.1.1.tgz",
+            "integrity": "sha512-8Um59dYNDdQyoczlf49RgWLzYgC2H/28W3JAIyOAU/+WkMcfZmaznm+0i1ikrE0jME6Ypk9CJ9CY2+vxbPs7Fg==",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
+        "ansi-bold": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-bold/-/ansi-bold-0.1.1.tgz",
+            "integrity": "sha512-wWKwcViX1E28U6FohtWOP4sHFyArELHJ2p7+3BzbibqJiuISeskq6t7JnrLisUngMF5zMhgmXVw8Equjzz9OlA==",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
         "ansi-colors": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -11430,10 +12372,73 @@
                 "ansi-wrap": "0.1.0"
             }
         },
+        "ansi-dim": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-dim/-/ansi-dim-0.1.1.tgz",
+            "integrity": "sha512-zAfb1fokXsq4BoZBkL0eK+6MfFctbzX3R4UMcoWrL1n2WHewFKentTvOZv2P11u6P4NtW/V47hVjaN7fJiefOg==",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
         "ansi-gray": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
             "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
+        "ansi-green": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
+            "integrity": "sha512-WJ70OI4jCaMy52vGa/ypFSKFb/TrYNPaQ2xco5nUwE0C5H8piume/uAZNNdXXiMQ6DbRmiE7l8oNBHu05ZKkrw==",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
+        "ansi-grey": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-grey/-/ansi-grey-0.1.1.tgz",
+            "integrity": "sha512-+J1nM4lC+whSvf3T4jsp1KR+C63lypb+VkkwtLQMc1Dlt+nOvdZpFT0wwFTYoSlSwCcLUAaOpHF6kPkYpSa24A==",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
+        "ansi-hidden": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-hidden/-/ansi-hidden-0.1.1.tgz",
+            "integrity": "sha512-8gB1bo9ym9qZ/Obvrse1flRsfp2RE+40B23DhQcKxY+GSeaOJblLnzBOxzvmLTWbi5jNON3as7wd9rC0fNK73Q==",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
+        "ansi-inverse": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-inverse/-/ansi-inverse-0.1.1.tgz",
+            "integrity": "sha512-Kq8Z0dBRhQhDMN/Rso1Nu9niwiTsRkJncfJZXiyj7ApbfJrGrrubHXqXI37feJZkYcIx6SlTBdNCeK0OQ6X6ag==",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
+        "ansi-italic": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-italic/-/ansi-italic-0.1.1.tgz",
+            "integrity": "sha512-jreCxifSAqbaBvcibeQxcwhQDbEj7gF69XnpA6x83qbECEBaRBD1epqskrmov1z4B+zzQuEdwbWxgzvhKa+PkA==",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
+        "ansi-magenta": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-magenta/-/ansi-magenta-0.1.1.tgz",
+            "integrity": "sha512-A1Giu+HRwyWuiXKyXPw2AhG1yWZjNHWO+5mpt+P+VWYkmGRpLPry0O5gmlJQEvpjNpl4RjFV7DJQ4iozWOmkbQ==",
             "dev": true,
             "requires": {
                 "ansi-wrap": "0.1.0"
@@ -11454,6 +12459,24 @@
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true
         },
+        "ansi-reset": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-reset/-/ansi-reset-0.1.1.tgz",
+            "integrity": "sha512-n+D0qD3B+h/lP0dSwXX1SZMoXufdUVotLMwUuvXa50LtBAh3f+WV8b5nFMfLL/hgoPBUt+rG/pqqzF8krlZKcw==",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
+        "ansi-strikethrough": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-strikethrough/-/ansi-strikethrough-0.1.1.tgz",
+            "integrity": "sha512-gWkLPDvHH2pC9YEKqp8dIl0mg3sRglMPvioqGDIOXiwxjxUwIJ1gF86E2o4R5yLNh8IAkwHbaMtASkJfkQ2hIA==",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
         "ansi-styles": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -11463,11 +12486,38 @@
                 "color-convert": "^1.9.0"
             }
         },
+        "ansi-underline": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-underline/-/ansi-underline-0.1.1.tgz",
+            "integrity": "sha512-D+Bzwio/0/a0Fu5vJzrIT6bFk43TW46vXfSvzysOTEHcXOAUJTVMHWDbELIzGU4AVxVw2rCTb7YyWS4my2cSKQ==",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
+        "ansi-white": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-white/-/ansi-white-0.1.1.tgz",
+            "integrity": "sha512-DJHaF2SRzBb9wZBgqIJNjjTa7JUJTO98sHeTS1sDopyKKRopL1KpaJ20R6W2f/ZGras8bYyIZDtNwYOVXNgNFg==",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
         "ansi-wrap": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
             "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
             "dev": true
+        },
+        "ansi-yellow": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-yellow/-/ansi-yellow-0.1.1.tgz",
+            "integrity": "sha512-6E3D4BQLXHLl3c/NwirWVZ+BCkMq2qsYxdeAGGOijKrx09FaqU+HktFL6QwAwNvgJiMLnv6AQ2C1gFZx0h1CBg==",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
         },
         "anymatch": {
             "version": "2.0.0",
@@ -13414,6 +14464,12 @@
                 "is-arrayish": "^0.2.1"
             }
         },
+        "error-symbol": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/error-symbol/-/error-symbol-0.1.0.tgz",
+            "integrity": "sha512-VyjaKxUmeDX/m2lxm/aknsJ1GWDWUO2Ze2Ad8S1Pb9dykAm9TjSKp5CjrNyltYqZ5W/PO6TInAmO2/BfwMyT1g==",
+            "dev": true
+        },
         "es5-ext": {
             "version": "0.10.53",
             "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
@@ -13589,6 +14645,15 @@
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
             "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
             "dev": true
+        },
+        "esprima-extract-comments": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/esprima-extract-comments/-/esprima-extract-comments-1.1.0.tgz",
+            "integrity": "sha512-sBQUnvJwpeE9QnPrxh7dpI/dp67erYG4WXEAreAMoelPRpMR7NWb4YtwRPn9b+H1uLQKl/qS8WYmyaljTpjIsw==",
+            "dev": true,
+            "requires": {
+                "esprima": "^4.0.0"
+            }
         },
         "esquery": {
             "version": "1.4.0",
@@ -13854,6 +14919,16 @@
                         "kind-of": "^6.0.2"
                     }
                 }
+            }
+        },
+        "extract-comments": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/extract-comments/-/extract-comments-1.1.0.tgz",
+            "integrity": "sha512-dzbZV2AdSSVW/4E7Ti5hZdHWbA+Z80RJsJhr5uiL10oyjl/gy7/o+HI1HwK4/WSZhlq4SNKU3oUzXlM13Qx02Q==",
+            "dev": true,
+            "requires": {
+                "esprima-extract-comments": "^1.1.0",
+                "parse-code-context": "^1.0.0"
             }
         },
         "fancy-log": {
@@ -14140,6 +15215,12 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.3.tgz",
             "integrity": "sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==",
+            "dev": true
+        },
+        "floating-point-regex": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/floating-point-regex/-/floating-point-regex-0.1.0.tgz",
+            "integrity": "sha512-4X7v7J8G3pw2iBJgAC+l3FaFVM0zLre9dk1PNnCM2/fDLVzuKP84b1YhtGw6BBCmlq60ABoK9Tg43UYpOHEqQw==",
             "dev": true
         },
         "flush-write-stream": {
@@ -15524,6 +16605,12 @@
             "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
             "dev": true
         },
+        "inflection": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.13.2.tgz",
+            "integrity": "sha512-cmZlljCRTBFouT8UzMzrGcVEvkv6D/wBdcdKG7J1QH5cXjtU75Dm+P27v9EKu/Y43UYyCJd1WC4zLebRrC8NBw==",
+            "dev": true
+        },
         "inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -15533,6 +16620,12 @@
                 "once": "^1.3.0",
                 "wrappy": "1"
             }
+        },
+        "info-symbol": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/info-symbol/-/info-symbol-0.1.0.tgz",
+            "integrity": "sha512-qkc9wjLDQ+dYYZnY5uJXGNNHyZ0UOMDUnhvy0SEZGVVYmQ5s4i8cPAin2MbU6OxJgi8dfj/AnwqPx0CJE6+Lsw==",
+            "dev": true
         },
         "inherits": {
             "version": "2.0.4",
@@ -15746,6 +16839,12 @@
                 "isobject": "^3.0.1"
             }
         },
+        "is-primitive": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+            "integrity": "sha512-N3w1tFaRfk3UrPfqeRyD+GYDASU3W5VinKhlORy8EWVf/sIdDL9GAcew85XmktCfH+ngG7SRXEVDoO18WMdB/Q==",
+            "dev": true
+        },
         "is-relative": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
@@ -15936,6 +17035,15 @@
             "requires": {
                 "default-resolution": "^2.0.0",
                 "es6-weak-map": "^2.0.1"
+            }
+        },
+        "lazy-cache": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+            "integrity": "sha512-7vp2Acd2+Kz4XkzxGxaB1FWOi8KjWIWsgdfD5MCb86DWvlLqhRPM+d6Pro3iNEL5VT9mstz5hKAlcd+QR6H3aA==",
+            "dev": true,
+            "requires": {
+                "set-getter": "^0.1.0"
             }
         },
         "lazystream": {
@@ -16207,6 +17315,74 @@
                 "lodash.keys": "~2.4.1"
             }
         },
+        "log-ok": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/log-ok/-/log-ok-0.1.1.tgz",
+            "integrity": "sha512-cc8VrkS6C+9TFuYAwuHpshrcrGRAv7d0tUJ0GdM72ZBlKXtlgjUZF84O+OhQUdiVHoF7U/nVxwpjOdwUJ8d3Vg==",
+            "dev": true,
+            "requires": {
+                "ansi-green": "^0.1.1",
+                "success-symbol": "^0.1.0"
+            }
+        },
+        "log-utils": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/log-utils/-/log-utils-0.2.1.tgz",
+            "integrity": "sha512-udyegKoMz9eGfpKAX//Khy7sVAZ8b1F7oLDnepZv/1/y8xTvsyPgqQrM94eG8V0vcc2BieYI2kVW4+aa6m+8Qw==",
+            "dev": true,
+            "requires": {
+                "ansi-colors": "^0.2.0",
+                "error-symbol": "^0.1.0",
+                "info-symbol": "^0.1.0",
+                "log-ok": "^0.1.1",
+                "success-symbol": "^0.1.0",
+                "time-stamp": "^1.0.1",
+                "warning-symbol": "^0.1.0"
+            },
+            "dependencies": {
+                "ansi-colors": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-0.2.0.tgz",
+                    "integrity": "sha512-ScRNUT0TovnYw6+Xo3iKh6G+VXDw2Ds7ZRnMIuKBgHY02DgvT2T2K22/tc/916Fi0W/5Z1RzDaHQwnp75hqdbA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-bgblack": "^0.1.1",
+                        "ansi-bgblue": "^0.1.1",
+                        "ansi-bgcyan": "^0.1.1",
+                        "ansi-bggreen": "^0.1.1",
+                        "ansi-bgmagenta": "^0.1.1",
+                        "ansi-bgred": "^0.1.1",
+                        "ansi-bgwhite": "^0.1.1",
+                        "ansi-bgyellow": "^0.1.1",
+                        "ansi-black": "^0.1.1",
+                        "ansi-blue": "^0.1.1",
+                        "ansi-bold": "^0.1.1",
+                        "ansi-cyan": "^0.1.1",
+                        "ansi-dim": "^0.1.1",
+                        "ansi-gray": "^0.1.1",
+                        "ansi-green": "^0.1.1",
+                        "ansi-grey": "^0.1.1",
+                        "ansi-hidden": "^0.1.1",
+                        "ansi-inverse": "^0.1.1",
+                        "ansi-italic": "^0.1.1",
+                        "ansi-magenta": "^0.1.1",
+                        "ansi-red": "^0.1.1",
+                        "ansi-reset": "^0.1.1",
+                        "ansi-strikethrough": "^0.1.1",
+                        "ansi-underline": "^0.1.1",
+                        "ansi-white": "^0.1.1",
+                        "ansi-yellow": "^0.1.1",
+                        "lazy-cache": "^2.0.1"
+                    }
+                }
+            }
+        },
+        "longest": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+            "integrity": "sha512-k+yt5n3l48JU4k8ftnKG6V7u32wyH2NfKzeMto9F/QRE0amxy/LayxwlvjjkZEIzqR+19IrtFO8p5kB9QaYUFg==",
+            "dev": true
+        },
         "loud-rejection": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
@@ -16261,6 +17437,141 @@
             "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
             "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
             "dev": true
+        },
+        "map-schema": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/map-schema/-/map-schema-0.2.4.tgz",
+            "integrity": "sha512-1sgduImleUF+8NiS1wlqDJ8uhmJtFbLRjVW3PZP5IZJd1n+11eV91AnHI4jOYT2UCirriivNUgh6DG73V+G9QQ==",
+            "dev": true,
+            "requires": {
+                "arr-union": "^3.1.0",
+                "collection-visit": "^0.2.3",
+                "component-emitter": "^1.2.1",
+                "debug": "^2.6.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "get-value": "^2.0.6",
+                "is-primitive": "^2.0.0",
+                "kind-of": "^3.1.0",
+                "lazy-cache": "^2.0.2",
+                "log-utils": "^0.2.1",
+                "longest": "^1.0.1",
+                "mixin-deep": "^1.1.3",
+                "object.omit": "^2.0.1",
+                "object.pick": "^1.2.0",
+                "omit-empty": "^0.4.1",
+                "pad-right": "^0.2.2",
+                "set-value": "^0.4.0",
+                "sort-object-arrays": "^0.1.1",
+                "union-value": "^0.2.3"
+            },
+            "dependencies": {
+                "collection-visit": {
+                    "version": "0.2.3",
+                    "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-0.2.3.tgz",
+                    "integrity": "sha512-V88PJOCqJfsZS45YBELDgmhQkECokQAAr9XR4hT6eFkFsAPsCsk3EoDHSuBPYzygjquGM/0KF4vdwTiQO6lbdw==",
+                    "dev": true,
+                    "requires": {
+                        "lazy-cache": "^2.0.1",
+                        "map-visit": "^0.1.5",
+                        "object-visit": "^0.3.4"
+                    }
+                },
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                },
+                "isobject": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                    "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
+                    "dev": true,
+                    "requires": {
+                        "isarray": "1.0.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                },
+                "map-visit": {
+                    "version": "0.1.5",
+                    "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-0.1.5.tgz",
+                    "integrity": "sha512-zdmJBFvvVR/H5wCfsCP7XxSLp+346yAZ30Wy2OsQLcH19OVGMWa3Ms9quO00lj9ybsySu3gKOINNgICb4Zqauw==",
+                    "dev": true,
+                    "requires": {
+                        "lazy-cache": "^2.0.1",
+                        "object-visit": "^0.3.4"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+                    "dev": true
+                },
+                "object-visit": {
+                    "version": "0.3.4",
+                    "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-0.3.4.tgz",
+                    "integrity": "sha512-6QNyX7uTuwqxP7pmDBqgBDKdmZws1rXriUyXM5KG6+7J0aYRuuAGoc636IGdLzgOL77WUwL+EpoTJrEHwWsyOA==",
+                    "dev": true,
+                    "requires": {
+                        "isobject": "^2.0.0"
+                    }
+                },
+                "set-value": {
+                    "version": "0.4.3",
+                    "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+                    "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "^2.0.1",
+                        "is-extendable": "^0.1.1",
+                        "is-plain-object": "^2.0.1",
+                        "to-object-path": "^0.3.0"
+                    }
+                },
+                "union-value": {
+                    "version": "0.2.4",
+                    "resolved": "https://registry.npmjs.org/union-value/-/union-value-0.2.4.tgz",
+                    "integrity": "sha1-c3UVJ4ZnkFfns3qmdug0aPwCdPA=",
+                    "dev": true,
+                    "requires": {
+                        "arr-union": "^3.1.0",
+                        "get-value": "^2.0.6",
+                        "is-extendable": "^0.1.1",
+                        "set-value": "^0.4.3"
+                    }
+                }
+            }
         },
         "map-stream": {
             "version": "0.0.7",
@@ -16801,6 +18112,27 @@
                 "make-iterator": "^1.0.0"
             }
         },
+        "object.omit": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+            "integrity": "sha512-UiAM5mhmIuKLsOvrL+B0U2d1hXHF3bFYWIuH1LMpuV2EJEHG1Ntz06PgLEHjm6VFd87NpH8rastvPoyv6UW2fA==",
+            "dev": true,
+            "requires": {
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
+            },
+            "dependencies": {
+                "for-own": {
+                    "version": "0.1.5",
+                    "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+                    "integrity": "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==",
+                    "dev": true,
+                    "requires": {
+                        "for-in": "^1.0.1"
+                    }
+                }
+            }
+        },
         "object.pick": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
@@ -16818,6 +18150,34 @@
             "requires": {
                 "for-own": "^1.0.0",
                 "make-iterator": "^1.0.0"
+            }
+        },
+        "omit-empty": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/omit-empty/-/omit-empty-0.4.1.tgz",
+            "integrity": "sha512-NwnVOAaLwUEYmvvwLKKqvG6BkSG0pu0yKhKc6uYbWerkIXe6Wi2HQ1qoL+Wksj3DCauRuNKIjZUsLyjLj1/lrw==",
+            "dev": true,
+            "requires": {
+                "has-values": "^0.1.4",
+                "kind-of": "^3.0.3",
+                "reduce-object": "^0.1.3"
+            },
+            "dependencies": {
+                "has-values": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+                    "integrity": "sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ==",
+                    "dev": true
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
             }
         },
         "on-finished": {
@@ -16941,6 +18301,15 @@
             "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
             "dev": true
         },
+        "pad-right": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/pad-right/-/pad-right-0.2.2.tgz",
+            "integrity": "sha512-4cy8M95ioIGolCoMmm2cMntGR1lPLEbOMzOKu8bzjuJP6JpzEMQcDHmh7hHLYGgob+nKe1YHFMaG4V59HQa89g==",
+            "dev": true,
+            "requires": {
+                "repeat-string": "^1.5.2"
+            }
+        },
         "pako": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -16953,6 +18322,45 @@
             "dev": true,
             "requires": {
                 "callsites": "^3.0.0"
+            }
+        },
+        "parse-code-context": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/parse-code-context/-/parse-code-context-1.0.0.tgz",
+            "integrity": "sha512-OZQaqKaQnR21iqhlnPfVisFjBWjhnMl5J9MgbP8xC+EwoVqbXrq78lp+9Zb3ahmLzrIX5Us/qbvBnaS3hkH6OA==",
+            "dev": true
+        },
+        "parse-comments": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/parse-comments/-/parse-comments-1.0.0.tgz",
+            "integrity": "sha512-GHM62374TgaGFoDYzDqd0CQSEUmUl9g99Af+EY2aaXB8tfp8AFgEzRqlxFMJRa8b4OEktLuGle9P+ZQukmXEVA==",
+            "dev": true,
+            "requires": {
+                "extract-comments": "^1.1.0",
+                "floating-point-regex": "^0.1.0",
+                "get-value": "^3.0.1",
+                "inflection": "^1.12.0",
+                "map-schema": "^0.2.4",
+                "snapdragon-node": "^3.0.0",
+                "snapdragon-parser": "^1.0.0",
+                "tokenize-comment": "^3.0.1"
+            },
+            "dependencies": {
+                "get-value": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/get-value/-/get-value-3.0.1.tgz",
+                    "integrity": "sha512-mKZj9JLQrwMBtj5wxi6MH8Z5eSKaERpAwjg43dPtlGI1ZVEgH/qC7T8/6R2OBSUA+zzHBZgICsVJaEIV2tKTDA==",
+                    "dev": true,
+                    "requires": {
+                        "isobject": "^3.0.1"
+                    }
+                },
+                "snapdragon-node": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-3.0.0.tgz",
+                    "integrity": "sha512-8fmjo9AOZXFBWxHS9kOdqA4Mq9x1ldbnPLXjz1voBCmDuQcVBySjlekv4+QnKj0LdNc3hEF19xUrTBQJ2zPyCw==",
+                    "dev": true
+                }
             }
         },
         "parse-filepath": {
@@ -17851,6 +19259,26 @@
                 "balanced-match": "^1.0.0"
             }
         },
+        "reduce-object": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/reduce-object/-/reduce-object-0.1.3.tgz",
+            "integrity": "sha1-1UnUCmwpNvpOPpt4yonJMxRZQhg=",
+            "dev": true,
+            "requires": {
+                "for-own": "^0.1.1"
+            },
+            "dependencies": {
+                "for-own": {
+                    "version": "0.1.5",
+                    "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+                    "integrity": "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==",
+                    "dev": true,
+                    "requires": {
+                        "for-in": "^1.0.1"
+                    }
+                }
+            }
+        },
         "regex-not": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -18228,6 +19656,15 @@
             "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
             "dev": true
         },
+        "set-getter": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.1.tgz",
+            "integrity": "sha512-9sVWOy+gthr+0G9DzqqLaYNA7+5OKkSmcqjL9cBpDEaZrr3ShQlyX2cZ/O/ozE41oxn/Tt0LGEM/w4Rub3A3gw==",
+            "dev": true,
+            "requires": {
+                "to-object-path": "^0.3.0"
+            }
+        },
         "set-immediate-shim": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
@@ -18388,6 +19825,12 @@
                 }
             }
         },
+        "snapdragon-lexer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/snapdragon-lexer/-/snapdragon-lexer-4.0.0.tgz",
+            "integrity": "sha512-ddXT9cpKI0PUrs3xeoQVKEjequr0UyW9w281dzu8RTgWtqdIGZSvoWDsnIMPCc8Fupk4dByatSodhwYEGgrdSg==",
+            "dev": true
+        },
         "snapdragon-node": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
@@ -18439,6 +19882,24 @@
                 }
             }
         },
+        "snapdragon-parser": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/snapdragon-parser/-/snapdragon-parser-1.0.0.tgz",
+            "integrity": "sha512-2sVQqqieRb2MbPAL+eIbkMjNQ3XhrMNiJZlznC3AdD9Hli+N769XHO6vDYTTgAhwDg8VX8Qt7aHBhLalnMhgZQ==",
+            "dev": true,
+            "requires": {
+                "snapdragon-lexer": "^4.0.0",
+                "snapdragon-node": "^3.0.0"
+            },
+            "dependencies": {
+                "snapdragon-node": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-3.0.0.tgz",
+                    "integrity": "sha512-8fmjo9AOZXFBWxHS9kOdqA4Mq9x1ldbnPLXjz1voBCmDuQcVBySjlekv4+QnKj0LdNc3hEF19xUrTBQJ2zPyCw==",
+                    "dev": true
+                }
+            }
+        },
         "snapdragon-util": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
@@ -18466,6 +19927,26 @@
             "dev": true,
             "requires": {
                 "is-plain-obj": "^1.0.0"
+            }
+        },
+        "sort-object-arrays": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/sort-object-arrays/-/sort-object-arrays-0.1.1.tgz",
+            "integrity": "sha1-mfVc8gWkkd3h9S8Jajaiawm0gy8=",
+            "dev": true,
+            "requires": {
+                "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
             }
         },
         "source-map": {
@@ -18681,6 +20162,12 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+            "dev": true
+        },
+        "success-symbol": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz",
+            "integrity": "sha1-JAIuSG878c3KCUKDt2nEctO3KJc=",
             "dev": true
         },
         "supports-color": {
@@ -18987,6 +20474,15 @@
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
             "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
             "dev": true
+        },
+        "tokenize-comment": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/tokenize-comment/-/tokenize-comment-3.0.1.tgz",
+            "integrity": "sha512-of5j9zCooBZxcE1EQ9PCjXcuFUPU/h8GxhWqF86cQ3muHQQreIWgY40ZNfuPQUSXyTa6i7oAWqWX4QivzZh26Q==",
+            "dev": true,
+            "requires": {
+                "snapdragon-lexer": "^4.0.0"
+            }
         },
         "trim-newlines": {
             "version": "1.0.0",
@@ -19424,6 +20920,12 @@
             "requires": {
                 "source-map": "^0.5.1"
             }
+        },
+        "warning-symbol": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/warning-symbol/-/warning-symbol-0.1.0.tgz",
+            "integrity": "sha1-uzHdEbeg+dZ6su2V9Fe2WCW7rSE=",
+            "dev": true
         },
         "watch": {
             "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "husky": "^7.0.4",
         "lodash": "^4.17.21",
         "merge-stream": "^2.0.0",
+        "parse-comments": "^1.0.0",
         "readable-stream": "^3.6.0",
         "through2": "^4.0.2"
     },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "gulp": "^4.0.2",
         "gulp-concat": "^2.6.1",
         "gulp-cssnano": "^2.1.3",
+        "gulp-flatten": "^0.4.0",
         "gulp-if": "^3.0.0",
         "gulp-rename": "^2.0.0",
         "gulp-uglify": "^3.0.2",
@@ -30,7 +31,8 @@
         "husky": "^7.0.4",
         "lodash": "^4.17.21",
         "merge-stream": "^2.0.0",
-        "readable-stream": "^3.6.0"
+        "readable-stream": "^3.6.0",
+        "through2": "^4.0.2"
     },
     "scripts": {
         "eslint": "npm run lint",
@@ -40,14 +42,15 @@
         "prepare": "husky install",
         "test": "gulp test",
         "buildonly": "gulp build",
-        "build": "npm run buildonly && npm run test && npm run lint",
+        "build": "npm run buildonly && npm run createJSDocs && npm run test && npm run lint",
         "clean": "gulp clean",
         "reset": "gulp reset",
         "release:dev": "gulp releaseDev",
         "release:staging": "gulp releaseStaging",
         "release:prod": "gulp releaseProd",
         "serve": "http-server . -p 8000 -c-1",
-        "serveExternal": "http-server . -p 8000 -a 0.0.0.0 --log-ip true -c-1"
+        "serveExternal": "http-server . -p 8000 -a 0.0.0.0 --log-ip true -c-1",
+        "createJSDocs": "gulp createJSDocs"
     },
     "licenses": [
         {

--- a/src/utils/Metrics.js
+++ b/src/utils/Metrics.js
@@ -19,10 +19,26 @@
  *
  */
 
-/**
- *  Utilities functions related to Health Data logging
- */
 /*global gtag, analytics*/
+
+/**
+ * @INCLUDE_IN_PHOENIX_API_DOCS
+ * The Metrics API can be used to send analytics data to track feature usage in accordance with users privacy settings.
+ *
+ *`Status: Internal - Not to be used by third party extensions.`
+ *
+ *## Import
+ * ```js
+ * // usage within core:
+ * const Metrics = require("utils/Metrics");
+ *
+ * // usage within default extensions:
+ * const Metrics = brackets.getModule("utils/Metrics");
+ * ```
+ *
+ *# APIs
+ * Two main APIs are available
+ */
 define(function (require, exports, module) {
     const MAX_AUDIT_ENTRIES = 3000;
     let initDone = false,

--- a/src/utils/Metrics.js
+++ b/src/utils/Metrics.js
@@ -21,13 +21,14 @@
 
 /*global gtag, analytics*/
 
+// @INCLUDE_IN_API_DOCS
 /**
- * @INCLUDE_IN_PHOENIX_API_DOCS
+ * # Metrics API
  * The Metrics API can be used to send analytics data to track feature usage in accordance with users privacy settings.
  *
  *`Status: Internal - Not to be used by third party extensions.`
  *
- *## Import
+ * ## Import
  * ```js
  * // usage within core:
  * const Metrics = require("utils/Metrics");
@@ -36,7 +37,7 @@
  * const Metrics = brackets.getModule("utils/Metrics");
  * ```
  *
- *# APIs
+ * ## APIs
  * Two main APIs are available
  */
 define(function (require, exports, module) {
@@ -173,7 +174,9 @@ define(function (require, exports, module) {
     }
 
     /**
+     * ### Metrics.countEvent
      * log a numeric count >=0
+     *
      * @param {string} eventType The kind of Event Type that needs to be logged- should be a js var compatible string
      * @param {string} eventCategory The kind of Event Category that
      * needs to be logged- should be a js var compatible string
@@ -188,7 +191,9 @@ define(function (require, exports, module) {
     }
 
     /**
-     * log a numeric count >=0
+     * ### Metrics.valueEvent
+     * log a numeric value (number).
+     *
      * @param {string} eventType The kind of Event Type that needs to be logged- should be a js var compatible string
      * @param {string} eventCategory The kind of Event Category that
      * needs to be logged- should be a js var compatible string


### PR DESCRIPTION
## Abstract

Put the below comment in any js file to include it in API DOCS:
```js
// @INCLUDE_IN_API_DOCS
```

Gulp scripts will process those files and generate markdown. 
JSDoc and Markdown syntax compatible (work in progress for full syntax support as required).

Based on https://www.npmjs.com/package/parse-comments library that generates abstract syntax tree for comments.


## commits
- feat: automatic API doc generation gulp script
- feat: jsdoc auto generation scripts initial draft

related to: https://github.com/phcode-dev/phoenix/issues/450
