### PR TITLE
new project file menu entries and shortcuts

### DIFF
--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -31,6 +31,7 @@ define(function (require, exports, module) {
     // FILE
     exports.FILE_NEW_UNTITLED           = "file.newDoc";                // DocumentCommandHandlers.js   handleFileNew()
     exports.FILE_NEW                    = "file.newFile";               // DocumentCommandHandlers.js   handleFileNewInProject()
+    exports.FILE_NEW_PROJECT            = "file.newProject";            // DocumentCommandHandlers.js   handleFileNewInProject()
     exports.FILE_NEW_FOLDER             = "file.newFolder";             // DocumentCommandHandlers.js   handleNewFolderInProject()
     exports.FILE_OPEN                   = "file.open";                  // DocumentCommandHandlers.js   handleDocumentOpen()
     exports.FILE_OPEN_FOLDER            = "file.openFolder";            // ProjectManager.js            openProject()

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -31,7 +31,7 @@ define(function (require, exports, module) {
     // FILE
     exports.FILE_NEW_UNTITLED           = "file.newDoc";                // DocumentCommandHandlers.js   handleFileNew()
     exports.FILE_NEW                    = "file.newFile";               // DocumentCommandHandlers.js   handleFileNewInProject()
-    exports.FILE_NEW_PROJECT            = "file.newProject";            // DocumentCommandHandlers.js   handleFileNewInProject()
+    exports.FILE_NEW_PROJECT            = "file.newProject";            // Phoenix extension: new-project.js
     exports.FILE_NEW_FOLDER             = "file.newFolder";             // DocumentCommandHandlers.js   handleNewFolderInProject()
     exports.FILE_OPEN                   = "file.open";                  // DocumentCommandHandlers.js   handleDocumentOpen()
     exports.FILE_OPEN_FOLDER            = "file.openFolder";            // ProjectManager.js            openProject()

--- a/src/extensions/default/Phoenix/new-project.js
+++ b/src/extensions/default/Phoenix/new-project.js
@@ -19,13 +19,16 @@
  */
 
 define(function (require, exports, module) {
-    let Dialogs = brackets.getModule("widgets/Dialogs"),
+    const Dialogs = brackets.getModule("widgets/Dialogs"),
         Mustache = brackets.getModule("thirdparty/mustache/mustache"),
         FeatureGate = brackets.getModule("utils/FeatureGate"),
         newProjectTemplate = require("text!new-project-template.html"),
         Strings = brackets.getModule("strings"),
         EventDispatcher = brackets.getModule("utils/EventDispatcher"),
-        EventManager = brackets.getModule("utils/EventManager");
+        EventManager = brackets.getModule("utils/EventManager"),
+        CommandManager = brackets.getModule("command/CommandManager"),
+        Commands = brackets.getModule("command/Commands"),
+        Menus = brackets.getModule("command/Menus");
 
     const FEATURE_NEW_PROJECT_DIALOGUE = 'newProjectDialogue',
         EVENT_HANDLER_NEW_PROJECT = "Extn.Phoenix.newProject",
@@ -47,6 +50,12 @@ define(function (require, exports, module) {
         dialogue = Dialogs.showModalDialogUsingTemplate(Mustache.render(newProjectTemplate, templateVars), true);
     }
 
+    function _addMenuEntries() {
+        CommandManager.register(Strings.CMD_PROJECT_NEW, Commands.FILE_NEW_PROJECT, _showNewProjectDialogue);
+        const fileMenu = Menus.getMenu(Menus.AppMenuBar.FILE_MENU);
+        fileMenu.addMenuItem(Commands.FILE_NEW_PROJECT, "Alt-Shift-N", Menus.AFTER, Commands.FILE_NEW);
+    }
+
     exports.on(EVENT_CLOSE_DIALOGUE, ()=>{
         dialogue.close();
     });
@@ -55,6 +64,7 @@ define(function (require, exports, module) {
         if(!FeatureGate.isFeatureEnabled(FEATURE_NEW_PROJECT_DIALOGUE)){
             return;
         }
+        _addMenuEntries();
         _showNewProjectDialogue();
     };
 });

--- a/src/extensions/default/RecentProjects/htmlContent/projects-menu.html
+++ b/src/extensions/default/RecentProjects/htmlContent/projects-menu.html
@@ -1,10 +1,11 @@
 <ul id="project-dropdown" class="dropdown-menu" tabindex="-1">
     <li><a id="open-folder-link">{{Strings.CMD_OPEN_FOLDER}}</a></li>
-    
+    <li><a id="new-project-link">{{Strings.CMD_PROJECT_NEW}}</a></li>
+
     {{#projectList.length}}
     <li class="divider"></li>
     {{/projectList.length}}
-    
+
     {{#projectList}}
     <li>
         <a class="recent-folder-link" data-path="{{path}}">

--- a/src/extensions/default/RecentProjects/main.js
+++ b/src/extensions/default/RecentProjects/main.js
@@ -43,10 +43,6 @@ define(function (require, exports, module) {
 
     var KeyboardPrefs = JSON.parse(require("text!keyboard.json"));
 
-
-    /** @const {string} Recent Projects commands ID */
-    var TOGGLE_DROPDOWN = "recentProjects.toggle";
-
     /** @const {number} Maximum number of displayed recent projects */
     var MAX_PROJECTS = 20;
 
@@ -297,6 +293,8 @@ define(function (require, exports, module) {
 
                 } else if (id === "open-folder-link") {
                     CommandManager.execute(Commands.FILE_OPEN_FOLDER);
+                } else if (id === "new-project-link") {
+                    CommandManager.execute(Commands.FILE_NEW_PROJECT);
                 }
 
             })
@@ -438,8 +436,8 @@ define(function (require, exports, module) {
     }
 
     // Register command handlers
-    CommandManager.register(Strings.CMD_TOGGLE_RECENT_PROJECTS, TOGGLE_DROPDOWN, handleKeyEvent);
-    KeyBindingManager.addBinding(TOGGLE_DROPDOWN, KeyboardPrefs.recentProjects);
+    CommandManager.register(Strings.CMD_TOGGLE_RECENT_PROJECTS, Commands.TOGGLE_DROPDOWN, handleKeyEvent);
+    KeyBindingManager.addBinding(Commands.TOGGLE_DROPDOWN, KeyboardPrefs.recentProjects);
 
     // Initialize extension
     AppInit.appReady(function () {

--- a/src/extensions/default/RecentProjects/main.js
+++ b/src/extensions/default/RecentProjects/main.js
@@ -43,6 +43,9 @@ define(function (require, exports, module) {
 
     var KeyboardPrefs = JSON.parse(require("text!keyboard.json"));
 
+    /** @const {string} Recent Projects commands ID */
+    let TOGGLE_DROPDOWN = "recentProjects.toggle";
+
     /** @const {number} Maximum number of displayed recent projects */
     var MAX_PROJECTS = 20;
 
@@ -436,8 +439,8 @@ define(function (require, exports, module) {
     }
 
     // Register command handlers
-    CommandManager.register(Strings.CMD_TOGGLE_RECENT_PROJECTS, Commands.TOGGLE_DROPDOWN, handleKeyEvent);
-    KeyBindingManager.addBinding(Commands.TOGGLE_DROPDOWN, KeyboardPrefs.recentProjects);
+    CommandManager.register(Strings.CMD_TOGGLE_RECENT_PROJECTS, TOGGLE_DROPDOWN, handleKeyEvent);
+    KeyBindingManager.addBinding(TOGGLE_DROPDOWN, KeyboardPrefs.recentProjects);
 
     // Initialize extension
     AppInit.appReady(function () {

--- a/src/extensions/default/RecentProjects/styles/styles.less
+++ b/src/extensions/default/RecentProjects/styles/styles.less
@@ -92,12 +92,12 @@
     padding: 5px 15px;
 }
 
-#project-dropdown.dropdown-menu .recent-folder-link, #project-dropdown.dropdown-menu #open-folder-link {
+#project-dropdown.dropdown-menu .recent-folder-link, #project-dropdown.dropdown-menu #open-folder-link #new-project-link{
 	display: block;
 	padding: 5px 26px 5px 26px;
 }
 
-.recent-folder, #open-folder-link {
+.recent-folder, #open-folder-link, #new-project-link {
     color: @bc-menu-text;
 
     .dark & {

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -325,6 +325,7 @@ define({
     "FILE_MENU": "File",
     "CMD_FILE_NEW_UNTITLED": "New",
     "CMD_FILE_NEW": "New File",
+    "CMD_PROJECT_NEW": "New Project",
     "CMD_FILE_NEW_FOLDER": "New Folder",
     "CMD_FILE_OPEN": "Open\u2026",
     "CMD_RECENT_FILES_OPEN": "Open Recent\u2026",

--- a/src/utils/Metrics.js
+++ b/src/utils/Metrics.js
@@ -159,7 +159,7 @@ define(function (require, exports, module) {
         if(!count){
             count = 1;
         }
-        let eventAct = `${action}.${category}.${label}`;
+        let eventAct = `${category}.${action}.${label}`;
         gtag('event', eventAct, {
             'event_category': category,
             'event_label': label,


### PR DESCRIPTION
- `Alt+shift+N` will open new project dialogue.
- added menu entries: see images below:
- chore: update google analytics tag name order
- feat: new project file menu entries and shortcuts
![image](https://user-images.githubusercontent.com/5336369/172386228-8a9ace56-61ea-48c5-bcd3-2d5842cd3f58.png)
![image](https://user-images.githubusercontent.com/5336369/172386280-c84a7bb6-5826-4104-a920-a0e8c7837c03.png)
