### PR TITLE
splash screen: add missing shooting-star in the left side.

### DIFF
--- a/src/assets/default-project/en/index.html
+++ b/src/assets/default-project/en/index.html
@@ -58,5 +58,10 @@
         <div class="shooting_star"/>
     </div>
 </div>
+<div class="night">
+    <div class="shooting_star">
+        <div class="shooting_star"/>
+    </div>
+</div>
 </body>
 </html>

--- a/src/assets/phoenix-splash/index.html
+++ b/src/assets/phoenix-splash/index.html
@@ -33,5 +33,10 @@
                 <div class="shooting_star"/>
             </div>
         </div>
+        <div class="night">
+            <div class="shooting_star">
+                <div class="shooting_star"/>
+            </div>
+        </div>
     </body>
 </html>


### PR DESCRIPTION
This PR will add missing shooting star to the left in the splash screen..

current state:

![Screenshot from 2022-06-21 17-33-00](https://user-images.githubusercontent.com/78793827/174796390-fbaf6c96-d272-4b8c-8c22-eb38d3cb3fac.png)


with this change:

![Screenshot from 2022-06-21 17-36-04](https://user-images.githubusercontent.com/78793827/174796501-8199e3f5-1752-4d5a-bf61-c502fb330741.png)

