### PR TITLE
fix: nav bar alignment issues with long project names

### DIFF
--- a/docs/generatedApiDocs/widgets/NotificationUI-API.md
+++ b/docs/generatedApiDocs/widgets/NotificationUI-API.md
@@ -17,7 +17,7 @@ We can do this with the following
 ```js
 const NotificationUI = brackets.getModule("widgets/NotificationUI");
 // or use window.NotificationUI global object has the same effect.
-let notification = NotificationUI.createFromTemplate("Click me to locate the file in file tree", "showInfileTree");
+let notification = NotificationUI.createFromTemplate("Click me to locate the file in file tree", "showInfileTree",{});
 notification.done(()=>{
     console.log("notification is closed in ui.");
 })

--- a/src/extensions/default/NavigationAndHistory/NavigationProvider.js
+++ b/src/extensions/default/NavigationAndHistory/NavigationProvider.js
@@ -653,17 +653,19 @@ define(function (require, exports, module) {
     }
 
     function _setupNavigationButtons() {
-        let $sidebar = $("#sidebar");
-        $sidebar.prepend("<div id=\"navBackButton\" class=\"nav-back-btn btn-alt-quiet\"></div>\n" +
+        let $mainNavBarRight = $("#mainNavBarRight");
+        let $mainNavBarLeft = $("#mainNavBarLeft");
+        $mainNavBarRight.prepend("<div id=\"navBackButton\" class=\"nav-back-btn btn-alt-quiet\"></div>\n" +
             "            <div id=\"navForwardButton\" class=\"nav-forward-btn btn-alt-quiet\"></div>\n" +
             "            <div id=\"showInfileTree\" class=\"show-in-file-tree-btn btn-alt-quiet\"></div>"+
-            "            <div id=\"newProject\" class=\"new-project-btn btn-alt-quiet\"></div>"+
             "            <div id=\"searchNav\" class=\"search-nav-btn btn-alt-quiet\"></div>");
-        let $showInTree = $sidebar.find("#showInfileTree");
-        $navback = $sidebar.find("#navBackButton");
-        $navForward = $sidebar.find("#navForwardButton");
-        $searchNav = $sidebar.find("#searchNav");
-        $newProject = $sidebar.find("#newProject");
+        let $showInTree = $mainNavBarRight.find("#showInfileTree");
+        $navback = $mainNavBarRight.find("#navBackButton");
+        $navForward = $mainNavBarRight.find("#navForwardButton");
+        $searchNav = $mainNavBarRight.find("#searchNav");
+
+        $mainNavBarLeft.prepend("<div id=\"newProject\" class=\"new-project-btn btn-alt-quiet\"></div>");
+        $newProject = $mainNavBarLeft.find("#newProject");
 
         $navback.attr("title", Strings.CMD_NAVIGATE_BACKWARD);
         $navForward.attr("title", Strings.CMD_NAVIGATE_FORWARD);

--- a/src/extensions/default/Phoenix/new-project.js
+++ b/src/extensions/default/Phoenix/new-project.js
@@ -35,7 +35,6 @@ define(function (require, exports, module) {
         FileSystem = brackets.getModule("filesystem/FileSystem"),
         FileUtils = brackets.getModule("file/FileUtils"),
         ProjectManager = brackets.getModule("project/ProjectManager"),
-        NotificationUI = brackets.getModule("widgets/NotificationUI"),
         createProjectDialogue = require("text!html/create-project-dialogue.html"),
         replaceProjectDialogue = require("text!html/replace-project-dialogue.html"),
         replaceKeepProjectDialogue = require("text!html/replace-keep-project-dialogue.html"),

--- a/src/htmlContent/main-view.html
+++ b/src/htmlContent/main-view.html
@@ -43,7 +43,12 @@
         <div id="notificationUIDefaultAnchor" href="#">
         </div>
         <div id="sidebar" class="sidebar panel quiet-scrollbars horz-resizable right-resizer collapsible" data-minsize="0" data-maxsize="80%" data-forceleft=".content">
-            <div class="working-set-splitview-btn btn-alt-quiet"></div>
+            <div id="mainNavBar">
+                <div id="mainNavBarLeft"></div>
+                <div id="mainNavBarRight">
+                    <div class="working-set-splitview-btn btn-alt-quiet"></div>
+                </div>
+            </div>
 
             <div id="working-set-list-container">
 

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -845,9 +845,24 @@ a, img {
     }
 }
 
+#mainNavBar {
+    height: var(--toolbar-height);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+#mainNavBarLeft {
+    float: left;
+    display: flex;
+}
+
+#mainNavBarRight {
+    float: right;
+    display: flex;
+}
+
 .working-set-splitview-btn {
-    position: absolute;
-    right: 30px;
     top: 7px;
     padding: 4px 6px;
     .sprite-icon(0, 0, 13px, 13px, "images/select-triangles.svg");
@@ -861,8 +876,6 @@ a, img {
 }
 
 .search-nav-btn {
-    position: absolute;
-    right: 4px;
     top: 7px;
     padding: 4px 6px;
     .sprite-icon(0, 0, 13px, 13px, "images/sprites.svg#search");
@@ -873,8 +886,6 @@ a, img {
 }
 
 .new-project-btn {
-    position: absolute;
-    right: 133px;
     top: 7px;
     padding: 4px 6px;
     .sprite-icon(0, 0, 13px, 13px, "images/sprites.svg#newFolder");
@@ -885,8 +896,6 @@ a, img {
 }
 
 .show-in-file-tree-btn {
-    position: absolute;
-    right: 105px;
     top: 7px;
     padding: 4px 6px;
     .sprite-icon(0, 0, 13px, 13px, "images/sprites.svg#binoculars");
@@ -897,8 +906,6 @@ a, img {
 }
 
 .nav-back-btn {
-    position: absolute;
-    right: 80px;
     top: 7px;
     padding: 4px 6px;
     .sprite-icon(0, 0, 13px, 13px, "images/sprites.svg#leftArrow");
@@ -909,8 +916,6 @@ a, img {
 }
 
 .nav-forward-btn {
-    position: absolute;
-    right: 55px;
     top: 7px;
     padding: 4px 6px;
     .sprite-icon(0, 0, 13px, 13px, "images/sprites.svg#rightArrow");
@@ -921,8 +926,6 @@ a, img {
 }
 
 .nav-back-btn-disabled {
-    position: absolute;
-    right: 80px;
     top: 7px;
     padding: 4px 6px;
     .sprite-icon(0, 0, 13px, 13px, "images/sprites.svg#leftArrowDisabled");
@@ -933,8 +936,6 @@ a, img {
 }
 
 .nav-forward-btn-disabled {
-    position: absolute;
-    right: 55px;
     top: 7px;
     padding: 4px 6px;
     .sprite-icon(0, 0, 13px, 13px, "images/sprites.svg#rightArrowDisabled");


### PR DESCRIPTION
The NavBar now takes a dedicated toolbar in top of the sidebar. This is required as we add more features in the navbar,
in translated languages where the string for `working files` is long or in long project names, the nav bar icons get hidden.

### fix
![image](https://user-images.githubusercontent.com/5336369/175097194-7721b664-6037-4406-9697-3c54de0b9499.png)

### Problem
![image](https://user-images.githubusercontent.com/5336369/175097041-f8829ed0-1b30-4f4f-8bf9-c08de5994e4f.png)
