### PR TITLE
fix: integrate third party markdown render libs instead of cdn load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ src/phoenix/virtualfs.js.map
 !/src/thirdparty/licences
 /src/thirdparty/jszip.js
 /src/thirdparty/underscore-min.js
+/src/thirdparty/bootstrap
+/src/thirdparty/highlight.js
+/src/thirdparty/gfm.min.css
 /src/thirdparty/mime-db.json
 /src/thirdparty/floating-ui.core.umd.min.js
 /src/thirdparty/floating-ui.dom.umd.min.js

--- a/gulpfile.js/index.js
+++ b/gulpfile.js/index.js
@@ -82,6 +82,26 @@ async function copyThirdPartyLibs(){
         src(['node_modules/underscore/LICENSE'])
             .pipe(rename("underscore.markdown"))
             .pipe(dest('src/thirdparty/licences/')),
+        // bootstrap
+        src(['node_modules/bootstrap/dist/js/bootstrap.min.js', 'node_modules/bootstrap/dist/js/bootstrap.min.js.map',
+            'node_modules/bootstrap/dist/css/bootstrap.min.css', 'node_modules/bootstrap/dist/css/bootstrap.min.css.map'])
+            .pipe(dest('src/thirdparty/bootstrap')),
+        src(['node_modules/bootstrap/LICENSE'])
+            .pipe(rename("bootstrap.markdown"))
+            .pipe(dest('src/thirdparty/licences/')),
+        // hilightjs
+        src(['node_modules/@highlightjs/cdn-assets/highlight.min.js'])
+            .pipe(dest('src/thirdparty/highlight.js')),
+        src(['node_modules/@highlightjs/cdn-assets/styles/*.*'])
+            .pipe(dest('src/thirdparty/highlight.js/styles')),
+        src(['node_modules/@highlightjs/cdn-assets/languages/*.*'])
+            .pipe(dest('src/thirdparty/highlight.js/languages')),
+        src(['node_modules/@highlightjs/cdn-assets/LICENSE'])
+            .pipe(rename("highlight.js.markdown"))
+            .pipe(dest('src/thirdparty/licences/')),
+        // gfm-stylesheet
+        src(['node_modules/@pixelbrackets/gfm-stylesheet/dist/gfm.min.css'])
+            .pipe(dest('src/thirdparty/')), // AGPL 2.0 license addded to
         // prettier
         src(['node_modules/prettier/*.js'])
             .pipe(dest('src/extensions/default/Phoenix-prettier/thirdParty')),

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,10 @@
             "version": "2.0.0-0",
             "dependencies": {
                 "@floating-ui/dom": "^0.5.3",
+                "@highlightjs/cdn-assets": "^11.5.1",
                 "@phcode/fs": "^1.0.13",
+                "@pixelbrackets/gfm-stylesheet": "^1.1.0",
+                "bootstrap": "^5.1.3",
                 "browser-mime": "^1.0.1",
                 "jszip": "^3.7.1",
                 "marked": "^4.0.14",
@@ -841,6 +844,14 @@
                 "@floating-ui/core": "^0.7.3"
             }
         },
+        "node_modules/@highlightjs/cdn-assets": {
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/@highlightjs/cdn-assets/-/cdn-assets-11.5.1.tgz",
+            "integrity": "sha512-43k8M1OhN+CP4LCOcbqfk4L/k1D5ily9inCCB9fMuvj+MUnJzLSUDLCAHKyDu7aALyHCzmRtZTflsh6u8Qty0g==",
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
@@ -957,6 +968,21 @@
             "version": "1.0.13",
             "resolved": "https://registry.npmjs.org/@phcode/fs/-/fs-1.0.13.tgz",
             "integrity": "sha512-oJUAcHP6nwgp/SXadND2KqP/EtcA3nIj37AUbqzcvguSytyUzexW3wjbVQgASHzng4Af1S5prJeBLrdJCQnvLg=="
+        },
+        "node_modules/@pixelbrackets/gfm-stylesheet": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@pixelbrackets/gfm-stylesheet/-/gfm-stylesheet-1.1.0.tgz",
+            "integrity": "sha512-Dal+yZ5FpZN8yq6XfZNWFl0gNi4AM5c4cEIGc0yKQYQAbCY0+erwQjAVQUuzkD4kRsrJK+hwF+Mf58/pXV421w=="
+        },
+        "node_modules/@popperjs/core": {
+            "version": "2.11.5",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+            "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
+            "peer": true,
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/popperjs"
+            }
         },
         "node_modules/@tsconfig/node10": {
             "version": "1.0.8",
@@ -2089,6 +2115,18 @@
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
             "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
             "dev": true
+        },
+        "node_modules/bootstrap": {
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
+            "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/bootstrap"
+            },
+            "peerDependencies": {
+                "@popperjs/core": "^2.10.2"
+            }
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
@@ -5221,6 +5259,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/documentation/node_modules/highlight.js": {
+            "version": "10.7.3",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+            "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+            "dev": true,
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/documentation/node_modules/is-binary-path": {
@@ -9089,15 +9136,6 @@
             "dev": true,
             "bin": {
                 "he": "bin/he"
-            }
-        },
-        "node_modules/highlight.js": {
-            "version": "10.7.3",
-            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-            "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
-            "dev": true,
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/homedir-polyfill": {
@@ -16546,6 +16584,11 @@
                 "@floating-ui/core": "^0.7.3"
             }
         },
+        "@highlightjs/cdn-assets": {
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/@highlightjs/cdn-assets/-/cdn-assets-11.5.1.tgz",
+            "integrity": "sha512-43k8M1OhN+CP4LCOcbqfk4L/k1D5ily9inCCB9fMuvj+MUnJzLSUDLCAHKyDu7aALyHCzmRtZTflsh6u8Qty0g=="
+        },
         "@humanwhocodes/config-array": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
@@ -16638,6 +16681,17 @@
             "version": "1.0.13",
             "resolved": "https://registry.npmjs.org/@phcode/fs/-/fs-1.0.13.tgz",
             "integrity": "sha512-oJUAcHP6nwgp/SXadND2KqP/EtcA3nIj37AUbqzcvguSytyUzexW3wjbVQgASHzng4Af1S5prJeBLrdJCQnvLg=="
+        },
+        "@pixelbrackets/gfm-stylesheet": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@pixelbrackets/gfm-stylesheet/-/gfm-stylesheet-1.1.0.tgz",
+            "integrity": "sha512-Dal+yZ5FpZN8yq6XfZNWFl0gNi4AM5c4cEIGc0yKQYQAbCY0+erwQjAVQUuzkD4kRsrJK+hwF+Mf58/pXV421w=="
+        },
+        "@popperjs/core": {
+            "version": "2.11.5",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+            "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
+            "peer": true
         },
         "@tsconfig/node10": {
             "version": "1.0.8",
@@ -17554,6 +17608,12 @@
                     "dev": true
                 }
             }
+        },
+        "bootstrap": {
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
+            "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==",
+            "requires": {}
         },
         "brace-expansion": {
             "version": "1.1.11",
@@ -19989,6 +20049,12 @@
                         "once": "^1.3.0",
                         "path-is-absolute": "^1.0.0"
                     }
+                },
+                "highlight.js": {
+                    "version": "10.7.3",
+                    "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+                    "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+                    "dev": true
                 },
                 "is-binary-path": {
                     "version": "2.1.0",
@@ -23105,12 +23171,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
             "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-            "dev": true
-        },
-        "highlight.js": {
-            "version": "10.7.3",
-            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-            "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
             "dev": true
         },
         "homedir-polyfill": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,10 @@
     ],
     "dependencies": {
         "@floating-ui/dom": "^0.5.3",
+        "@highlightjs/cdn-assets": "^11.5.1",
         "@phcode/fs": "^1.0.13",
+        "@pixelbrackets/gfm-stylesheet": "^1.1.0",
+        "bootstrap": "^5.1.3",
         "browser-mime": "^1.0.1",
         "jszip": "^3.7.1",
         "marked": "^4.0.14",

--- a/src/extensions/default/Phoenix-live-preview/main.js
+++ b/src/extensions/default/Phoenix-live-preview/main.js
@@ -76,7 +76,7 @@ define(function (require, exports, module) {
 
     // Templates
     let panelHTML       = require("text!panel.html"),
-        markdownHTML = require("text!markdown.html");
+        markdownHTMLTemplate = require("text!markdown.html");
     ExtensionUtils.loadStyleSheet(module, "live-preview.css");
 
     // jQuery objects
@@ -172,9 +172,13 @@ define(function (require, exports, module) {
                 let text = doc.getText();
                 let markdownHtml = marked.parse(text);
                 let templateVars = {
-                    markdownContent: markdownHtml
+                    markdownContent: markdownHtml,
+                    BOOTSTRAP_LIB_CSS: `${window.parent.Phoenix.baseURL}thirdparty/bootstrap/bootstrap.min.css`,
+                    HIGHLIGHT_JS_CSS: `${window.parent.Phoenix.baseURL}thirdparty/highlight.js/styles/github.min.css`,
+                    HIGHLIGHT_JS: `${window.parent.Phoenix.baseURL}thirdparty/highlight.js/highlight.min.js`,
+                    GFM_CSS: `${window.parent.Phoenix.baseURL}thirdparty/gfm.min.css`
                 };
-                let html = Mustache.render(markdownHTML, templateVars);
+                let html = Mustache.render(markdownHTMLTemplate, templateVars);
                 $iframe.attr('srcdoc', html);
                 if(tab && !tab.closed){
                     tab.location = "about:blank";

--- a/src/extensions/default/Phoenix-live-preview/markdown.html
+++ b/src/extensions/default/Phoenix-live-preview/markdown.html
@@ -9,12 +9,6 @@
     <link href="{{{HIGHLIGHT_JS_CSS}}}" rel="stylesheet">
     <script src="{{{HIGHLIGHT_JS}}}"></script>
     <link rel="stylesheet" href="{{{GFM_CSS}}}" />
-
-    <script>
-        hljs.highlightAll();
-    </script>
-
-
     <style>
 
         *{
@@ -78,7 +72,7 @@
 
     </style>
 </head>
-<body >
+<body onload="hljs.highlightAll();">
 {{{markdownContent}}}
 </body>
 </html>

--- a/src/extensions/default/Phoenix-live-preview/markdown.html
+++ b/src/extensions/default/Phoenix-live-preview/markdown.html
@@ -5,13 +5,13 @@
     <title>Markdown- Phoenix</title>
 
 
-    <link rel="stylesheet" href="http://cdn.bootcss.com/bootstrap/3.3.5/css/bootstrap.min.css">
-    <link href="http://cdn.bootcss.com/highlight.js/8.0/styles/monokai_sublime.min.css" rel="stylesheet">
-    <script src="http://cdn.bootcss.com/highlight.js/8.0/highlight.min.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/pixelbrackets/gfm-stylesheet/dist/gfm.min.css" />
+    <link rel="stylesheet" href="{{{BOOTSTRAP_LIB_CSS}}}">
+    <link href="{{{HIGHLIGHT_JS_CSS}}}" rel="stylesheet">
+    <script src="{{{HIGHLIGHT_JS}}}"></script>
+    <link rel="stylesheet" href="{{{GFM_CSS}}}" />
 
     <script>
-        hljs.initHighlightingOnLoad();
+        hljs.highlightAll();
     </script>
 
 

--- a/src/thirdparty/licences/bootstrap.markdown
+++ b/src/thirdparty/licences/bootstrap.markdown
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2011-2021 Twitter, Inc.
+Copyright (c) 2011-2021 The Bootstrap Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/thirdparty/licences/credits.md
+++ b/src/thirdparty/licences/credits.md
@@ -7,6 +7,9 @@ All projects we depend upon and their licenses can be found in this [folder](htt
 
 Please find all other licenses and attributions below:
 
+## Other Libraries used
+1. https://www.npmjs.com/package/@pixelbrackets/gfm-stylesheet under AGPL 2.0 license
+
 ## Attributions for Images and other assets used
 
 ### wikimedia CC

--- a/src/thirdparty/licences/highlight.js.markdown
+++ b/src/thirdparty/licences/highlight.js.markdown
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2006, Ivan Sagalaev.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
* integrate markdown live preview libs in src directly as the load of the lib from cdn was taking time and inconsistently.
* add github code styles for code in markdown

![image](https://user-images.githubusercontent.com/5336369/175824759-f4f9efc5-f952-4af3-b446-9b212b89552e.png)
