### PR TITLE
fix: crash when searching large projects

### DIFF
--- a/src/filesystem/FileSystemEntry.js
+++ b/src/filesystem/FileSystemEntry.js
@@ -531,6 +531,9 @@ define(function (require, exports, module) {
 
                 try{
                     for(let entry of entries){
+                        // this is left intentionally serial to prevent a chrome crash bug when large number of fs
+                        // access APIs are called. Try to make this parallel in the future after verifying on a large
+                        // folder with more than 100K entries.
                         await entry._visitHelper(entry._entryStats, visitedPaths, visitor, options, _currentDepth + 1);
                     }
                     resolve();

--- a/src/project/ProjectModel.js
+++ b/src/project/ProjectModel.js
@@ -55,6 +55,7 @@ define(function (require, exports, module) {
      * @type {RegExp}
      */
     var _exclusionListRegEx = /\.pyc$|^\.git$|^\.gitmodules$|^\.svn$|^\.DS_Store$|^Icon\r|^Thumbs\.db$|^\.hg$|^CVS$|^\.hgtags$|^\.idea$|^\.c9revisions$|^\.SyncArchive$|^\.SyncID$|^\.SyncIgnore$|\~$/;
+    var _cacheExcludeRegEx = /^node_modules$|^bower_components$/;
 
     /**
      * Glob definition of files and folders that should be excluded directly
@@ -124,6 +125,10 @@ define(function (require, exports, module) {
      */
     function shouldShow(entry) {
         return _shouldShowName(entry.name);
+    }
+
+    function _shouldCache(entry) {
+        return shouldShow(entry) && !_cacheExcludeRegEx.test(entry.name);
     }
 
     // Constants used by the ProjectModel
@@ -440,7 +445,7 @@ define(function (require, exports, module) {
             var deferred = new $.Deferred(),
                 allFiles = [],
                 allFilesVisitor = function (entry) {
-                    if (shouldShow(entry)) {
+                    if (_shouldCache(entry)) {
                         if (entry.isFile) {
                             allFiles.push(entry);
                         }

--- a/test/spec/LowLevelFileIO-test.js
+++ b/test/spec/LowLevelFileIO-test.js
@@ -37,7 +37,8 @@ define(function (require, exports, module) {
 
     describe("LowLevelFileIO", function () {
 
-        var baseDir = SpecRunnerUtils.getTempDirectory();
+        var baseDir = SpecRunnerUtils.getTempDirectory(),
+            testDir;
 
         function readdirSpy() {
             var callback = function (err, content) {
@@ -93,6 +94,7 @@ define(function (require, exports, module) {
                 // create the test folder and init the test files
                 var testFiles = SpecRunnerUtils.getTestPath("/spec/LowLevelFileIO-test-files");
                 waitsForDone(SpecRunnerUtils.copy(testFiles, baseDir), "copy temp files");
+                testDir = `${baseDir}/LowLevelFileIO-test-files`;
             });
         });
 
@@ -110,7 +112,7 @@ define(function (require, exports, module) {
                 var cb = readdirSpy();
 
                 runs(function () {
-                    brackets.fs.readdir(baseDir, cb);
+                    brackets.fs.readdir(testDir, cb);
                 });
 
                 waitsFor(function () { return cb.wasCalled; }, "readdir to finish", 1000);
@@ -191,7 +193,7 @@ define(function (require, exports, module) {
                 var cb = statSpy();
 
                 runs(function () {
-                    brackets.fs.stat(baseDir + "/file_one.txt", cb);
+                    brackets.fs.stat(testDir + "/file_one.txt", cb);
                 });
 
                 waitsFor(function () { return cb.wasCalled; }, "stat to finish", 1000);
@@ -233,7 +235,7 @@ define(function (require, exports, module) {
                 var cb = readFileSpy();
 
                 runs(function () {
-                    brackets.fs.readFile(baseDir + "/file_one.txt", UTF8, cb);
+                    brackets.fs.readFile(testDir + "/file_one.txt", UTF8, cb);
                 });
 
                 waitsFor(function () { return cb.wasCalled; }, "readFile to finish", 1000);
@@ -260,7 +262,7 @@ define(function (require, exports, module) {
 
             it("should return an error if trying to use an unsppported encoding", function () {
                 runs(function () {
-                    brackets.fs.readFile(baseDir + "/file_one.txt", UTF16, (a, c)=>{
+                    brackets.fs.readFile(testDir + "/file_one.txt", UTF16, (a, c)=>{
                         expect(ArrayBuffer.isView(c)).toBe(true);
                     });
                 });
@@ -290,7 +292,7 @@ define(function (require, exports, module) {
 
             it("should return an error trying to read a binary file", function () {
                 runs(function () {
-                    brackets.fs.readFile(baseDir + "/tree.jpg", "bin", (a, c)=> {
+                    brackets.fs.readFile(testDir + "/tree.jpg", "bin", (a, c)=> {
                         expect(ArrayBuffer.isView(c)).toBe(true);
                     });
                 });
@@ -300,7 +302,7 @@ define(function (require, exports, module) {
                 var cb = readFileSpy();
 
                 runs(function () {
-                    brackets.fs.readFile(baseDir + "/ru_utf8.html", UTF8, cb);
+                    brackets.fs.readFile(testDir + "/ru_utf8.html", UTF8, cb);
                 });
 
                 waitsFor(function () { return cb.wasCalled; }, "readFile to finish", 1000);
@@ -314,7 +316,7 @@ define(function (require, exports, module) {
                 var cb = readFileSpy();
 
                 runs(function () {
-                    brackets.fs.readFile(baseDir + "/es_small_utf8.html", UTF8, cb);
+                    brackets.fs.readFile(testDir + "/es_small_utf8.html", UTF8, cb);
                 });
 
                 waitsFor(function () { return cb.wasCalled; }, "readFile to finish", 1000);
@@ -329,7 +331,7 @@ define(function (require, exports, module) {
                var cb = readFileSpy();
 
                runs(function () {
-                   brackets.fs.readFile(baseDir + "/emptyfile.txt", UTF8, cb);
+                   brackets.fs.readFile(testDir + "/emptyfile.txt", UTF8, cb);
                });
 
                waitsFor(function () { return cb.wasCalled; }, "readFile to finish", 1000);
@@ -343,7 +345,7 @@ define(function (require, exports, module) {
                 var cb = readFileSpy();
 
                 runs(function () {
-                    brackets.fs.readFile(baseDir + "/ru_utf8_wBOM.html", UTF8, cb);
+                    brackets.fs.readFile(testDir + "/ru_utf8_wBOM.html", UTF8, cb);
                 });
 
                 waitsFor(function () { return cb.wasCalled; }, "readFile to finish", 1000);
@@ -613,8 +615,8 @@ define(function (require, exports, module) {
             var complete;
 
             it("should rename a file", function () {
-                var oldName     = baseDir + "/file_one.txt",
-                    newName     = baseDir + "/file_one_renamed.txt",
+                var oldName     = testDir + "/file_one.txt",
+                    newName     = testDir + "/file_one_renamed.txt",
                     renameCB    = errSpy(),
                     statCB      = statSpy();
 
@@ -666,8 +668,8 @@ define(function (require, exports, module) {
 
             });
             it("should rename a folder", function () {
-                var oldName     = baseDir + "/rename_me",
-                    newName     = baseDir + "/renamed_folder",
+                var oldName     = testDir + "/rename_me",
+                    newName     = testDir + "/renamed_folder",
                     renameCB    = errSpy(),
                     statCB      = statSpy();
 
@@ -718,8 +720,8 @@ define(function (require, exports, module) {
                 });
             });
             it("should return an error if the new name already exists", function () {
-                var oldName = baseDir + "/file_one.txt",
-                    newName = baseDir + "/file_two.txt",
+                var oldName = testDir + "/file_one.txt",
+                    newName = testDir + "/file_two.txt",
                     cb      = errSpy();
 
                 complete = false;
@@ -736,8 +738,8 @@ define(function (require, exports, module) {
             });
             it("should return an error if the parent folder is read only (Mac only)", function () {
                 if (brackets.platform === "mac") {
-                    var oldName = baseDir + "/cant_write_here/readme.txt",
-                        newName = baseDir + "/cant_write_here/readme_renamed.txt",
+                    var oldName = testDir + "/cant_write_here/readme.txt",
+                        newName = testDir + "/cant_write_here/readme_renamed.txt",
                         cb      = errSpy();
 
                     complete = false;
@@ -760,8 +762,8 @@ define(function (require, exports, module) {
             var complete;
 
             it("should copy a file", function () {
-                var fileName     = baseDir + "/file_one.txt",
-                    copyName     = baseDir + "/file_one_copy.txt",
+                var fileName     = testDir + "/file_one.txt",
+                    copyName     = testDir + "/file_one_copy.txt",
                     copyCB       = errSpy(),
                     unlinkCB     = errSpy(),
                     statCB       = statSpy(),


### PR DESCRIPTION
- fix: crash when searching large projects
- fix: dont cache node_modeuls
- fix low level file io tests regression as we changed copy behavior to comply with unix copy semantics. The copy api was only used by the tests module as i remember, so fixed the tests.
