### PR TITLE
feat: sort dirs first option and folder icons

### DIFF
--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -56,6 +56,7 @@ define(function (require, exports, module) {
     exports.FILE_DELETE                 = "file.delete";                // DocumentCommandHandlers.js   handleFileDelete()
     exports.FILE_EXTENSION_MANAGER      = "file.extensionManager";      // ExtensionManagerDialog.js    _showDialog()
     exports.FILE_REFRESH                = "file.refresh";               // ProjectManager.js            refreshFileTree()
+    exports.FILE_SHOW_FOLDERS_FIRST     = "file.showFolderFirst";       // ProjectManager.js
     exports.FILE_OPEN_PREFERENCES       = "file.openPreferences";       // PreferencesManager.js        _handleOpenPreferences()
     exports.FILE_OPEN_KEYMAP            = "file.openKeyMap";            // KeyBindingManager.js         _openUserKeyMap()
 

--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -244,6 +244,7 @@ define(function (require, exports, module) {
         splitview_menu.addMenuItem(Commands.CMD_WORKINGSET_SORT_BY_TYPE);
         splitview_menu.addMenuDivider();
         splitview_menu.addMenuItem(Commands.CMD_WORKING_SORT_TOGGLE_AUTO);
+        splitview_menu.addMenuItem(Commands.FILE_SHOW_FOLDERS_FIRST);
 
         var project_cmenu = Menus.registerContextMenu(Menus.ContextMenuIds.PROJECT_MENU);
         project_cmenu.addMenuItem(Commands.FILE_NEW);

--- a/src/extensions/default/icons/main.js
+++ b/src/extensions/default/icons/main.js
@@ -11,7 +11,10 @@ define(function (require, exports, module) {
 
     // use this cheetsheet for fontawesome icons https://fontawesome.com/v5/cheatsheet/free/brands
     // or https://fontawesome.com/v5/cheatsheet/free/solid or https://fontawesome.com/v5/cheatsheet/free/regular
+    // or https://devicon.dev/
     var exts = {
+        folder: "fa-folder fa-solid",
+
         css: "devicon-css3-plain",
         htm: "devicon-html5-plain",
         html: "devicon-html5-plain",
@@ -146,18 +149,21 @@ define(function (require, exports, module) {
 
     var iconProvider = function (entry) {
         let color = true;
-        if (!entry.isFile) {
-            return;
-        }
-
-        let ext = getExtension(entry.fullPath) || entry.name.substr(1);
-        let filename = fileUtils.getBaseName(entry.fullPath).toLowerCase();
 
         let span = $('<span>');
         span.addClass('bd-icon');
         let el = $('<i>');
         span.append(el);
         el.addClass('fa-solid fa-file');
+
+        if (!entry.isFile) {
+            el.removeClass('fa-solid fa-file');
+            el.addClass(exts.folder);
+            return span;
+        }
+
+        let ext = getExtension(entry.fullPath) || entry.name.substr(1);
+        let filename = fileUtils.getBaseName(entry.fullPath).toLowerCase();
 
         if (files[filename]) {
             el.removeClass('fa-solid fa-file');

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -369,6 +369,7 @@ define({
     "CMD_INSTALL_EXTENSION": "Install Extension\u2026",
     "CMD_EXTENSION_MANAGER": "Extension Manager\u2026",
     "CMD_FILE_REFRESH": "Refresh File Tree",
+    "CMD_FILE_SHOW_FOLDERS_FIRST": "Sort Folders First",
     "CMD_QUIT": "Quit",
     // Used in native File menu on Windows
     "CMD_EXIT": "Exit",

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1099,7 +1099,6 @@ define(function (require, exports, module) {
     function _showFolderFirst() {
         const newPref = !PreferencesManager.get(SORT_DIRECTORIES_FIRST);
         PreferencesManager.set(SORT_DIRECTORIES_FIRST, newPref);
-        CommandManager.get(Commands.FILE_SHOW_FOLDERS_FIRST).setChecked(newPref);
     }
 
     refreshFileTree = _.debounce(refreshFileTree, _refreshDelay);
@@ -1585,7 +1584,9 @@ define(function (require, exports, module) {
         description: Strings.DESCRIPTION_SORT_DIRECTORIES_FIRST
     })
         .on("change", function () {
-            actionCreator.setSortDirectoriesFirst(PreferencesManager.get(SORT_DIRECTORIES_FIRST));
+            let sortPref = PreferencesManager.get(SORT_DIRECTORIES_FIRST);
+            actionCreator.setSortDirectoriesFirst(sortPref);
+            CommandManager.get(Commands.FILE_SHOW_FOLDERS_FIRST).setChecked(sortPref);
         });
     CommandManager.register(Strings.CMD_FILE_SHOW_FOLDERS_FIRST, Commands.FILE_SHOW_FOLDERS_FIRST, _showFolderFirst);
     CommandManager.get(Commands.FILE_SHOW_FOLDERS_FIRST).setChecked(PreferencesManager.get(SORT_DIRECTORIES_FIRST));

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1096,6 +1096,12 @@ define(function (require, exports, module) {
         return new $.Deferred().resolve().promise();
     };
 
+    function _showFolderFirst() {
+        const newPref = !PreferencesManager.get(SORT_DIRECTORIES_FIRST);
+        PreferencesManager.set(SORT_DIRECTORIES_FIRST, newPref);
+        CommandManager.get(Commands.FILE_SHOW_FOLDERS_FIRST).setChecked(newPref);
+    }
+
     refreshFileTree = _.debounce(refreshFileTree, _refreshDelay);
 
     /**
@@ -1575,12 +1581,14 @@ define(function (require, exports, module) {
     CommandManager.register(Strings.CMD_FILE_DUPLICATE, Commands.FILE_DUPLICATE, _duplicateFileCMD);
 
     // Define the preference to decide how to sort the Project Tree files
-    PreferencesManager.definePreference(SORT_DIRECTORIES_FIRST, "boolean", brackets.platform !== "mac", {
+    PreferencesManager.definePreference(SORT_DIRECTORIES_FIRST, "boolean", true, {
         description: Strings.DESCRIPTION_SORT_DIRECTORIES_FIRST
     })
         .on("change", function () {
             actionCreator.setSortDirectoriesFirst(PreferencesManager.get(SORT_DIRECTORIES_FIRST));
         });
+    CommandManager.register(Strings.CMD_FILE_SHOW_FOLDERS_FIRST, Commands.FILE_SHOW_FOLDERS_FIRST, _showFolderFirst);
+    CommandManager.get(Commands.FILE_SHOW_FOLDERS_FIRST).setChecked(PreferencesManager.get(SORT_DIRECTORIES_FIRST));
 
     actionCreator.setSortDirectoriesFirst(PreferencesManager.get(SORT_DIRECTORIES_FIRST));
 


### PR DESCRIPTION
* In Mac, by default we were using system sort order and not segregating files and folders. All code editors in mac- vscode, webstorm. we will follow the same for consistency and provide an option an option. 
* adds folder icons

![image](https://user-images.githubusercontent.com/5336369/177300616-4263957b-a2a5-4b7b-80f2-751be836afe0.png)
![image](https://user-images.githubusercontent.com/5336369/177300663-c3603745-9c13-4953-8534-4febce042abd.png)
