### PR TITLE
fix: selection layout bug and add more lanuguage types

### DIFF
--- a/src/extensions/default/icons/main.js
+++ b/src/extensions/default/icons/main.js
@@ -5,21 +5,22 @@ define(function (require, exports, module) {
 
     let extensionUtils = brackets.getModule('utils/ExtensionUtils'),
         fileUtils = brackets.getModule('file/FileUtils'),
-        ProjectManager = brackets.getModule('project/ProjectManager');
+        ProjectManager = brackets.getModule('project/ProjectManager'),
+        LanguageManager = brackets.getModule("language/LanguageManager");
 
     extensionUtils.loadStyleSheet(module, 'css/main.css');
 
     // use this cheetsheet for fontawesome icons https://fontawesome.com/v5/cheatsheet/free/brands
     // or https://fontawesome.com/v5/cheatsheet/free/solid or https://fontawesome.com/v5/cheatsheet/free/regular
     // or https://devicon.dev/
-    var exts = {
+    var languages = {
         folder: "fa-folder fa-solid",
 
         css: "devicon-css3-plain",
         htm: "devicon-html5-plain",
         html: "devicon-html5-plain",
-        js: "devicon-javascript-plain",
-        ts: "devicon-typescript-plain",
+        javascript: "devicon-javascript-plain",
+        typescript: "devicon-typescript-plain",
         map: "fa-map-signs fa-solid",
         'js.map': "fa-map-signs fa-solid",
         'css.map': "fa-map-signs fa-solid",
@@ -30,6 +31,7 @@ define(function (require, exports, module) {
         woff: "fa-font fa-solid",
         ttf: "fa-font fa-solid",
         txt: "fa-file-alt fa-solid",
+        text: "fa-file-alt fa-solid",
 
         json: "fa-cogs fa-solid",
         yml: "fa-cogs fa-solid",
@@ -41,21 +43,19 @@ define(function (require, exports, module) {
         htpasswd: "fa-cogs fa-solid",
         project: "fa-cogs fa-solid",
         org: "fa-cogs fa-solid",
+        properties: "fa-cogs fa-solid",
 
         markdown: "devicon-markdown-original nocolor",
-        md: "devicon-markdown-original nocolor",
+        'markdown (github)': "devicon-markdown-original nocolor",
 
-        py: "devicon-python-plain",
+        python: "devicon-python-plain",
         pyc: "devicon-python-plain",
         pyd: "devicon-python-plain",
         pyo: "devicon-python-plain",
 
         php: "devicon-php-plain",
-        phtml: "devicon-php-plain",
-        php3: "devicon-php-plain",
-        php4: "devicon-php-plain",
-        php5: "devicon-php-plain",
-        phps: "devicon-php-plain",
+
+        lua: "devicon-lua-plain",
 
         gitignore: "devicon-git-plain",
         gitattributes: "devicon-git-plain",
@@ -67,6 +67,9 @@ define(function (require, exports, module) {
 
         c: "devicon-c-plain nocolor",
         cpp: "devicon-cplusplus-plain nocolor",
+        'objective-c': "devicon-objectivec-plain nocolor",
+        kotlin: "devicon-kotlin-plain",
+        'c#': "devicon-csharp-plain",
 
         bat: "fa-file-code fa-solid",
         sh: "fa-file-code fa-solid",
@@ -77,20 +80,25 @@ define(function (require, exports, module) {
         java: "fa-java fa-brands",
         jar: "fa-archive fa-solid",
 
-        rb: "devicon-ruby-plain",
-        erb: "devicon-ruby-plain",
+        'erb_html': "devicon-ruby-plain",
+        ruby: "devicon-ruby-plain",
         rbw: "devicon-ruby-plain",
         rdoc: "devicon-ruby-plain",
         haml: "devicon-rails-plain",
 
-        coffee: "devicon-coffeescript-original nocolor",
+        coffeescript: "devicon-coffeescript-original nocolor",
+
+        groovy: "devicon-groovy-plain",
+
+        clojure: "devicon-clojure-plain",
 
         styl: "devicon-stylus-original nocolor",
+
+        dart: "devicon-dart-plain",
 
         npmignore: "fa-npm fa-brands",
 
         scala: "devicon-scala-plain",
-        sc: "devicon-scala-plain",
 
         go: "devicon-go-plain",
 
@@ -98,14 +106,14 @@ define(function (require, exports, module) {
 
         sln: 'devicon-visualstudio-plain',
 
-        pl: 'devicon-perl-plain nocolor',
-        pm: 'devicon-perl-plain nocolor',
+        perl: 'devicon-perl-plain nocolor',
 
         hs: 'devicon-haskell-plain nocolor',
         lhs: 'devicon-haskell-plain nocolor',
 
         psd: 'devicon-photoshop-plain',
         ai: 'devicon-illustrator-plain',
+        image: 'fa-image fa-solid',
         png: 'fa-image fa-solid',
         ico: 'fa-image fa-solid',
         jpg: 'fa-image fa-solid',
@@ -114,6 +122,7 @@ define(function (require, exports, module) {
         gif: 'fa-photo-video fa-solid',
         svg: 'fa-code fa-solid',
 
+        audio: 'fa-music fa-solid',
         mp3: 'fa-music fa-solid',
         wav: 'fa-music fa-solid',
 
@@ -158,7 +167,7 @@ define(function (require, exports, module) {
 
         if (!entry.isFile) {
             el.removeClass('fa-solid fa-file');
-            el.addClass(exts.folder);
+            el.addClass(languages.folder);
             return span;
         }
 
@@ -171,10 +180,20 @@ define(function (require, exports, module) {
             if(!files[filename].includes('nocolor') && color){
                 el.addClass('colored');
             }
-        } else if (exts[ext]) {
+        } else if (languages[ext]) {
             el.removeClass('fa-solid fa-file');
-            el.addClass(exts[ext]);
-            if(!exts[ext].includes('nocolor') && color){
+            el.addClass(languages[ext]);
+            if(!languages[ext].includes('nocolor') && color){
+                el.addClass('colored');
+            }
+        } else{
+            let lang = LanguageManager.getLanguageForPath(entry.fullPath).getName().toLowerCase();
+            if(!languages[lang]){
+                return span;
+            }
+            el.removeClass('fa-solid fa-file');
+            el.addClass(languages[lang]);
+            if(!languages[lang].includes('nocolor') && color){
                 el.addClass('colored');
             }
         }

--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -3,7 +3,7 @@
         "name": "Text",
         "mode": ["null", "text/plain"]
     },
-    
+
     "groovy": {
         "name": "Groovy",
         "mode": "groovy",
@@ -11,7 +11,7 @@
         "blockComment": ["/*", "*/"],
         "lineComment": ["//"]
     },
-   
+
     "properties": {
         "name": "Properties",
         "mode": ["properties", "text/x-properties"],
@@ -47,14 +47,14 @@
         "fileExtensions": ["html", "htm", "shtm", "shtml", "xhtml", "cfm", "cfml", "cfc", "dhtml", "xht", "tpl", "twig", "kit", "jsp", "aspx", "ascx", "asp", "master", "cshtml", "vbhtml"],
         "blockComment": ["<!--", "-->"]
     },
-    
+
     "ejs": {
         "name": "EJS",
         "mode": ["htmlembedded", "application/x-ejs"],
         "fileExtensions": ["ejs", "dust"],
         "blockComment": ["<!--", "-->"]
     },
-    
+
     "erb_html": {
         "name": "Embedded Ruby",
         "mode": ["htmlembedded", "application/x-erb"],
@@ -66,6 +66,14 @@
         "name": "JavaScript",
         "mode": "javascript",
         "fileExtensions": ["js", "js.erb", "jsm", "_js"],
+        "blockComment": ["/*", "*/"],
+        "lineComment": ["//"]
+    },
+
+    "typescript": {
+        "name": "Typescript",
+        "mode": ["javascript", "application/typescript"],
+        "fileExtensions": ["ts", "d.ts"],
         "blockComment": ["/*", "*/"],
         "lineComment": ["//"]
     },
@@ -124,7 +132,7 @@
     "php": {
         "name": "PHP",
         "mode": "php",
-        "fileExtensions": ["php", "php3", "php4", "php5", "phtm", "phtml", "ctp"],
+        "fileExtensions": ["php", "php3", "php4", "php5", "phps", "phtm", "phtml", "ctp"],
         "blockComment": ["/*", "*/"],
         "lineComment": ["//", "#"]
     },
@@ -141,6 +149,22 @@
         "name": "C++",
         "mode": ["clike", "text/x-c++src"],
         "fileExtensions": ["cc", "cp", "cpp", "c++", "cxx", "hh", "hpp", "hxx", "h++", "ii", "ino"],
+        "blockComment": ["/*", "*/"],
+        "lineComment": ["//"]
+    },
+
+    "objectivec": {
+        "name": "Objective-C",
+        "mode": ["clike", "text/x-objectivec"],
+        "fileExtensions": ["m", "mm", "M"],
+        "blockComment": ["/*", "*/"],
+        "lineComment": ["//"]
+    },
+
+    "kotlin": {
+        "name": "Kotlin",
+        "mode": ["clike", "text/x-kotlin"],
+        "fileExtensions": ["kt", "kts", "ktm"],
         "blockComment": ["/*", "*/"],
         "lineComment": ["//"]
     },
@@ -164,7 +188,7 @@
     "scala": {
         "name": "Scala",
         "mode": ["clike", "text/x-scala"],
-        "fileExtensions": ["scala", "sbt"],
+        "fileExtensions": ["scala", "sbt", "sc"],
         "blockComment": ["/*", "*/"],
         "lineComment": ["//"]
     },
@@ -238,13 +262,14 @@
     "markdown": {
         "name": "Markdown",
         "mode": "markdown",
-        "fileExtensions": ["md", "markdown", "mdown", "mkdn"],
         "blockComment": ["<!--", "-->"]
     },
 
     "gfm": {
         "name": "Markdown (GitHub)",
-        "mode": "gfm"
+        "mode": "gfm",
+        "fileExtensions": ["md", "markdown", "mdown", "mkdn"],
+        "blockComment": ["<!--", "-->"]
     },
 
     "yaml": {
@@ -269,19 +294,19 @@
         "fileNames": [".bash_login", ".bash_logout", ".bash_profile", ".bashrc", ".profile"],
         "lineComment": ["#"]
     },
-  
+
     "image": {
         "name": "Image",
         "fileExtensions": ["gif", "png", "jpe", "jpeg", "jpg", "ico", "bmp", "webp"],
         "isBinary": true
     },
-    
+
     "audio": {
         "name": "Audio",
         "fileExtensions": ["mp3", "wav", "aif", "aiff", "ogg"],
         "isBinary": true
     },
-    
+
     "binary": {
         "name": "Other Binary",
         "fileExtensions": [
@@ -303,20 +328,26 @@
         "blockComment": ["{-", "-}"],
         "lineComment": ["--"]
     },
-    
+
     "turtle": {
         "name": "RDF Turtle",
         "mode": "turtle",
         "fileExtensions": ["ttl"],
         "lineComment": ["#"]
     },
-    
+
     "go": {
         "name": "Go",
         "mode": "go",
         "fileExtensions": ["go"],
         "blockComment": ["/*", "*/"],
         "lineComment": ["//"]
+    },
+
+    "swift": {
+        "name": "Swift",
+        "mode": "swift",
+        "fileExtensions": ["swift"]
     },
 
     "pug": {

--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -117,6 +117,11 @@ div.CodeMirror-cursors {
     z-index: 3;
 }
 
+.CodeMirror pre.CodeMirror-line,
+.CodeMirror pre.CodeMirror-line-like {
+    padding: 0 0; /* Horizontal padding of content */
+}
+
 .CodeMirror-lines {
     padding: @code-padding 0;
 


### PR DESCRIPTION
## Added more language support
* Support syntax highlighting for typescript, objective-c, kotlin, swift
* Added icons support for newly defined languages
* Made GitHub markdown the default markdown format instead of commonmark.

## selection fix
The selection dimensions was improper. See image below
### bug
![image](https://user-images.githubusercontent.com/5336369/177756763-b08087dc-0165-4453-a074-eb2aa293780a.png)
### fix
![image](https://user-images.githubusercontent.com/5336369/177756939-6337ab9c-4040-4b60-bb37-7c2df4bbd472.png)
