### PR TITLE
fix: test suits not working in deployed stages

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -16,9 +16,8 @@ jobs:
           npm run release:dev
           npm run test
           cp -r dist distToDeploy/
-          mkdir distToDeploy/testing/
-          cp -r dist distToDeploy/testing/src/
-          cp -r test distToDeploy/testing/test/
+          cp -r dist distToDeploy/src/
+          cp -r test distToDeploy/test/
         shell: bash
 
       - name: Deploy dist folder to Github Pages

--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ IDEs from this link before raising a pull request: https://www.sonarlint.org/
 
 ### Running tests in dev staging and prod stacks
 * To run tests against these stacks go to the following url: 
-* dev: https://dev.phcode.dev/testing/test/SpecRunner.html
-* staging: https://staging.phcode.dev/testing/test/SpecRunner.html
-* prod: https://phcode.dev/testing/test/SpecRunner.html
+* dev: https://dev.phcode.dev/test/SpecRunner.html
+* staging: https://staging.phcode.dev/test/SpecRunner.html
+* prod: https://phcode.dev/test/SpecRunner.html
 
 ## Browsing the virtual file system
 To view/edit the files in the browser virtual file system in Phoenix:

--- a/src/extensions/default/DebugCommands/main.js
+++ b/src/extensions/default/DebugCommands/main.js
@@ -94,7 +94,7 @@ define(function (require, exports, module) {
         let testBaseURL = "../test/SpecRunner.html";
         if(window.location.hostname !== 'localhost' && window.location.hostname !== '127.0.0.1'){
             // must be a deployed in phcode.dev/other sites. point to site test url
-            testBaseURL = "testing/test/SpecRunner.html";
+            testBaseURL = "test/SpecRunner.html";
         }
         if (_testWindow && !_testWindow.closed) {
             if (_testWindow.location.search !== queryString) {


### PR DESCRIPTION
The tests assumes that the path is `baseurl/src` and `test` . So a large number of tests are failing at this time. 
We do not have the necessary resources to do a refactor of large number of tests assets to its own folder at this time, so putting it to the required folders for now. 