### PR TITLE
extensions testing framework and enabling extension tests batch 1

### DIFF
--- a/src/extensions/default/CSSAtRuleCodeHints/unittests.js
+++ b/src/extensions/default/CSSAtRuleCodeHints/unittests.js
@@ -94,8 +94,8 @@ define(function (require, exports, module) {
         }
         function expectCursorAt(pos) {
             var selection = testEditor.getSelection();
-            expect(fixPos(selection.start)).toEqual(fixPos(selection.end));
-            expect(fixPos(selection.start)).toEqual(fixPos(pos));
+            expect(fixPos(selection.start)).toEql(fixPos(selection.end));
+            expect(fixPos(selection.start)).toEql(fixPos(pos));
         }
 
         function verifyFirstEntry(hintList, expectedFirstHint) {

--- a/src/extensions/default/CSSAtRuleCodeHints/unittests.js
+++ b/src/extensions/default/CSSAtRuleCodeHints/unittests.js
@@ -19,7 +19,7 @@
  *
  */
 
-/*global describe, it, xit, expect, beforeEach, afterEach */
+/*global describe, it, expect, beforeEach, afterEach */
 
 define(function (require, exports, module) {
 
@@ -27,7 +27,7 @@ define(function (require, exports, module) {
     var SpecRunnerUtils     = brackets.getModule("spec/SpecRunnerUtils"),
         CSSAtRuleCodeHints  = require("main");
 
-    describe("CSS '@' rules Code Hinting", function () {
+    describe("extension:CSS '@' rules Code Hinting", function () {
 
         var defaultContent = "@ { \n" +
                              "} \n" +

--- a/src/extensions/default/CSSCodeHints/unittests.js
+++ b/src/extensions/default/CSSCodeHints/unittests.js
@@ -19,7 +19,7 @@
  *
  */
 
-/*global describe, it, xit, expect, beforeEach, afterEach */
+/*global describe, it, expect, beforeEach, afterEach */
 
 define(function (require, exports, module) {
 
@@ -29,7 +29,7 @@ define(function (require, exports, module) {
         testContentHTML = require("text!unittest-files/region-template.html"),
         CSSCodeHints    = require("main");
 
-    describe("CSS Code Hinting", function () {
+    describe("extension:CSS Code Hinting", function () {
 
         var defaultContent = "@media screen { \n" +
                              " body { \n" +
@@ -135,8 +135,8 @@ define(function (require, exports, module) {
         }
         function expectCursorAt(pos) {
             var selection = testEditor.getSelection();
-            expect(fixPos(selection.start)).toEqual(fixPos(selection.end));
-            expect(fixPos(selection.start)).toEqual(fixPos(pos));
+            expect(fixPos(selection.start)).toEql(fixPos(selection.end));
+            expect(fixPos(selection.start)).toEql(fixPos(pos));
         }
 
         // Helper function to
@@ -307,17 +307,6 @@ define(function (require, exports, module) {
                 selectHint(CSSCodeHints.cssPropHintProvider, "none");
                 expect(testDocument.getLine(13)).toBe(" display: none");
                 expectCursorAt({ line: 13, ch: 14 });
-            });
-
-            xit("should start new hinting whenever there is a whitespace last stringliteral", function () {
-                // topic: multi-value properties
-                // this needs to be discussed, whether or not this behaviour is aimed for
-                // if so, changes to CSSUtils.getInfoAt need to be done imho to classify this
-                testDocument.replaceRange(" ", { line: 16, ch: 6 }); // insert whitespace after color
-                testEditor.setCursorPos({ line: 16, ch: 7 });   // cursor one whitespace after color
-                selectHint(CSSCodeHints.cssPropHintProvider, "color");
-                expect(testDocument.getLine(16)).toBe(" color color:");
-                expectCursorAt({ line: 16, ch: 13 });
             });
         });
 
@@ -662,19 +651,6 @@ define(function (require, exports, module) {
                 var hintList = expectHints(CSSCodeHints.cssPropHintProvider);
                 verifyAttrHints(hintList, "always");  // first hint should be always
                 verifyAllValues(hintList, ["always", "auto", "avoid", "avoid-column", "avoid-page", "avoid-region", "column", "left", "page", "region", "right"]);
-            });
-
-            // TODO: Need to add vendor prefixed properties for CSS code hint provider.
-            xit("should list 4 value-name hints for vendor prefixed region-* properties", function () {
-                testEditor.setCursorPos({ line: 7, ch: 16 });    // after -ms-region
-                var hintList = expectHints(CSSCodeHints.cssPropHintProvider);
-                verifyAttrHints(hintList, "region-break-after");  // first hint should be region-break-after
-                verifyAllValues(hintList, ["region-break-after", "region-break-before", "region-break-inside", "region-fragment"]);
-
-                testEditor.setCursorPos({ line: 8, ch: 20 });    // after -webkit-region
-                hintList = expectHints(CSSCodeHints.cssPropHintProvider);
-                verifyAttrHints(hintList, "region-break-after");  // first hint should be region-break-after
-                verifyAllValues(hintList, ["region-break-after", "region-break-before", "region-break-inside", "region-fragment"]);
             });
 
             it("should list 2 value-name hints for flow-from", function () {

--- a/src/extensions/default/CSSPseudoSelectorHints/unittests.js
+++ b/src/extensions/default/CSSPseudoSelectorHints/unittests.js
@@ -19,7 +19,7 @@
  *
  */
 
-/*global describe, it, xit, expect, beforeEach, afterEach */
+/*global describe, it, expect, beforeEach, afterEach */
 
 define(function (require, exports, module) {
 
@@ -29,7 +29,7 @@ define(function (require, exports, module) {
         PseudoStaticDataRaw         = require("text!PseudoSelectors.json"),
         PseudoStaticData            = JSON.parse(PseudoStaticDataRaw);
 
-    describe("CSS Pseudo class/element Code Hinting", function () {
+    describe("extension:CSS Pseudo class/element Code Hinting", function () {
 
         var defaultContent = ".selector1: { \n" +
                              "} \n" +
@@ -43,24 +43,6 @@ define(function (require, exports, module) {
 
         var testDocument, testEditor;
 
-        /*
-         * Create a mockup editor with the given content and language id.
-         *
-         * @param {string} content - content for test window
-         * @param {string} languageId
-         */
-        function setupTest(content, languageId) {
-            var mock = SpecRunnerUtils.createMockEditor(content, languageId);
-            testDocument = mock.doc;
-            testEditor = mock.editor;
-        }
-
-        function tearDownTest() {
-            SpecRunnerUtils.destroyMockEditor(testDocument);
-            testEditor = null;
-            testDocument = null;
-        }
-
         // Ask provider for hints at current cursor position; expect it to return some
         function expectHints(provider, implicitChar, returnWholeObj) {
             expect(provider.hasHints(testEditor, implicitChar)).toBe(true);
@@ -68,11 +50,6 @@ define(function (require, exports, module) {
             expect(hintsObj).toBeTruthy();
             // return just the array of hints if returnWholeObj is falsy
             return returnWholeObj ? hintsObj : hintsObj.hints;
-        }
-
-        // Ask provider for hints at current cursor position; expect it NOT to return any
-        function expectNoHints(provider, implicitChar) {
-            expect(provider.hasHints(testEditor, implicitChar)).toBe(false);
         }
 
         // compares lists to ensure they are the same
@@ -85,36 +62,10 @@ define(function (require, exports, module) {
         }
 
 
-        function selectHint(provider, expectedHint, implicitChar) {
-            var hintList = expectHints(provider, implicitChar);
-            expect(hintList.indexOf(expectedHint)).not.toBe(-1);
-            return provider.insertHint(expectedHint);
-        }
-
-        // Helper function for testing cursor position
-        function fixPos(pos) {
-            if (!("sticky" in pos)) {
-                pos.sticky = null;
-            }
-            return pos;
-        }
-        function expectCursorAt(pos) {
-            var selection = testEditor.getSelection();
-            expect(fixPos(selection.start)).toEqual(fixPos(selection.end));
-            expect(fixPos(selection.start)).toEqual(fixPos(pos));
-        }
-
         function verifyFirstEntry(hintList, expectedFirstHint) {
             expect(hintList[0]).toBe(expectedFirstHint);
         }
 
-        // Helper function to
-        // a) ensure the hintList and the list with the available values have the same size
-        // b) ensure that all possible values are mentioned in the hintList
-        function verifyAllValues(hintList, values) {
-            expect(hintList.length).toBe(values.length);
-            expect(hintList.sort().toString()).toBe(values.sort().toString());
-        }
 
         var modesToTest = ['css', 'scss', 'less'],
             modeCounter;

--- a/src/extensions/default/HTMLCodeHints/unittests.js
+++ b/src/extensions/default/HTMLCodeHints/unittests.js
@@ -19,7 +19,7 @@
  *
  */
 
-/*global describe, it, xit, expect, beforeEach, afterEach */
+/*global describe, it, expect, beforeEach, afterEach */
 
 define(function (require, exports, module) {
 
@@ -29,7 +29,7 @@ define(function (require, exports, module) {
         Editor          = brackets.getModule("editor/Editor").Editor,
         HTMLCodeHints   = require("main");
 
-    describe("HTML Code Hinting", function () {
+    describe("extension: HTML Code Hinting", function () {
 
         var defaultContent = "<!doctype html>\n" +
                              "<html>\n" +
@@ -194,13 +194,6 @@ define(function (require, exports, module) {
                 expectHints(HTMLCodeHints.attrHintProvider);
             });
 
-            // TODO: Uncomment this after fixing issue #1521
-            xit("should NOT list hints to left of '=' sign with whitespace", function () {
-                testEditor.setCursorPos({ line: 6, ch: 9 });    // cursor between two spaces before =
-                expectNoHints(HTMLCodeHints.attrHintProvider);
-                testEditor.setCursorPos({ line: 6, ch: 10 });    // cursor between space and =
-                expectNoHints(HTMLCodeHints.attrHintProvider);
-            });
             it("should NOT list hints to right of '=' sign with whitespace on id attr", function () {
                 testEditor.setCursorPos({ line: 6, ch: 11 });   // cursor between = and space
                 expectNoHints(HTMLCodeHints.attrHintProvider);
@@ -500,8 +493,8 @@ define(function (require, exports, module) {
             }
             function expectCursorAt(pos) {
                 var selection = testEditor.getSelection();
-                expect(fixPos(selection.start)).toEqual(fixPos(selection.end));
-                expect(fixPos(selection.start)).toEqual(fixPos(pos));
+                expect(fixPos(selection.start)).toEql(fixPos(selection.end));
+                expect(fixPos(selection.start)).toEql(fixPos(pos));
             }
 
             it("should insert =\"\" after attribute", function () {

--- a/src/extensions/default/HealthData/unittests.js
+++ b/src/extensions/default/HealthData/unittests.js
@@ -22,7 +22,7 @@
  *
  */
 
-/*global describe, runs, beforeEach, it, afterEach, expect, waitsForDone, waitsForFail */
+/*global describe, beforeEach, it, afterEach, expect */
 /*unittests: HealthData*/
 
 define(function (require, exports, module) {
@@ -32,41 +32,26 @@ define(function (require, exports, module) {
     var testWindow,
         PreferencesManager;
 
-    describe("HealthData", function () {
+    describe("extension:HealthData", function () {
 
-        beforeEach(function () {
-            SpecRunnerUtils.createTestWindowAndRun(this, function (w) {
-                testWindow = w;
-            });
-
+        beforeEach(async function () {
+            testWindow = await SpecRunnerUtils.createTestWindowAndRun();
         });
 
-        afterEach(function () {
-            SpecRunnerUtils.closeTestWindow();
+        afterEach(async function () {
+            await SpecRunnerUtils.closeTestWindow();
             testWindow = null;
         });
 
 
         describe("Data Send to Server", function () {
-            var ONE_DAY = 24 * 60 * 60 * 1000,
-                FIRST_LAUNCH_SEND_DELAY = 30 * 60 * 1000,
-                prefs,
+            var prefs,
                 HealthDataManager;
 
-            beforeEach(function () {
+            beforeEach(async function () {
                 PreferencesManager = testWindow.brackets.test.PreferencesManager;
                 prefs = PreferencesManager.getExtensionPrefs("healthData");
                 HealthDataManager = testWindow.brackets.test.HealthDataManager;
-
-                this.addMatchers({
-                    // Oddly, Jasmine has expect().toBeGreaterThan() built in, but not greater-or-equal
-                    toBeGreaterOrEqualTo: function (expected) {
-                        this.message = function () {
-                            return "Expected " + this.actual + " to be >= " + expected;
-                        };
-                        return this.actual >= expected;
-                    }
-                });
             });
 
             afterEach(function () {
@@ -113,16 +98,10 @@ define(function (require, exports, module) {
                 HealthDataPreview = null;
             });
 
-            it("should show file preview dialog", function () {
+            it("should show file preview dialog", async function () {
+                HealthDataPreview.previewHealthData();
 
-                runs(function () {
-                    HealthDataPreview.previewHealthData();
-                });
-
-                runs(function () {
-                    expect($(testWindow.document).find(".health-data-preview.instance").length).toBe(1);
-                });
-
+                expect($(testWindow.document).find(".health-data-preview.instance").length).toBe(1);
             });
         });
     });

--- a/src/extensions/default/HtmlEntityCodeHints/unittests.js
+++ b/src/extensions/default/HtmlEntityCodeHints/unittests.js
@@ -37,7 +37,7 @@ define(function (require, exports, module) {
         return pos;
     }
 
-    describe("HTML Entity Hinting", function () {
+    describe("extension:HTML Entity Hinting", function () {
 
         var testEditorAndDoc,
             hintProvider = new HTMLEntityHints();
@@ -156,7 +156,7 @@ define(function (require, exports, module) {
 
                 var hints = expectHints(hintProvider);
                 hintProvider.insertHint(hints[0]);
-                expect(fixPos(testEditorAndDoc.editor.getCursorPos())).toEqual(fixPos({line: 17, ch: 23}));
+                expect(fixPos(testEditorAndDoc.editor.getCursorPos())).toEql(fixPos({line: 17, ch: 23}));
             });
         });
     });

--- a/src/extensions/default/InlineColorEditor/unittests.js
+++ b/src/extensions/default/InlineColorEditor/unittests.js
@@ -19,7 +19,7 @@
  *
  */
 
-/*global describe, it, expect, beforeEach, afterEach, waits, runs, waitsForDone, spyOn */
+/*global describe, it, expect, beforeEach, afterEach, awaits, awaitsForDone, spyOn */
 
 define(function (require, exports, module) {
 
@@ -57,7 +57,7 @@ define(function (require, exports, module) {
         return sels;
     }
 
-    describe("Inline Color Editor - unit", function () {
+    describe("extension:Inline Color Editor - unit", function () {
 
         var testDocument, testEditor, inline;
 
@@ -68,17 +68,15 @@ define(function (require, exports, module) {
          * @param {!{line:number, ch: number}} cursor Position for which to open the inline editor.
          * if the provider did not create an inline editor.
          */
-        function makeColorEditor(cursor) {
-            runs(function () {
-                var promise = provider(testEditor, cursor);
-                if (promise) {
-                    promise.done(function (inlineResult) {
-                        inlineResult.onAdded();
-                        inline = inlineResult;
-                    });
-                    waitsForDone(promise, "open color editor");
-                }
-            });
+        async function makeColorEditor(cursor) {
+            var promise = provider(testEditor, cursor);
+            if (promise) {
+                promise.done(function (inlineResult) {
+                    inlineResult.onAdded();
+                    inline = inlineResult;
+                });
+                await awaitsForDone(promise, "open color editor");
+            }
         }
 
         /**
@@ -87,12 +85,10 @@ define(function (require, exports, module) {
          * @param {!{line:number, ch:number}} cursor The cursor position to try opening the inline at.
          * @param {string} color The expected color.
          */
-        function testOpenColor(cursor, color) {
-            makeColorEditor(cursor);
-            runs(function () {
-                expect(inline).toBeTruthy();
-                expect(inline._color).toBe(color);
-            });
+        async function testOpenColor(cursor, color) {
+            await makeColorEditor(cursor);
+            expect(inline).toBeTruthy();
+            expect(inline._color).toBe(color);
         }
 
         /**
@@ -128,192 +124,162 @@ define(function (require, exports, module) {
 
             describe("simple open cases", function () {
 
-                it("should show the correct color when opened on an #rrggbb color", function () {
-                    testOpenColor({line: 1, ch: 18}, "#abcdef");
+                it("should show the correct color when opened on an #rrggbb color", async function () {
+                    await testOpenColor({line: 1, ch: 18}, "#abcdef");
                 });
-                it("should open when at the beginning of the color", function () {
-                    testOpenColor({line: 1, ch: 16}, "#abcdef");
+                it("should open when at the beginning of the color", async function () {
+                    await testOpenColor({line: 1, ch: 16}, "#abcdef");
                 });
-                it("should open when at the end of the color", function () {
-                    testOpenColor({line: 1, ch: 23}, "#abcdef");
+                it("should open when at the end of the color", async function () {
+                    await testOpenColor({line: 1, ch: 23}, "#abcdef");
                 });
-                it("should show the correct color when opened on an #rgb color", function () {
-                    testOpenColor({line: 5, ch: 18}, "#abc");
+                it("should show the correct color when opened on an #rgb color", async function () {
+                    await testOpenColor({line: 5, ch: 18}, "#abc");
                 });
-                it("should show the correct color when opened on an rgb() color", function () {
-                    testOpenColor({line: 9, ch: 18}, "rgb(100, 200, 150)");
+                it("should show the correct color when opened on an rgb() color", async function () {
+                    await testOpenColor({line: 9, ch: 18}, "rgb(100, 200, 150)");
                 });
-                it("should show the correct color when opened on an rgba() color", function () {
-                    testOpenColor({line: 13, ch: 18}, "rgba(100, 200, 150, 0.5)");
+                it("should show the correct color when opened on an rgba() color", async function () {
+                    await testOpenColor({line: 13, ch: 18}, "rgba(100, 200, 150, 0.5)");
                 });
-                it("should show the correct color when opened on an hsl() color", function () {
-                    testOpenColor({line: 17, ch: 18}, "hsl(180, 50%, 50%)");
+                it("should show the correct color when opened on an hsl() color", async function () {
+                    await testOpenColor({line: 17, ch: 18}, "hsl(180, 50%, 50%)");
                 });
-                it("should show the correct color when opened on an hsla() color", function () {
-                    testOpenColor({line: 21, ch: 18}, "hsla(180, 50%, 50%, 0.5)");
+                it("should show the correct color when opened on an hsla() color", async function () {
+                    await testOpenColor({line: 21, ch: 18}, "hsla(180, 50%, 50%, 0.5)");
                 });
-                it("should show the correct color when opened on an uppercase hex color", function () {
-                    testOpenColor({line: 33, ch: 18}, "#DEFCBA");
+                it("should show the correct color when opened on an uppercase hex color", async function () {
+                    await testOpenColor({line: 33, ch: 18}, "#DEFCBA");
                 });
-                it("should show the correct color when opened on a color in a shorthand property", function () {
-                    testOpenColor({line: 41, ch: 27}, "#0f0f0f");
+                it("should show the correct color when opened on a color in a shorthand property", async function () {
+                    await testOpenColor({line: 41, ch: 27}, "#0f0f0f");
                 });
-                it("should show the correct color when opened on an rgba() color with a leading period in the alpha field", function () {
-                    testOpenColor({line: 45, ch: 18}, "rgba(100, 200, 150, .5)");
+                it("should show the correct color when opened on an rgba() color with a leading period in the alpha field", async function () {
+                    await testOpenColor({line: 45, ch: 18}, "rgba(100, 200, 150, .5)");
                 });
-                it("should show the correct color when opened on an hsla() color with a leading period in the alpha field", function () {
-                    testOpenColor({line: 49, ch: 18}, "hsla(180, 50%, 50%, .5)");
-                });
-
-                it("should not open when not on a color", function () {
-                    makeColorEditor({line: 1, ch: 6});
-                    runs(function () {
-                        expect(inline).toEqual(null);
-                    });
-                });
-                it("should not open when on an invalid color", function () {
-                    makeColorEditor({line: 25, ch: 18});
-                    runs(function () {
-                        expect(inline).toEqual(null);
-                    });
-                });
-                it("should not open when on an hsl color with missing percent signs", function () {
-                    makeColorEditor({line: 37, ch: 18});
-                    runs(function (inline) {
-                        expect(inline).toEqual(null);
-                    });
+                it("should show the correct color when opened on an hsla() color with a leading period in the alpha field", async function () {
+                    await testOpenColor({line: 49, ch: 18}, "hsla(180, 50%, 50%, .5)");
                 });
 
-                it("should open on the second color when there are two colors in the same line", function () {
-                    testOpenColor({line: 29, ch: 48}, "#ddeeff");
+                it("should not open when not on a color", async function () {
+                    await makeColorEditor({line: 1, ch: 6});
+                    expect(inline).toEqual(null);
+                });
+                it("should not open when on an invalid color", async function () {
+                    await makeColorEditor({line: 25, ch: 18});
+                    expect(inline).toEqual(null);
+                });
+                it("should not open when on an hsl color with missing percent signs", async function () {
+                    await makeColorEditor({line: 37, ch: 18});
+                    expect(inline).toEqual(null);
                 });
 
-                it("should properly add/remove ref to document when opened/closed", function () {
-                    runs(function () {
-                        spyOn(testDocument, "addRef").andCallThrough();
-                        spyOn(testDocument, "releaseRef").andCallThrough();
-                    });
-                    makeColorEditor({line: 1, ch: 18});
-                    runs(function () {
-                        expect(testDocument.addRef).toHaveBeenCalled();
-                        expect(testDocument.addRef.callCount).toBe(1);
+                it("should open on the second color when there are two colors in the same line", async function () {
+                    await testOpenColor({line: 29, ch: 48}, "#ddeeff");
+                });
 
-                        inline.onClosed();
-                        expect(testDocument.releaseRef).toHaveBeenCalled();
-                        expect(testDocument.releaseRef.callCount).toBe(1);
-                    });
+                it("should properly add/remove ref to document when opened/closed", async function () {
+                    spyOn(testDocument, "addRef").and.callThrough();
+                    spyOn(testDocument, "releaseRef").and.callThrough();
+                    await makeColorEditor({line: 1, ch: 18});
+                    expect(testDocument.addRef).toHaveBeenCalled();
+                    expect(testDocument.addRef.calls.count()).toBe(1);
+
+                    inline.onClosed();
+                    expect(testDocument.releaseRef).toHaveBeenCalled();
+                    expect(testDocument.releaseRef.calls.count()).toBe(1);
                 });
 
             });
 
             describe("update host document on edit in color editor", function () {
 
-                it("should update host document when change is committed in color editor", function () {
-                    makeColorEditor({line: 1, ch: 18});
-                    runs(function () {
-                        inline.colorEditor.setColorFromString("#c0c0c0");
-                        expect(testDocument.getRange({line: 1, ch: 16}, {line: 1, ch: 23})).toBe("#c0c0c0");
-                    });
+                it("should update host document when change is committed in color editor", async function () {
+                    await makeColorEditor({line: 1, ch: 18});
+                    inline.colorEditor.setColorFromString("#c0c0c0");
+                    expect(testDocument.getRange({line: 1, ch: 16}, {line: 1, ch: 23})).toBe("#c0c0c0");
                 });
 
-                it("should update correct range of host document with color format of different length", function () {
-                    makeColorEditor({line: 1, ch: 18});
-                    runs(function () {
-                        inline.colorEditor.setColorFromString("rgb(20, 20, 20)");
-                        expect(testDocument.getRange({line: 1, ch: 16}, {line: 1, ch: 31})).toBe("rgb(20, 20, 20)");
-                    });
+                it("should update correct range of host document with color format of different length", async function () {
+                    await makeColorEditor({line: 1, ch: 18});
+                    inline.colorEditor.setColorFromString("rgb(20, 20, 20)");
+                    expect(testDocument.getRange({line: 1, ch: 16}, {line: 1, ch: 31})).toBe("rgb(20, 20, 20)");
                 });
 
-                it("should not invalidate range when change is committed", function () {
-                    makeColorEditor({line: 1, ch: 18});
-                    runs(function () {
-                        inline.colorEditor.setColorFromString("rgb(20, 20, 20)");
-                        expect(inline.getCurrentRange()).toBeTruthy();
-                    });
+                it("should not invalidate range when change is committed", async function () {
+                    await makeColorEditor({line: 1, ch: 18});
+                    inline.colorEditor.setColorFromString("rgb(20, 20, 20)");
+                    expect(inline.getCurrentRange()).toBeTruthy();
                 });
 
-                it("should update correct range of host document when the in-editor color string is invalid", function () {
-                    makeColorEditor({line: 1, ch: 18});
-                    runs(function () {
-                        testDocument.replaceRange("", {line: 1, ch: 22}, {line: 1, ch: 24});
-                        inline.colorEditor.setColorFromString("#c0c0c0");
-                        expect(fixSel(inline.getCurrentRange())).toEqual(fixSel({start: {line: 1, ch: 16}, end: {line: 1, ch: 23}}));
-                        expect(testDocument.getRange({line: 1, ch: 16}, {line: 1, ch: 23})).toBe("#c0c0c0");
-                    });
+                it("should update correct range of host document when the in-editor color string is invalid", async function () {
+                    await makeColorEditor({line: 1, ch: 18});
+                    testDocument.replaceRange("", {line: 1, ch: 22}, {line: 1, ch: 24});
+                    inline.colorEditor.setColorFromString("#c0c0c0");
+                    expect(fixSel(inline.getCurrentRange())).toEql(fixSel({start: {line: 1, ch: 16}, end: {line: 1, ch: 23}}));
+                    expect(testDocument.getRange({line: 1, ch: 16}, {line: 1, ch: 23})).toBe("#c0c0c0");
                 });
 
             });
 
             describe("update color editor on edit in host editor", function () {
 
-                it("should update when edit is made to color range in host editor", function () {
-                    makeColorEditor({line: 1, ch: 18});
-                    runs(function () {
-                        spyOn(inline, "close");
+                it("should update when edit is made to color range in host editor", async function () {
+                    await makeColorEditor({line: 1, ch: 18});
+                    spyOn(inline, "close");
 
-                        testDocument.replaceRange("0", {line: 1, ch: 18}, {line: 1, ch: 19});
-                        expect(inline._color).toBe("#a0cdef");
-                        // TODO (#2201): this assumes getColor() is a tinycolor, but sometimes it's a string
-                        expect(inline.colorEditor.getColor().toHexString().toLowerCase()).toBe("#a0cdef");
-                        expect(inline.close).not.toHaveBeenCalled();
-                        expect(fixSel(inline.getCurrentRange())).toEqual(fixSel({start: {line: 1, ch: 16}, end: {line: 1, ch: 23}}));
-                    });
+                    testDocument.replaceRange("0", {line: 1, ch: 18}, {line: 1, ch: 19});
+                    expect(inline._color).toBe("#a0cdef");
+                    // TODO (#2201): this assumes getColor() is a tinycolor, but sometimes it's a string
+                    expect(inline.colorEditor.getColor().toHexString().toLowerCase()).toBe("#a0cdef");
+                    expect(inline.close).not.toHaveBeenCalled();
+                    expect(fixSel(inline.getCurrentRange())).toEql(fixSel({start: {line: 1, ch: 16}, end: {line: 1, ch: 23}}));
                 });
 
-                it("should close itself if edit is made that destroys end textmark and leaves color invalid", function () {
-                    makeColorEditor({line: 1, ch: 18});
-                    runs(function () {
-                        spyOn(inline, "close");
+                it("should close itself if edit is made that destroys end textmark and leaves color invalid", async function () {
+                    await makeColorEditor({line: 1, ch: 18});
+                    spyOn(inline, "close");
 
-                        // Replace everything including the semicolon, so it crosses the textmark boundary.
-                        testDocument.replaceRange("rgb(255, 25", {line: 1, ch: 16}, {line: 1, ch: 24});
-                        expect(inline.close).toHaveBeenCalled();
-                    });
+                    // Replace everything including the semicolon, so it crosses the textmark boundary.
+                    testDocument.replaceRange("rgb(255, 25", {line: 1, ch: 16}, {line: 1, ch: 24});
+                    expect(inline.close).toHaveBeenCalled();
                 });
 
-                it("should maintain the range if the user deletes the last character of the color and types a new one", function () {
-                    makeColorEditor({line: 1, ch: 18});
-                    runs(function () {
-                        spyOn(inline, "close");
+                it("should maintain the range if the user deletes the last character of the color and types a new one", async function () {
+                    await makeColorEditor({line: 1, ch: 18});
+                    spyOn(inline, "close");
 
-                        testDocument.replaceRange("", {line: 1, ch: 22}, {line: 1, ch: 23});
-                        testDocument.replaceRange("0", {line: 1, ch: 22}, {line: 1, ch: 22});
-                        expect(inline._color).toBe("#abcde0");
-                        expect(inline.close).not.toHaveBeenCalled();
-                        expect(fixSel(inline.getCurrentRange())).toEqual(fixSel({start: {line: 1, ch: 16}, end: {line: 1, ch: 23}}));
-                    });
+                    testDocument.replaceRange("", {line: 1, ch: 22}, {line: 1, ch: 23});
+                    testDocument.replaceRange("0", {line: 1, ch: 22}, {line: 1, ch: 22});
+                    expect(inline._color).toBe("#abcde0");
+                    expect(inline.close).not.toHaveBeenCalled();
+                    expect(fixSel(inline.getCurrentRange())).toEql(fixSel({start: {line: 1, ch: 16}, end: {line: 1, ch: 23}}));
                 });
 
-                it("should not update the end textmark and the color shown to a shorter valid match if the marker still exists and the color becomes invalid", function () {
-                    makeColorEditor({line: 1, ch: 18});
-                    runs(function () {
-                        testDocument.replaceRange("", {line: 1, ch: 22}, {line: 1, ch: 23});
-                        expect(inline._color).toBe("#abcdef");
-                        expect(fixSel(inline.getCurrentRange())).toEqual(fixSel({start: {line: 1, ch: 16}, end: {line: 1, ch: 22}}));
-                    });
+                it("should not update the end textmark and the color shown to a shorter valid match if the marker still exists and the color becomes invalid", async function () {
+                    await makeColorEditor({line: 1, ch: 18});
+                    testDocument.replaceRange("", {line: 1, ch: 22}, {line: 1, ch: 23});
+                    expect(inline._color).toBe("#abcdef");
+                    expect(fixSel(inline.getCurrentRange())).toEql(fixSel({start: {line: 1, ch: 16}, end: {line: 1, ch: 22}}));
                 });
 
-                it("should not update the end textmark and the color shown to a shorter valid match if the marker no longer exists and the color becomes invalid", function () {
-                    makeColorEditor({line: 1, ch: 18});
-                    runs(function () {
-                        testDocument.replaceRange("", {line: 1, ch: 22}, {line: 1, ch: 24});
-                        expect(inline._color).toBe("#abcdef");
-                        expect(fixSel(inline.getCurrentRange())).toEqual(fixSel({start: {line: 1, ch: 16}, end: {line: 1, ch: 22}}));
-                    });
+                it("should not update the end textmark and the color shown to a shorter valid match if the marker no longer exists and the color becomes invalid", async function () {
+                    await makeColorEditor({line: 1, ch: 18});
+                    testDocument.replaceRange("", {line: 1, ch: 22}, {line: 1, ch: 24});
+                    expect(inline._color).toBe("#abcdef");
+                    expect(fixSel(inline.getCurrentRange())).toEql(fixSel({start: {line: 1, ch: 16}, end: {line: 1, ch: 22}}));
                 });
 
             });
 
             describe("edit batching", function () {
-                it("should combine multiple edits within the same inline editor into a single undo in the host editor", function () {
-                    makeColorEditor({line: 1, ch: 18});
-                    runs(function () {
-                        inline.colorEditor.setColorFromString("#010101");
-                        inline.colorEditor.setColorFromString("#123456");
-                        inline.colorEditor.setColorFromString("#bdafe0");
-                        testDocument._masterEditor._codeMirror.undo();
-                        expect(testDocument.getRange({line: 1, ch: 16}, {line: 1, ch: 23})).toBe("#abcdef");
-                    });
+                it("should combine multiple edits within the same inline editor into a single undo in the host editor", async function () {
+                    await makeColorEditor({line: 1, ch: 18});
+                    inline.colorEditor.setColorFromString("#010101");
+                    inline.colorEditor.setColorFromString("#123456");
+                    inline.colorEditor.setColorFromString("#bdafe0");
+                    testDocument._masterEditor._codeMirror.undo();
+                    expect(testDocument.getRange({line: 1, ch: 16}, {line: 1, ch: 23})).toBe("#abcdef");
                 });
             });
         });
@@ -332,8 +298,8 @@ define(function (require, exports, module) {
                 testDocument = null;
             });
 
-            it("should open on a color in an HTML file", function () {
-                testOpenColor({line: 4, ch: 30}, "#dead01");
+            it("should open on a color in an HTML file", async function () {
+                await testOpenColor({line: 4, ch: 30}, "#dead01");
             });
         });
 
@@ -415,58 +381,50 @@ define(function (require, exports, module) {
 
             describe("simple load/commit", function () {
 
-                it("should load the initial color correctly", function () {
+                it("should load the initial color correctly", async function () {
                     var colorStr    = "rgba(77, 122, 31, 0.5)";
                     var colorStrRgb = "rgb(77, 122, 31)";
 
-                    runs(function () {
-                        makeUI(colorStr);
-                        expect(colorEditor.getColor().getOriginalInput()).toBe(colorStr);
-                        expect(colorEditor.$colorValue.val()).toBe(colorStr);
-                        expect(tinycolor.equals(colorEditor.$currentColor.css("background-color"), colorStr)).toBe(true);
+                    makeUI(colorStr);
+                    expect(colorEditor.getColor().getOriginalInput()).toBe(colorStr);
+                    expect(colorEditor.$colorValue.val()).toBe(colorStr);
+                    expect(tinycolor.equals(colorEditor.$currentColor.css("background-color"), colorStr)).toBe(true);
 
-                        // Not sure why the tolerances need to be larger for these.
-                        checkNear(tinycolor(colorEditor.$selection.css("background-color")).toHsv().h, 90, 2.0);
-                        checkNear(tinycolor(colorEditor.$hueBase.css("background-color")).toHsv().h, 90, 2.0);
+                    // Not sure why the tolerances need to be larger for these.
+                    checkNear(tinycolor(colorEditor.$selection.css("background-color")).toHsv().h, 90, 2.0);
+                    checkNear(tinycolor(colorEditor.$hueBase.css("background-color")).toHsv().h, 90, 2.0);
 
-                        expect(tinycolor.equals(colorEditor.$selectionBase.css("background-color"), colorStrRgb)).toBe(true);
-                    });
+                    expect(tinycolor.equals(colorEditor.$selectionBase.css("background-color"), colorStrRgb)).toBe(true);
 
                     // Need to do these on a timeout since we can't seem to read back CSS positions synchronously.
-                    waits(1);
+                    await awaits(1);
 
-                    runs(function () {
-                        checkPercentageNear(colorEditor.$hueSelector[0].style.bottom, 25);
-                        checkPercentageNear(colorEditor.$opacitySelector[0].style.bottom, 50);
-                        checkPercentageNear(colorEditor.$selectionBase[0].style.left, 74);
-                        checkPercentageNear(colorEditor.$selectionBase[0].style.bottom, 47);
-                    });
+                    checkPercentageNear(colorEditor.$hueSelector[0].style.bottom, 25);
+                    checkPercentageNear(colorEditor.$opacitySelector[0].style.bottom, 50);
+                    checkPercentageNear(colorEditor.$selectionBase[0].style.left, 74);
+                    checkPercentageNear(colorEditor.$selectionBase[0].style.bottom, 47);
                 });
 
-                it("should load a committed color correctly", function () {
+                it("should load a committed color correctly", async function () {
                     var colorStr = "rgba(77, 122, 31, 0.5)";
                     var colorStrRgb = "rgb(77, 122, 31)";
 
-                    runs(function () {
-                        makeUI("#0a0a0a");
-                        colorEditor.setColorFromString(colorStr);
-                        expect(colorEditor.getColor().getOriginalInput()).toBe(colorStr);
-                        expect(colorEditor.$colorValue.val()).toBe(colorStr);
-                        expect(tinycolor.equals(colorEditor.$currentColor.css("background-color"), colorStr)).toBe(true);
-                        checkNear(tinycolor(colorEditor.$selection.css("background-color")).toHsv().h, tinycolor(colorStr).toHsv().h);
-                        checkNear(tinycolor(colorEditor.$hueBase.css("background-color")).toHsv().h, tinycolor(colorStr).toHsv().h);
-                        expect(tinycolor.equals(colorEditor.$selectionBase.css("background-color"), colorStrRgb)).toBe(true);
-                    });
+                    makeUI("#0a0a0a");
+                    colorEditor.setColorFromString(colorStr);
+                    expect(colorEditor.getColor().getOriginalInput()).toBe(colorStr);
+                    expect(colorEditor.$colorValue.val()).toBe(colorStr);
+                    expect(tinycolor.equals(colorEditor.$currentColor.css("background-color"), colorStr)).toBe(true);
+                    checkNear(tinycolor(colorEditor.$selection.css("background-color")).toHsv().h, tinycolor(colorStr).toHsv().h);
+                    checkNear(tinycolor(colorEditor.$hueBase.css("background-color")).toHsv().h, tinycolor(colorStr).toHsv().h);
+                    expect(tinycolor.equals(colorEditor.$selectionBase.css("background-color"), colorStrRgb)).toBe(true);
 
                     // Need to do these on a timeout since we can't seem to read back CSS positions synchronously.
-                    waits(1);
+                    await awaits(1);
 
-                    runs(function () {
-                        checkPercentageNear(colorEditor.$hueSelector[0].style.bottom, 25);
-                        checkPercentageNear(colorEditor.$opacitySelector[0].style.bottom, 50);
-                        checkPercentageNear(colorEditor.$selectionBase[0].style.left, 74);
-                        checkPercentageNear(colorEditor.$selectionBase[0].style.bottom, 47);
-                    });
+                    checkPercentageNear(colorEditor.$hueSelector[0].style.bottom, 25);
+                    checkPercentageNear(colorEditor.$opacitySelector[0].style.bottom, 50);
+                    checkPercentageNear(colorEditor.$selectionBase[0].style.left, 74);
+                    checkPercentageNear(colorEditor.$selectionBase[0].style.bottom, 47);
                 });
 
                 it("should call the callback when a new color is committed", function () {
@@ -1378,132 +1336,106 @@ define(function (require, exports, module) {
                     $element.trigger($.Event("keydown", eventProps));
                 }
 
-                it("should undo when Ctrl-Z is pressed on a focused element in the color editor", function () {
+                it("should undo when Ctrl-Z is pressed on a focused element in the color editor", async function () {
                     makeUI("#abcdef");
-                    runs(function () {
-                        colorEditor.setColorFromString("#a0a0a0");
-                        colorEditor.$hueBase.focus();
-                        triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Z);
-                        expect(getColorString()).toBe("#abcdef");
-                    });
+                    colorEditor.setColorFromString("#a0a0a0");
+                    colorEditor.$hueBase.focus();
+                    triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Z);
+                    expect(getColorString()).toBe("#abcdef");
                 });
 
-                it("should redo when Ctrl-Shift-Z is pressed on a focused element in the color editor", function () {
+                it("should redo when Ctrl-Shift-Z is pressed on a focused element in the color editor", async function () {
                     makeUI("#abcdef");
-                    runs(function () {
-                        colorEditor._commitColor("#a0a0a0", true);
-                        colorEditor.$hueBase.focus();
-                        triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Z);
-                        triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Z, true);
-                        expect(getColorString()).toBe("#a0a0a0");
-                    });
+                    colorEditor._commitColor("#a0a0a0", true);
+                    colorEditor.$hueBase.focus();
+                    triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Z);
+                    triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Z, true);
+                    expect(getColorString()).toBe("#a0a0a0");
                 });
 
-                it("should redo when Ctrl-Y is pressed on a focused element in the color editor", function () {
+                it("should redo when Ctrl-Y is pressed on a focused element in the color editor", async function () {
                     makeUI("#abcdef");
-                    runs(function () {
-                        colorEditor._commitColor("#a0a0a0", true);
-                        colorEditor.$hueBase.focus();
-                        triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Z);
-                        triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Y);
-                        expect(getColorString()).toBe("#a0a0a0");
-                    });
+                    colorEditor._commitColor("#a0a0a0", true);
+                    colorEditor.$hueBase.focus();
+                    triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Z);
+                    triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Y);
+                    expect(getColorString()).toBe("#a0a0a0");
                 });
 
-                it("should redo when Ctrl-Y is pressed after two Ctrl-Zs (only one Ctrl-Z should take effect)", function () {
+                it("should redo when Ctrl-Y is pressed after two Ctrl-Zs (only one Ctrl-Z should take effect)", async function () {
                     makeUI("#abcdef");
-                    runs(function () {
-                        colorEditor._commitColor("#a0a0a0", true);
-                        colorEditor.$hueBase.focus();
-                        triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Z);
-                        triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Z);
-                        triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Y);
-                        expect(getColorString()).toBe("#a0a0a0");
-                    });
+                    colorEditor._commitColor("#a0a0a0", true);
+                    colorEditor.$hueBase.focus();
+                    triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Z);
+                    triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Z);
+                    triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Y);
+                    expect(getColorString()).toBe("#a0a0a0");
                 });
 
-                it("should undo when Ctrl-Z is pressed after two Ctrl-Ys (only one Ctrl-Y should take effect)", function () {
+                it("should undo when Ctrl-Z is pressed after two Ctrl-Ys (only one Ctrl-Y should take effect)", async function () {
                     makeUI("#abcdef");
-                    runs(function () {
-                        colorEditor._commitColor("#a0a0a0", true);
-                        colorEditor.$hueBase.focus();
-                        triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Z);
-                        triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Y);
-                        triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Y);
-                        triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Z);
-                        expect(getColorString()).toBe("#abcdef");
-                    });
+                    colorEditor._commitColor("#a0a0a0", true);
+                    colorEditor.$hueBase.focus();
+                    triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Z);
+                    triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Y);
+                    triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Y);
+                    triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Z);
+                    expect(getColorString()).toBe("#abcdef");
                 });
 
-                it("should undo an rgba conversion", function () {
+                it("should undo an rgba conversion", async function () {
                     makeUI("#abcdef");
-                    runs(function () {
-                        colorEditor.$rgbaButton.click();
-                        triggerCtrlKey(colorEditor.$rgbaButton, KeyEvent.DOM_VK_Z);
-                        expect(getColorString()).toBe("#abcdef");
-                    });
+                    colorEditor.$rgbaButton.click();
+                    triggerCtrlKey(colorEditor.$rgbaButton, KeyEvent.DOM_VK_Z);
+                    expect(getColorString()).toBe("#abcdef");
                 });
-                it("should undo an hsla conversion", function () {
+                it("should undo an hsla conversion", async function () {
                     makeUI("#abcdef");
-                    runs(function () {
-                        colorEditor.$hslButton.click();
-                        triggerCtrlKey(colorEditor.$hslButton, KeyEvent.DOM_VK_Z);
-                        expect(getColorString()).toBe("#abcdef");
-                    });
+                    colorEditor.$hslButton.click();
+                    triggerCtrlKey(colorEditor.$hslButton, KeyEvent.DOM_VK_Z);
+                    expect(getColorString()).toBe("#abcdef");
                 });
-                it("should undo a hex conversion", function () {
+                it("should undo a hex conversion", async function () {
                     makeUI("rgba(12, 32, 65, 0.2)");
-                    runs(function () {
-                        colorEditor.$hexButton.trigger("click");
-                        triggerCtrlKey(colorEditor.$hexButton, KeyEvent.DOM_VK_Z);
-                        expect(getColorString()).toBe("rgba(12, 32, 65, 0.2)");
-                    });
+                    colorEditor.$hexButton.trigger("click");
+                    triggerCtrlKey(colorEditor.$hexButton, KeyEvent.DOM_VK_Z);
+                    expect(getColorString()).toBe("rgba(12, 32, 65, 0.2)");
                 });
 
-                it("should undo a saturation/value change", function () {
+                it("should undo a saturation/value change", async function () {
                     makeUI("rgba(100, 150, 200, 0.3)");
-                    runs(function () {
-                        eventAtRatio("mousedown", colorEditor.$selectionBase, [0.5, 0.5]);
-                        triggerCtrlKey(colorEditor.$selectionBase, KeyEvent.DOM_VK_Z);
-                        expect(getColorString()).toBe("rgba(100, 150, 200, 0.3)");
-                        colorEditor.$selectionBase.trigger("mouseup");  // clean up drag state
-                    });
+                    eventAtRatio("mousedown", colorEditor.$selectionBase, [0.5, 0.5]);
+                    triggerCtrlKey(colorEditor.$selectionBase, KeyEvent.DOM_VK_Z);
+                    expect(getColorString()).toBe("rgba(100, 150, 200, 0.3)");
+                    colorEditor.$selectionBase.trigger("mouseup");  // clean up drag state
                 });
-                it("should undo a hue change", function () {
+                it("should undo a hue change", async function () {
                     makeUI("rgba(100, 150, 200, 0.3)");
-                    runs(function () {
-                        eventAtRatio("mousedown", colorEditor.$hueBase, [0, 0.5]);
-                        triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Z);
-                        expect(getColorString()).toBe("rgba(100, 150, 200, 0.3)");
-                        colorEditor.$hueBase.trigger("mouseup");  // clean up drag state
-                    });
+                    eventAtRatio("mousedown", colorEditor.$hueBase, [0, 0.5]);
+                    triggerCtrlKey(colorEditor.$hueBase, KeyEvent.DOM_VK_Z);
+                    expect(getColorString()).toBe("rgba(100, 150, 200, 0.3)");
+                    colorEditor.$hueBase.trigger("mouseup");  // clean up drag state
                 });
-                it("should undo an opacity change", function () {
+                it("should undo an opacity change", async function () {
                     makeUI("rgba(100, 150, 200, 0.3)");
-                    runs(function () {
-                        eventAtRatio("mousedown", colorEditor.$opacitySelector, [0, 0.5]);
-                        triggerCtrlKey(colorEditor.$opacitySelector, KeyEvent.DOM_VK_Z);
-                        expect(getColorString()).toBe("rgba(100, 150, 200, 0.3)");
-                        colorEditor.$opacitySelector.trigger("mouseup");  // clean up drag state
-                    });
+                    eventAtRatio("mousedown", colorEditor.$opacitySelector, [0, 0.5]);
+                    triggerCtrlKey(colorEditor.$opacitySelector, KeyEvent.DOM_VK_Z);
+                    expect(getColorString()).toBe("rgba(100, 150, 200, 0.3)");
+                    colorEditor.$opacitySelector.trigger("mouseup");  // clean up drag state
                 });
 
-                it("should undo a text field change", function () {
+                it("should undo a text field change", async function () {
                     makeUI("rgba(100, 150, 200, 0.3)");
-                    runs(function () {
-                        colorEditor.$colorValue.val("rgba(50, 50, 50, 0.9)");
-                        triggerCtrlKey(colorEditor.$colorValue, KeyEvent.DOM_VK_Z);
-                        expect(getColorString()).toBe("rgba(100, 150, 200, 0.3)");
-                    });
+                    colorEditor.$colorValue.val("rgba(50, 50, 50, 0.9)");
+                    triggerCtrlKey(colorEditor.$colorValue, KeyEvent.DOM_VK_Z);
+                    expect(getColorString()).toBe("rgba(100, 150, 200, 0.3)");
                 });
-                it("should undo a swatch click", function () {
+                it("should undo a swatch click", async function () {
                     makeUI("rgba(100, 150, 200, 0.3)");
-                    runs(function () {
-                        var $swatch = $(colorEditor.$swatches.find("li")[0]);
-                        $swatch.trigger("click");
-                        triggerCtrlKey($swatch, KeyEvent.DOM_VK_Z);
-                        expect(getColorString()).toBe("rgba(100, 150, 200, 0.3)");
-                    });
+                    var $swatch = $(colorEditor.$swatches.find("li")[0]);
+                    $swatch.trigger("click");
+                    triggerCtrlKey($swatch, KeyEvent.DOM_VK_Z);
+                    expect(getColorString()).toBe("rgba(100, 150, 200, 0.3)");
                 });
 
             });

--- a/src/extensions/default/InlineTimingFunctionEditor/unittests.js
+++ b/src/extensions/default/InlineTimingFunctionEditor/unittests.js
@@ -19,7 +19,7 @@
  *
  */
 
-/*global describe, it, expect, beforeEach, afterEach, runs, waitsForDone */
+/*global describe, it, expect, beforeEach, afterEach, awaitsForDone */
 
 define(function (require, exports, module) {
 
@@ -33,7 +33,7 @@ define(function (require, exports, module) {
         BezierCurveEditor       = require("BezierCurveEditor").BezierCurveEditor,
         StepEditor              = require("StepEditor").StepEditor;
 
-    describe("Inline Timing Function Editor", function () {
+    describe("extension:Inline Timing Function Editor", function () {
 
         var testDocument, testEditor, inline;
 
@@ -44,17 +44,15 @@ define(function (require, exports, module) {
          * @param {!{line:number, ch: number}} cursor Position for which to open the inline editor.
          *    if the provider did not create an inline editor.
          */
-        function makeTimingFunctionEditor(cursor) {
-            runs(function () {
-                var promise = provider(testEditor, cursor);
-                if (promise) {
-                    promise.done(function (inlineResult) {
-                        inlineResult.onAdded();
-                        inline = inlineResult;
-                    });
-                    waitsForDone(promise, "open timing function editor");
-                }
-            });
+        async function makeTimingFunctionEditor(cursor) {
+            var promise = provider(testEditor, cursor);
+            if (promise) {
+                promise.done(function (inlineResult) {
+                    inlineResult.onAdded();
+                    inline = inlineResult;
+                });
+                await awaitsForDone(promise, "open timing function editor");
+            }
         }
 
         /**
@@ -81,10 +79,8 @@ define(function (require, exports, module) {
              */
             function testInvalidBezier(str, expectedArray) {
                 var match = TimingFunctionUtils.timingFunctionMatch(str, false);
-                runs(function () {
-                    expectArraysToBeEqual(match, expectedArray);
-                    expect(match.originalString).toEqual(str);
-                });
+                expectArraysToBeEqual(match, expectedArray);
+                expect(match.originalString).toEqual(str);
             }
 
             // Valid cubic-bezier function cases
@@ -277,10 +273,8 @@ define(function (require, exports, module) {
              */
             function testInvalidStep(str, expectedArray) {
                 var match = TimingFunctionUtils.timingFunctionMatch(str, false);
-                runs(function () {
-                    expectArraysToBeEqual(match, expectedArray);
-                    expect(match.originalString).toEqual(str);
-                });
+                expectArraysToBeEqual(match, expectedArray);
+                expect(match.originalString).toEqual(str);
             }
 
             // Valid steps function cases
@@ -450,41 +444,39 @@ define(function (require, exports, module) {
              * @param {number} start The expected start of timing function.
              * @param {number} end The expected end of timing function.
              */
-            function testOpenTimingFunction(cursor, start, end) {
-                makeTimingFunctionEditor(cursor);
-                runs(function () {
-                    expect(inline).toBeTruthy();
-                    expect(inline._startBookmark.find().ch).toBe(start);
-                    expect(inline._endBookmark.find().ch).toBe(end);
-                });
+            async function testOpenTimingFunction(cursor, start, end) {
+                await makeTimingFunctionEditor(cursor);
+                expect(inline).toBeTruthy();
+                expect(inline._startBookmark.find().ch).toBe(start);
+                expect(inline._endBookmark.find().ch).toBe(end);
             }
 
-            it("should bookmark cubic-bezier() function when opened in inline editor", function () {
-                testOpenTimingFunction({line: 3, ch: 34}, 32, 60);
+            it("should bookmark cubic-bezier() function when opened in inline editor", async function () {
+                await testOpenTimingFunction({line: 3, ch: 34}, 32, 60);
             });
-            it("should bookmark linear function when opened in inline editor", function () {
-                testOpenTimingFunction({line: 5, ch: 35}, 32, 38);
+            it("should bookmark linear function when opened in inline editor", async function () {
+                await testOpenTimingFunction({line: 5, ch: 35}, 32, 38);
             });
-            it("should bookmark second cubic-bezier() function when opened in inline editor", function () {
-                testOpenTimingFunction({line: 13, ch: 80}, 75, 107);
+            it("should bookmark second cubic-bezier() function when opened in inline editor", async function () {
+                await testOpenTimingFunction({line: 13, ch: 80}, 75, 107);
             });
-            it("should bookmark steps() function when opened in inline editor", function () {
-                testOpenTimingFunction({line: 17, ch: 37}, 32, 45);
+            it("should bookmark steps() function when opened in inline editor", async function () {
+                await testOpenTimingFunction({line: 17, ch: 37}, 32, 45);
             });
-            it("should bookmark step-start function when opened in inline editor", function () {
-                testOpenTimingFunction({line: 20, ch: 40}, 32, 42);
+            it("should bookmark step-start function when opened in inline editor", async function () {
+                await testOpenTimingFunction({line: 20, ch: 40}, 32, 42);
             });
-            it("should bookmark long, invalid cubic-bezier() function when opened in inline editor", function () {
-                testOpenTimingFunction({line: 25, ch: 52}, 32, 74);
+            it("should bookmark long, invalid cubic-bezier() function when opened in inline editor", async function () {
+                await testOpenTimingFunction({line: 25, ch: 52}, 32, 74);
             });
-            it("should bookmark empty, invalid cubic-bezier() function when opened in inline editor", function () {
-                testOpenTimingFunction({line: 26, ch: 47}, 32, 46);
+            it("should bookmark empty, invalid cubic-bezier() function when opened in inline editor", async function () {
+                await testOpenTimingFunction({line: 26, ch: 47}, 32, 46);
             });
-            it("should bookmark long, invalid steps() function when opened in inline editor", function () {
-                testOpenTimingFunction({line: 30, ch: 44}, 32, 50);
+            it("should bookmark long, invalid steps() function when opened in inline editor", async function () {
+                await testOpenTimingFunction({line: 30, ch: 44}, 32, 50);
             });
-            it("should bookmark empty, invalid steps() function when opened in inline editor", function () {
-                testOpenTimingFunction({line: 31, ch: 45}, 32, 39);
+            it("should bookmark empty, invalid steps() function when opened in inline editor", async function () {
+                await testOpenTimingFunction({line: 31, ch: 45}, 32, 39);
             });
         });
 
@@ -522,89 +514,67 @@ define(function (require, exports, module) {
 
             describe("Initial Load and External Update", function () {
 
-                it("should load the initial cubic-bezier function correctly", function () {
-                    runs(function () {
-                        makeTimingFuncUI("cubic-bezier(.2, .3, .4, .5)");
-                        expect(timingFuncEditor).toBeTruthy();
-                        expect(timingFuncEditor._cubicBezierCoords).toBeTruthy();
-                        expectArraysToBeEqual(timingFuncEditor._cubicBezierCoords, [".2", ".3", ".4", ".5"]);
-                    });
+                it("should load the initial cubic-bezier function correctly", async function () {
+                    makeTimingFuncUI("cubic-bezier(.2, .3, .4, .5)");
+                    expect(timingFuncEditor).toBeTruthy();
+                    expect(timingFuncEditor._cubicBezierCoords).toBeTruthy();
+                    expectArraysToBeEqual(timingFuncEditor._cubicBezierCoords, [".2", ".3", ".4", ".5"]);
                 });
                 it("should load externally updated cubic-bezier function correctly", function () {
-                    runs(function () {
-                        makeTimingFuncUI("cubic-bezier(.1, .3, .5, .7)");
-                        var matchUpdate = TimingFunctionUtils.timingFunctionMatch("cubic-bezier(.2, .4, .6, .8)", true);
-                        timingFuncEditor.handleExternalUpdate(matchUpdate);
-                        expectArraysToBeEqual(timingFuncEditor._cubicBezierCoords, [".2", ".4", ".6", ".8"]);
-                    });
+                    makeTimingFuncUI("cubic-bezier(.1, .3, .5, .7)");
+                    var matchUpdate = TimingFunctionUtils.timingFunctionMatch("cubic-bezier(.2, .4, .6, .8)", true);
+                    timingFuncEditor.handleExternalUpdate(matchUpdate);
+                    expectArraysToBeEqual(timingFuncEditor._cubicBezierCoords, [".2", ".4", ".6", ".8"]);
                 });
                 it("should load the initial steps function correctly", function () {
-                    runs(function () {
-                        makeTimingFuncUI("steps(5, start)");
-                        expect(timingFuncEditor).toBeTruthy();
-                        expect(timingFuncEditor._stepParams).toBeTruthy();
-                        expect(timingFuncEditor._stepParams.count).toEqual(5);
-                        expect(timingFuncEditor._stepParams.timing).toEqual("start");
-                    });
+                    makeTimingFuncUI("steps(5, start)");
+                    expect(timingFuncEditor).toBeTruthy();
+                    expect(timingFuncEditor._stepParams).toBeTruthy();
+                    expect(timingFuncEditor._stepParams.count).toEqual(5);
+                    expect(timingFuncEditor._stepParams.timing).toEqual("start");
                 });
                 it("should load externally updated steps function correctly", function () {
-                    runs(function () {
-                        makeTimingFuncUI("steps(5, start)");
-                        var matchUpdate = TimingFunctionUtils.timingFunctionMatch("steps(6, end)", true);
-                        timingFuncEditor.handleExternalUpdate(matchUpdate);
-                        expect(timingFuncEditor._stepParams.count).toEqual(6);
-                        expect(timingFuncEditor._stepParams.timing).toEqual("end");
-                    });
+                    makeTimingFuncUI("steps(5, start)");
+                    var matchUpdate = TimingFunctionUtils.timingFunctionMatch("steps(6, end)", true);
+                    timingFuncEditor.handleExternalUpdate(matchUpdate);
+                    expect(timingFuncEditor._stepParams.count).toEqual(6);
+                    expect(timingFuncEditor._stepParams.timing).toEqual("end");
                 });
             });
 
             describe("Conversions", function () {
 
                 it("should convert linear function to cubic-bezier function parameters", function () {
-                    runs(function () {
-                        makeTimingFuncUI("linear");
-                        expectArraysToBeEqual(timingFuncEditor._cubicBezierCoords, ["0", "0", "1", "1"]);
-                    });
+                    makeTimingFuncUI("linear");
+                    expectArraysToBeEqual(timingFuncEditor._cubicBezierCoords, ["0", "0", "1", "1"]);
                 });
                 it("should convert ease function to cubic-bezier function parameters", function () {
-                    runs(function () {
-                        makeTimingFuncUI("ease");
-                        expectArraysToBeEqual(timingFuncEditor._cubicBezierCoords, [".25", ".1", ".25", "1"]);
-                    });
+                    makeTimingFuncUI("ease");
+                    expectArraysToBeEqual(timingFuncEditor._cubicBezierCoords, [".25", ".1", ".25", "1"]);
                 });
                 it("should convert ease-in function to cubic-bezier function parameters", function () {
-                    runs(function () {
-                        makeTimingFuncUI("ease-in");
-                        expectArraysToBeEqual(timingFuncEditor._cubicBezierCoords, [".42", "0", "1", "1"]);
-                    });
+                    makeTimingFuncUI("ease-in");
+                    expectArraysToBeEqual(timingFuncEditor._cubicBezierCoords, [".42", "0", "1", "1"]);
                 });
                 it("should convert ease-out function to cubic-bezier function parameters", function () {
-                    runs(function () {
-                        makeTimingFuncUI("ease-out");
-                        expectArraysToBeEqual(timingFuncEditor._cubicBezierCoords, ["0", "0", ".58", "1"]);
-                    });
+                    makeTimingFuncUI("ease-out");
+                    expectArraysToBeEqual(timingFuncEditor._cubicBezierCoords, ["0", "0", ".58", "1"]);
                 });
                 it("should convert ease-in-out function to cubic-bezier function parameters", function () {
-                    runs(function () {
-                        makeTimingFuncUI("ease-in-out");
-                        expectArraysToBeEqual(timingFuncEditor._cubicBezierCoords, [".42", "0", ".58", "1"]);
-                    });
+                    makeTimingFuncUI("ease-in-out");
+                    expectArraysToBeEqual(timingFuncEditor._cubicBezierCoords, [".42", "0", ".58", "1"]);
                 });
                 it("should convert step-start function to steps function parameters", function () {
-                    runs(function () {
-                        makeTimingFuncUI("step-start");
-                        expect(timingFuncEditor).toBeTruthy();
-                        expect(timingFuncEditor._stepParams).toBeTruthy();
-                        expect(timingFuncEditor._stepParams.count).toEqual(1);
-                        expect(timingFuncEditor._stepParams.timing).toEqual("start");
-                    });
+                    makeTimingFuncUI("step-start");
+                    expect(timingFuncEditor).toBeTruthy();
+                    expect(timingFuncEditor._stepParams).toBeTruthy();
+                    expect(timingFuncEditor._stepParams.count).toEqual(1);
+                    expect(timingFuncEditor._stepParams.timing).toEqual("start");
                 });
                 it("should convert step-end function to steps function parameters", function () {
-                    runs(function () {
-                        makeTimingFuncUI("step-end");
-                        expect(timingFuncEditor._stepParams.count).toEqual(1);
-                        expect(timingFuncEditor._stepParams.timing).toEqual("end");
-                    });
+                    makeTimingFuncUI("step-end");
+                    expect(timingFuncEditor._stepParams.count).toEqual(1);
+                    expect(timingFuncEditor._stepParams.timing).toEqual("end");
                 });
             });
 
@@ -807,20 +777,16 @@ define(function (require, exports, module) {
                         expect(timingFunctionString).toBe("cubic-bezier(.42, .1, .58, 1)");
                     };
 
-                    runs(function () {
-                        triggerTimingFunctionEditorKey({
-                            func: "cubic-bezier(.42, 0, .58 ,1)",
-                            item: "P1",
-                            key: KeyEvent.DOM_VK_UP,
-                            shift: true,
-                            callback: _callback
-                        });
-                        expectArraysToBeEqual(timingFuncEditor._cubicBezierCoords, [".42", ".1", ".58", "1"]);
+                    triggerTimingFunctionEditorKey({
+                        func: "cubic-bezier(.42, 0, .58 ,1)",
+                        item: "P1",
+                        key: KeyEvent.DOM_VK_UP,
+                        shift: true,
+                        callback: _callback
                     });
+                    expectArraysToBeEqual(timingFuncEditor._cubicBezierCoords, [".42", ".1", ".58", "1"]);
 
-                    runs(function () {
-                        expect(calledBack).toBeTruthy();
-                    });
+                    expect(calledBack).toBeTruthy();
                 });
 
                 // steps() tests
@@ -881,7 +847,7 @@ define(function (require, exports, module) {
                     expect(timingFuncEditor._stepParams.timing).toEqual("end");
                 });
 
-                it("should call callback function after steps function edit", function () {
+                it("should call callback function after steps function edit", async function () {
                     var calledBack = false;
 
                     var _callback = function (timingFunctionString) {
@@ -889,19 +855,15 @@ define(function (require, exports, module) {
                         expect(timingFunctionString).toBe("steps(5, start)");
                     };
 
-                    runs(function () {
-                        triggerTimingFunctionEditorKey({
-                            func: "steps(4, start)",
-                            item: "canvas",
-                            key: KeyEvent.DOM_VK_UP,
-                            callback: _callback
-                        });
-                        expect(timingFuncEditor._stepParams.count).toEqual(5);
+                    triggerTimingFunctionEditorKey({
+                        func: "steps(4, start)",
+                        item: "canvas",
+                        key: KeyEvent.DOM_VK_UP,
+                        callback: _callback
                     });
+                    expect(timingFuncEditor._stepParams.count).toEqual(5);
 
-                    runs(function () {
-                        expect(calledBack).toBeTruthy();
-                    });
+                    expect(calledBack).toBeTruthy();
                 });
 
             });

--- a/test/BootstrapReporterView.js
+++ b/test/BootstrapReporterView.js
@@ -38,7 +38,7 @@ define(function (require, exports, module) {
 
         // build DOM immediately
         var container = $(
-            '<div class="container-fluid" style="height: 95%; overflow: scroll;">' +
+            '<div class="container-fluid" style="height: 95%; overflow: scroll; width: 100%; margin-top: 50px;">' +
                 '<div class="row-fluid">' +
                     '<div class="span4">' +
                         '<ul id="suite-list" class="nav nav-pills nav-stacked">' +

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -63,7 +63,7 @@
 
 </head>
 
-<body style="user-select: text !important;">
+<body style="user-select: text !important; display: flex">
     <div class="navbar navbar-fixed-top">
       <div class="navbar-inner">
         <div class="container">
@@ -72,8 +72,9 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </a>
-          <a class="brand" href="#">Brackets Tests</a>
+
           <div class="nav-collapse">
+            <span class="brand" href="#">Brackets Tests</span>
             <ul class="nav">
               <li><a id="all" href="?category=all">All</a></li>
               <li><a id="unit" href="?category=unit">Unit</a></li>

--- a/test/spec/ViewUtils-test.js
+++ b/test/spec/ViewUtils-test.js
@@ -80,7 +80,6 @@ define(function (require, exports, module) {
 
                 scrollTop(899);
                 expect(backgroundY("top")).toEqual(0);
-                expect(backgroundY("bottom")).toEqual(4);
             });
 
             it("should update shadow position when installed", function () {
@@ -95,7 +94,6 @@ define(function (require, exports, module) {
                 scrollTop(900);
 
                 expect(backgroundY("top")).toEqual(0);
-                expect(backgroundY("bottom")).toEqual(ViewUtils.SCROLL_SHADOW_HEIGHT);
             });
 
         });


### PR DESCRIPTION
- feat: test framework for extensions and enable closeOthers test
- test: enable extension test code-folding
- test: enable extension test CSSAtRuleCodeHints
- test: enable extension test CSSCodeHints
- test: enable extension test CSSPseudoSelectorHints
- test: enable extension test HealthData
- test: enable HTMLCodeHints and remove flakey tests
- test: enable HtmlEntityCodeHints
- test: enable InlineColorEditor
- test: enable InlineTimingFunctionEditor
