### PR TITLE
ecape closes panels and shift escape brings them back

### DIFF
--- a/src/view/PanelView.js
+++ b/src/view/PanelView.js
@@ -55,10 +55,36 @@ define(function (require, exports, module) {
     };
 
     /**
+     * Registers a call back function that will be called just before panel is shown. The handler should return true
+     * if the panel can be shown, else return false and the panel will not be shown.
+     * @param {function|null} canShowHandlerFn function that should return true of false if the panel can be shown/not.
+     * or null to clear the handler.
+     * @return {boolean} true if visible, false if not
+     */
+    Panel.prototype.registerCanBeShownHandler = function (canShowHandlerFn) {
+        if(this.canBeShownHandler && canShowHandlerFn){
+            console.warn(`canBeShownHandler already registered for panel: ${this.panelID}. will be overwritten`);
+        }
+        this.canBeShownHandler = canShowHandlerFn;
+    };
+
+    /**
+     * Returns true if th panel can be shown, else false.
+     * @return {boolean}
+     */
+    Panel.prototype.canBeShown = function () {
+        let self = this;
+        if(self.canBeShownHandler){
+            return self.canBeShownHandler();
+        }
+        return true;
+    };
+
+    /**
      * Shows the panel
      */
     Panel.prototype.show = function () {
-        if(!this.isVisible()){
+        if(!this.isVisible() && this.canBeShown()){
             Resizer.show(this.$panel[0]);
             exports.trigger(EVENT_PANEL_SHOWN, this.panelID);
         }

--- a/src/view/PluginPanelView.js
+++ b/src/view/PluginPanelView.js
@@ -65,10 +65,36 @@ define(function (require, exports, module) {
     };
 
     /**
+     * Registers a call back function that will be called just before panel is shown. The handler should return true
+     * if the panel can be shown, else return false and the panel will not be shown.
+     * @param {function|null} canShowHandlerFn function that should return true of false if the panel can be shown/not.
+     * or null to clear the handler.
+     * @return {boolean} true if visible, false if not
+     */
+    Panel.prototype.registerCanBeShownHandler = function (canShowHandlerFn) {
+        if(this.canBeShownHandler && canShowHandlerFn){
+            console.warn(`canBeShownHandler already registered for panel: ${this.panelID}. will be overwritten`);
+        }
+        this.canBeShownHandler = canShowHandlerFn;
+    };
+
+    /**
+     * Returns true if th panel can be shown, else false.
+     * @return {boolean}
+     */
+    Panel.prototype.canBeShown = function () {
+        let self = this;
+        if(self.canBeShownHandler){
+            return self.canBeShownHandler();
+        }
+        return true;
+    };
+
+    /**
      * Shows the panel
      */
     Panel.prototype.show = function () {
-        if(!this.isVisible()){
+        if(!this.isVisible() && this.canBeShown()){
             this.$toolbarIcon.addClass("selected-button");
             this.$panel.show();
             exports.trigger(EVENT_PANEL_SHOWN, this.panelID);

--- a/src/view/WorkspaceManager.js
+++ b/src/view/WorkspaceManager.js
@@ -378,7 +378,23 @@ define(function (require, exports, module) {
         if(!focussedEditor){
             return;
         }
+        if (e.keyCode === KeyEvent.DOM_VK_ESCAPE && e.shiftKey) {
+            // shift + escape will close all open panels one by one
+            let allPanelsIDs = getAllPanelIDs();
+            for(let panelID of allPanelsIDs){
+                let panel = getPanelForID(panelID);
+                if(panel.getPanelType() === PanelView.PANEL_TYPE_BOTTOM_PANEL && panel.isVisible()){
+                    panel.hide();
+                    lastToggledBottomPanel = panel;
+                    break;
+                }
+            }
+            e.stopPropagation();
+            e.preventDefault();
+            return;
+        }
         if (e.keyCode === KeyEvent.DOM_VK_ESCAPE && lastToggledBottomPanel) {
+            // just escape will toggle last toggled panel
             let visibility = !lastToggledBottomPanel.isVisible();
             if(visibility){
                 lastToggledBottomPanel.show();

--- a/src/view/WorkspaceManager.js
+++ b/src/view/WorkspaceManager.js
@@ -89,7 +89,8 @@ define(function (require, exports, module) {
      */
     var windowResizing = false;
 
-    let lastToggledBottomPanel = null;
+    let lastHiddenBottomPanelStack = [],
+        lastShownBottomPanelStack = [];
 
 
     /**
@@ -308,11 +309,15 @@ define(function (require, exports, module) {
     EventDispatcher.makeEventDispatcher(exports);
 
     PanelView.on(PanelView.EVENT_PANEL_SHOWN, (event, panelID)=>{
-        lastToggledBottomPanel = getPanelForID(panelID);
+        lastHiddenBottomPanelStack = lastHiddenBottomPanelStack.filter(item => item !== panelID);
+        lastShownBottomPanelStack = lastShownBottomPanelStack.filter(item => item !== panelID);
+        lastShownBottomPanelStack.push(panelID);
         exports.trigger(EVENT_WORKSPACE_PANEL_SHOWN, panelID);
     });
     PanelView.on(PanelView.EVENT_PANEL_HIDDEN, (event, panelID)=>{
-        lastToggledBottomPanel = getPanelForID(panelID);
+        lastHiddenBottomPanelStack = lastHiddenBottomPanelStack.filter(item => item !== panelID);
+        lastHiddenBottomPanelStack.push(panelID);
+        lastShownBottomPanelStack = lastShownBottomPanelStack.filter(item => item !== panelID);
         exports.trigger(EVENT_WORKSPACE_PANEL_HIDDEN, panelID);
     });
 
@@ -372,58 +377,64 @@ define(function (require, exports, module) {
         return false;
     }
 
+    function _showLastHiddenPanelIfPossible() {
+        while(lastHiddenBottomPanelStack.length > 0){
+            let panelToShow = getPanelForID(lastHiddenBottomPanelStack.pop());
+            if(panelToShow.canBeShown()){
+                panelToShow.show();
+                return;
+            }
+        }
+    }
+
+    function _handleEscapeKey(e) {
+        let allPanelsIDs = getAllPanelIDs();
+        // first we see if there is any least recently shown panel
+        if(lastShownBottomPanelStack.length > 0){
+            let panelToHide = getPanelForID(lastShownBottomPanelStack.pop());
+            panelToHide.hide();
+            return;
+        }
+        // if not, see if there is any open panels that are not yet tracked in the least recently used stacks.
+        for(let panelID of allPanelsIDs){
+            let panel = getPanelForID(panelID);
+            if(panel.getPanelType() === PanelView.PANEL_TYPE_BOTTOM_PANEL && panel.isVisible()){
+                panel.hide();
+                lastHiddenBottomPanelStack.push(panelID);
+                return;
+            }
+        }
+        // no panels hidden, we will toggle the last hidden panel with succeeding escape key presses
+        _showLastHiddenPanelIfPossible();
+        e.stopPropagation();
+        e.preventDefault();
+    }
+
+    function _handleShiftEscapeKey(e) {
+        // show hidden panels one by one
+        _showLastHiddenPanelIfPossible();
+        e.stopPropagation();
+        e.preventDefault();
+    }
+
     // pressing escape when focused on editor will toggle the last opened bottom panel
     function _handleKeydown(e) {
         let focussedEditor = EditorManager.getFocusedEditor();
         if(!focussedEditor){
             return;
         }
-        if (e.keyCode === KeyEvent.DOM_VK_ESCAPE && e.shiftKey) {
-            // shift + escape will close all open panels one by one
-            let allPanelsIDs = getAllPanelIDs();
-            for(let panelID of allPanelsIDs){
-                let panel = getPanelForID(panelID);
-                if(panel.getPanelType() === PanelView.PANEL_TYPE_BOTTOM_PANEL && panel.isVisible()){
-                    panel.hide();
-                    lastToggledBottomPanel = panel;
-                    break;
-                }
-            }
-            e.stopPropagation();
-            e.preventDefault();
-            return;
-        }
-        if (e.keyCode === KeyEvent.DOM_VK_ESCAPE && lastToggledBottomPanel) {
-            // just escape will toggle last toggled panel
-            let visibility = !lastToggledBottomPanel.isVisible();
-            if(visibility){
-                lastToggledBottomPanel.show();
-            } else {
-                lastToggledBottomPanel.hide();
-            }
-            e.stopPropagation();
-            e.preventDefault();
+        if (e.keyCode === KeyEvent.DOM_VK_ESCAPE  && e.shiftKey) {
+            _handleShiftEscapeKey(e);
+        } else if (e.keyCode === KeyEvent.DOM_VK_ESCAPE) {
+            _handleEscapeKey(e);
         }
     }
     window.document.body.addEventListener("keydown", _handleKeydown, true);
-
-    /**
-     * Sets the panel to toggle when escape key is pressed in the editor area with the given panelID.
-     * This can be used to override the default panel keyboard toggle behavior, but use this sparsely.
-     * @param panelId
-     */
-    function setEscapeKeyTogglePanel(panelId) {
-        let panel = getPanelForID(panelId);
-        if(panel){
-            lastToggledBottomPanel = panel;
-        }
-    }
 
     // Define public API
     exports.createBottomPanel               = createBottomPanel;
     exports.createPluginPanel               = createPluginPanel;
     exports.isPanelVisible                  = isPanelVisible;
-    exports.setEscapeKeyTogglePanel         = setEscapeKeyTogglePanel;
     exports.recomputeLayout                 = recomputeLayout;
     exports.getAllPanelIDs                  = getAllPanelIDs;
     exports.getPanelForID                   = getPanelForID;

--- a/test/spec/MainViewManager-integ-test.js
+++ b/test/spec/MainViewManager-integ-test.js
@@ -832,13 +832,23 @@ define(function (require, exports, module) {
         describe("Bottom panel toggle with escape", function () {
             let panel1, panel2;
             beforeAll(function () {
+                let samplePanelTemplate2 = `<div id="some-panel2" class="bottom-panel vert-resizable top-resizer"></div>`;
+                panel2 = WorkspaceManager.createBottomPanel("panel2", _$(samplePanelTemplate2), 100);
+                panel2.hide();
+                expect(panel2.isVisible()).toBeFalse();
                 let samplePanelTemplate = `<div id="some-panel1" class="bottom-panel vert-resizable top-resizer"></div>`;
                 panel1 = WorkspaceManager.createBottomPanel("panel1", _$(samplePanelTemplate), 100);
-                panel1.show();
-                expect(panel1.isVisible()).toBeTrue();
+                panel1.hide();
+                expect(panel1.isVisible()).toBeFalse();
+            });
+
+            beforeEach(function () {
+               panel1.hide();
+               panel2.hide();
             });
 
             it("should bottom panel not toggle visibility on escape when there is no editor", async function () {
+                panel1.show();
                 SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_ESCAPE, "keydown", _$("#editor-holder")[0]);
                 expect(panel1.isVisible()).toBeTrue();
                 SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_ESCAPE, "keydown", _$("#editor-holder")[0]);
@@ -862,8 +872,6 @@ define(function (require, exports, module) {
             it("should bottom panel only toggle visibility of last shown panel", async function () {
                 panel1.show();
                 expect(panel1.isVisible()).toBeTrue();
-                let samplePanelTemplate = `<div id="some-panel2" class="bottom-panel vert-resizable top-resizer"></div>`;
-                panel2 = WorkspaceManager.createBottomPanel("panel1", _$(samplePanelTemplate), 100);
                 panel2.show();
                 expect(panel2.isVisible()).toBeTrue();
 
@@ -876,6 +884,36 @@ define(function (require, exports, module) {
                 expect(panel1.isVisible()).toBeTrue();
                 SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_ESCAPE, "keydown", _$("#editor-holder")[0]);
                 expect(panel2.isVisible()).toBeTrue();
+                expect(panel1.isVisible()).toBeTrue();
+            });
+
+            it("should bottom panel close one by one if shift-escape is pressed", async function () {
+                panel1.show();
+                expect(panel1.isVisible()).toBeTrue();
+                panel2.show();
+                expect(panel2.isVisible()).toBeTrue();
+
+                expect(MainViewManager.getActivePaneId()).toEqual("first-pane");
+                promise = MainViewManager._open(MainViewManager.FIRST_PANE, FileSystem.getFileForPath(testPath + "/test.js"));
+                await awaitsForDone(promise, "MainViewManager.doOpen");
+
+                SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_ESCAPE, "keydown", _$("#editor-holder")[0], {
+                    shiftKey: true
+                });
+                expect(panel2.isVisible()).toBeFalse();
+                expect(panel1.isVisible()).toBeTrue();
+                SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_ESCAPE, "keydown", _$("#editor-holder")[0], {
+                    shiftKey: true
+                });
+                expect(panel2.isVisible()).toBeFalse();
+                expect(panel1.isVisible()).toBeFalse();
+                SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_ESCAPE, "keydown", _$("#editor-holder")[0], {
+                    shiftKey: true
+                });
+                expect(panel2.isVisible()).toBeFalse();
+                expect(panel1.isVisible()).toBeFalse();
+                SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_ESCAPE, "keydown", _$("#editor-holder")[0]);
+                expect(panel2.isVisible()).toBeFalse();
                 expect(panel1.isVisible()).toBeTrue();
             });
         });


### PR DESCRIPTION
- feat: shift escape will now close all panels one by one in LRU order
- feat: add panel and plugin panel CanBeShownHandler
- integration tests