### PR TITLE
feat: find in files search term copy from preview editor

### DIFF
--- a/src/search/FindInFilesUI.js
+++ b/src/search/FindInFilesUI.js
@@ -166,8 +166,14 @@ define(function (require, exports, module) {
         }
 
         // Get initial query/replace text
-        var currentEditor = EditorManager.getActiveEditor(),
-            initialQuery = FindBar.getInitialQuery(_findBar, currentEditor);
+        let currentEditor = EditorManager.getActiveEditor();
+        let focussedEditor = EditorManager.getFocusedEditor();
+        if(!focussedEditor && _resultsView._$previewEditor && _resultsView._$previewEditor.editor
+            && _resultsView._$previewEditor.editor.hasFocus()){
+            currentEditor =  _resultsView._$previewEditor.editor;
+        }
+
+        let initialQuery = FindBar.getInitialQuery(_findBar, currentEditor);
 
         // Close our previous find bar, if any. (The open() of the new _findBar will
         // take care of closing any other find bar instances.)


### PR DESCRIPTION
When searching, we might want to copy text from the preview editor by double clicking and then triggering search. We will now auto fill the search term if there is a selection in preview editor and the preview editor is in focus.
![fif copy search term](https://user-images.githubusercontent.com/5336369/180603434-2deba087-843e-4eb9-a832-e102d803e000.gif)


