### PR TITLE
Fix: bugs, leaky event listener messages in console

### DIFF
--- a/docs/generatedApiDocs/utils/EventDispatcher-API.md
+++ b/docs/generatedApiDocs/utils/EventDispatcher-API.md
@@ -92,6 +92,20 @@ Type: [function][2]
 
 Returns **!{event: [string][3], ns: [string][3]}** Uses "" for missing parts.
 
+## setLeakThresholdForEvent
+
+By default, we consider any events having more than 15 listeners to be leaky. But sometimes there may be
+genuine use cases where an event can have a large number of listeners. For those events, it is recommended
+to increase the leaky warning threshold individually with this API.
+
+Type: [function][2]
+
+### Parameters
+
+*   `eventName` **[string][3]** 
+*   `threshold` **[number][4]** The new threshold to set. Will only be set if the new threshold is greater than
+    the current threshold.
+
 ## on
 
 Adds the given handler function to 'events': a space-separated list of one or more event names, each
@@ -149,7 +163,7 @@ Type: [function][2]
 
 ### Parameters
 
-*   `obj` **\![Object][4]** Object to add event-dispatch methods to
+*   `obj` **\![Object][5]** Object to add event-dispatch methods to
 
 ## triggerWithArray
 
@@ -160,9 +174,9 @@ Type: [function][2]
 
 ### Parameters
 
-*   `dispatcher` **\![Object][4]** 
+*   `dispatcher` **\![Object][5]** 
 *   `eventName` **[string][3]** 
-*   `argsArray` **\![Array][5]\<any>** 
+*   `argsArray` **\![Array][6]\<any>** 
 
 ## on_duringInit
 
@@ -179,7 +193,7 @@ Type: [function][2]
 
 ### Parameters
 
-*   `futureDispatcher` **\![Object][4]** 
+*   `futureDispatcher` **\![Object][5]** 
 *   `events` **[string][3]** 
 *   `fn`  
 
@@ -194,7 +208,7 @@ Type: [function][2]
 
 ### Parameters
 
-*   `obj` **\![Object][4]** Event dispatcher object
+*   `obj` **\![Object][5]** Event dispatcher object
 *   `eventName` **[string][3]** Name of deprecated event
 *   `insteadStr` **[string][3]?** Suggested thing to use instead
 
@@ -204,6 +218,8 @@ Type: [function][2]
 
 [3]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
-[4]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+[4]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[5]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[5]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+
+[6]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array

--- a/docs/generatedApiDocs/worker/WorkerComm-API.md
+++ b/docs/generatedApiDocs/worker/WorkerComm-API.md
@@ -57,6 +57,7 @@ importScripts(urlParams.get('eventDispatcherURL'));
 ## createWorkerComm
 
 Adds support for WorkerComm APIs to the provided web-Worker instance. Only available in the main thread.
+This API should be called immediately after creating the worker in main thread.
 
 Type: [function][1]
 
@@ -186,7 +187,7 @@ WorkerComm.createWorkerComm(_myWorker, exports);
 .....
 let ExtensionUtils = brackets.getModule("utils/ExtensionUtils");
 let addWorkerScriptPath = ExtensionUtils.getModulePath(module, "add_worker_Script.js")
-exports.loadScriptInWorker(addWorkerScriptPath);
+await exports.loadScriptInWorker(addWorkerScriptPath);
 ```
 
 ## EVENT_WORKER_COMM_INIT_COMPLETE

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -393,6 +393,11 @@ define(function (require, exports, module) {
             key = "-";
         }
 
+        // Check if it is a shift key only press
+        if (key === "" && origDescriptor.toLowerCase() === 'shift-shift') {
+            key = "Shift";
+        }
+
         // '+' char is valid if it's the only key. Keyboard shortcut strings should use
         // unicode characters (unescaped). Keyboard shortcut display strings may use
         // unicode escape sequences (e.g. \u20AC euro sign)

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -517,12 +517,12 @@ define(function (require, exports, module) {
      *      Pass Menus.DIVIDER for a menu divider, or just call addMenuDivider() instead.
      * @param {?string | Array.<{key: string, platform: string}>}  keyBindings - register one
      *      one or more key bindings to associate with the supplied command.
-     * @param {?string} position - constant defining the position of new MenuItem relative to
+     * @param {?string} [position] - constant defining the position of new MenuItem relative to
      *      other MenuItems. Values:
      *          - With no relativeID, use Menus.FIRST or LAST (default is LAST)
      *          - Relative to a command id, use BEFORE or AFTER (required)
      *          - Relative to a MenuSection, use FIRST_IN_SECTION or LAST_IN_SECTION (required)
-     * @param {?string} relativeID - command id OR one of the MenuSection.* constants. Required
+     * @param {?string} [relativeID] - command id OR one of the MenuSection.* constants. Required
      *      for all position constants except FIRST and LAST.
      *
      * @return {MenuItem} the newly created MenuItem

--- a/src/extensions/default/JavaScriptRefactoring/RefactoringUtils.js
+++ b/src/extensions/default/JavaScriptRefactoring/RefactoringUtils.js
@@ -471,7 +471,7 @@ define(function (require, exports, module) {
         try {
             ast = Acorn.parse(text);
         } catch(e) {
-            ast = Acorn.parse(text);
+            ast = AcornLoose.parse(text);
         }
         return ast;
     };

--- a/src/extensions/default/JavaScriptRefactoring/keyboard.json
+++ b/src/extensions/default/JavaScriptRefactoring/keyboard.json
@@ -6,14 +6,6 @@
         "Ctrl-Alt-M"
     ],
     "renameIdentifier": [
-        {
-            "key": "Ctrl-R", "platform": "mac"
-        },
-        {
-            "key": "Ctrl-R", "platform": "win"
-        },
-        {
-            "key": "Ctrl-R", "platform": "linux"
-        }
+        "Shift-F2"
     ]
 }

--- a/src/extensions/default/Phoenix-live-preview/main.js
+++ b/src/extensions/default/Phoenix-live-preview/main.js
@@ -304,7 +304,7 @@ define(function (require, exports, module) {
             _toggleVisibility();
         });
         let fileMenu = Menus.getMenu(Menus.AppMenuBar.FILE_MENU);
-        fileMenu.addMenuItem(Commands.FILE_LIVE_FILE_PREVIEW, "", Menus.BEFORE, Commands.FILE_PROJECT_SETTINGS);
+        fileMenu.addMenuItem(Commands.FILE_LIVE_FILE_PREVIEW, "");
         // We always show the live preview panel on startup if there is a preview file
         setTimeout(async ()=>{
             let previewDetails = await utils.getPreviewDetails();

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -88,6 +88,8 @@ define(function (require, exports, module) {
         EVENT_PROJECT_FILE_CHANGED = "projectFileChanged",
         EVENT_PROJECT_FILE_RENAMED = "projectFileRenamed";
 
+    EventDispatcher.setLeakThresholdForEvent(EVENT_PROJECT_OPEN, 25);
+
     /**
      * @private
      * Filename to use for project settings files.

--- a/src/view/MainViewManager.js
+++ b/src/view/MainViewManager.js
@@ -1714,6 +1714,8 @@ define(function (require, exports, module) {
 
 
     EventDispatcher.makeEventDispatcher(exports);
+    // currentFileChange has a large number of listeners. so we raise warning threshold to 25
+    EventDispatcher.setLeakThresholdForEvent("currentFileChange", 25);
 
     // Unit Test Helpers
     exports._initialize                   = _initialize;


### PR DESCRIPTION
## fixes
1. shift key presses was raising a no event listener attached message in console.
2. refactor-rename is not tied to shortcut `Shift-F2`
3. refactoring not working if there was invalid syntax
4. fix: leaky event listener messages in console
   - Added `setLeakThresholdForEvent` in event dispatcher and docs.

## setLeakThresholdForEvent
By default, we consider any events having more than 15 listeners to be leaky. But sometimes there may be
genuine use cases where an event can have a large number of listeners. For those events, it is recommended
to increase the leaky warning threshold individually with this API.
Type: [function][2]
### Parameters
*   `eventName` **[string][3]** 
*   `threshold` **[number][4]** The new threshold to set. Will only be set if the new threshold is greater than
    the current threshold.