### PR TITLE
fix: escape key handling and change refactor f2 shortcut

### DIFF
--- a/docs/generatedApiDocs/worker/IndexingWorker-API.md
+++ b/docs/generatedApiDocs/worker/IndexingWorker-API.md
@@ -35,6 +35,9 @@ Once the worker script is loaded with the above step, we can communicate with it
 reference within Phoenix or the global `WorkerComm` reference within the Indexing worker.
 All utility methods in module [worker/WorkerComm][1] can be used for worker communication.
 
+A global constant `Phoenix.baseURL` is available in the worker context to get the base url from which phoenix was
+launched.
+
 NB: You can use all util methods available in `worker/WorkerComm` as `IndexingWorker` internally uses `WorkerComm`
 to communicate with the underlying worker thread.
 

--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -322,7 +322,7 @@
         "Ctrl-Alt-N"
     ],
     "file.rename":  [
-        "F2"
+        "Shift-F2"
     ],
     "help.support": [
         "F1"

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -264,9 +264,14 @@ define(function (require, exports, module) {
                 self._handleSoftTabNavigation(1, "deleteH");
             },
             "Esc": function (instance) {
-                if (self.getSelections().length > 1) {
-                    CodeMirror.commands.singleSelection(instance);
-                } else {
+                if(!self.canConsumeEscapeKeyEvent()){
+                    return;
+                }
+                if (self.getSelections().length > 1) { // multi cursor
+                    self.clearSelection();
+                } else if(self.hasSelection()){
+                    self.clearSelection();
+                }else {
                     self.removeAllInlineWidgets();
                 }
             },
@@ -396,6 +401,16 @@ define(function (require, exports, module) {
         // and the document is already dirty and present in another working set, make sure
         // to add this documents to the new panes working set.
         this._doWorkingSetSync(null, this.document);
+    };
+
+    /**
+     * returns true if the editor can do something an escape key event. Eg. Disable multi cursor escape
+     */
+    Editor.prototype.canConsumeEscapeKeyEvent = function () {
+        let self = this;
+        return (self.getSelections().length > 1) // multi cursor should go away on escape
+            || (self.hasSelection()) // selection should go away on escape
+            || self.getFocusedInlineWidget(); // inline widget
     };
 
     Editor.prototype._doWorkingSetSync = function (event, doc) {
@@ -594,9 +609,9 @@ define(function (require, exports, module) {
 
     /**
      * Gets the current cursor position within the editor.
-     * @param {boolean} expandTabs  If true, return the actual visual column number instead of the character offset in
+     * @param {?boolean} [expandTabs]  If true, return the actual visual column number instead of the character offset in
      *      the "ch" property.
-     * @param {?string} which Optional string indicating which end of the
+     * @param {?string} [which] Optional string indicating which end of the
      *  selection to return. It may be "start", "end", "head" (the side of the
      *  selection that moves when you press shift+arrow), or "anchor" (the
      *  fixed side of the selection). Omitting the argument is the same as
@@ -927,6 +942,14 @@ define(function (require, exports, module) {
      */
     Editor.prototype.setSelection = function (start, end, center, centerOptions, origin) {
         this.setSelections([{start: start, end: end || start}], center, centerOptions, origin);
+    };
+
+    /**
+     * Clears any active selection if present.
+     */
+    Editor.prototype.clearSelection = function () {
+        let pos = this.getCursorPos();
+        this.setCursorPos(pos.line, pos.ch);
     };
 
     /**

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -263,7 +263,7 @@ define(function (require, exports, module) {
             "Delete": function (instance) {
                 self._handleSoftTabNavigation(1, "deleteH");
             },
-            "Esc": function (instance) {
+            "Esc": function (_instance) {
                 if(!self.canConsumeEscapeKeyEvent()){
                     return;
                 }

--- a/src/extensions/default/JavaScriptRefactoring/keyboard.json
+++ b/src/extensions/default/JavaScriptRefactoring/keyboard.json
@@ -6,6 +6,6 @@
         "Ctrl-Alt-M"
     ],
     "renameIdentifier": [
-        "Shift-F2"
+        "F2"
     ]
 }

--- a/src/view/WorkspaceManager.js
+++ b/src/view/WorkspaceManager.js
@@ -423,6 +423,9 @@ define(function (require, exports, module) {
             // handled by the inline widget itself first.
             return;
         }
+        if(focussedEditor.canConsumeEscapeKeyEvent()){
+            return;
+        }
         let handled = false;
         if (e.keyCode === KeyEvent.DOM_VK_ESCAPE  && e.shiftKey) {
             handled = _handleShiftEscapeKey();

--- a/test/spec/MainViewManager-integ-test.js
+++ b/test/spec/MainViewManager-integ-test.js
@@ -869,6 +869,22 @@ define(function (require, exports, module) {
                 expect(panel1.isVisible()).toBeTrue();
             });
 
+            it("should bottom panel not toggle visibility on escape if focused editor has selection", async function () {
+                panel1.show();
+                expect(panel1.isVisible()).toBeTrue();
+
+                expect(MainViewManager.getActivePaneId()).toEqual("first-pane");
+                promise = MainViewManager._open(MainViewManager.FIRST_PANE, FileSystem.getFileForPath(testPath + "/test.js"));
+                await awaitsForDone(promise, "MainViewManager.doOpen");
+                let editor = EditorManager.getActiveEditor();
+                editor.setSelection({line: 0, ch: 0}, {line: 0, ch: 1});
+                expect(editor.hasSelection()).toBeTrue();
+
+                SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_ESCAPE, "keydown", _$("#editor-holder")[0]);
+                expect(panel1.isVisible()).toBeTrue();
+                editor.clearSelection();
+            });
+
             it("should escape close bottom panel one by one", async function () {
                 panel1.show();
                 expect(panel1.isVisible()).toBeTrue();


### PR DESCRIPTION
* Escape key press will first ask the active editor if there is something it can do before we consume it for panel toggle.
* This will fix issues where editor need to dismiss multi cursor or selections on escape
* Editor will now clear all selections on escape key press too apart from multi cursor.
* Change of shourtcut keys.
   * Rename file shorcut is now `Shift-F2` instead of earlier `F2` . Eventually we will wire this to `F2` too if the files panel has focus.
   * Rename variable/refactor shortcut is now `F2` instead of earlier `Shift-F2`.

## Testing
* New integration tests
* current tests working as expected.