### PR TITLE
fix: code-inspection integration tests

### DIFF
--- a/src/preferences/PreferencesBase.js
+++ b/src/preferences/PreferencesBase.js
@@ -314,7 +314,7 @@ define(function (require, exports, module) {
         load: function () {
             var result = new $.Deferred();
             this.storage.load()
-                .then(function (data) {
+                .done(function (data) {
                     var oldKeys = this.getKeys();
                     this.data = data;
                     result.resolve();
@@ -1486,7 +1486,7 @@ define(function (require, exports, module) {
 
             if (!isPending) {
                 promise
-                    .then(function () {
+                    .done(function () {
                         this._scopes[id] = scope;
                         this._tryAddToScopeOrder(shadowEntry);
                     }.bind(this))
@@ -1788,7 +1788,7 @@ define(function (require, exports, module) {
                 }
                 return (new $.Deferred()).resolve().promise();
 
-            }).then(function () {
+            }).done(function () {
                 that._saveInProgress = false;
                 if (that._nextSaveDeferred) {
                     that.save();

--- a/test/spec/CodeInspection-integ-test.js
+++ b/test/spec/CodeInspection-integ-test.js
@@ -563,7 +563,7 @@ define(function (require, exports, module) {
                 asyncProvider.futures[noErrorsJS][1].resolve(failLintResult());
                 await awaits(100);
                 expect($("#problems-panel").is(":visible")).toBe(true);
-            }, 1000000);
+            });
 
             it("should ignore async results from previous run in same file - finishing reverse order", async function () {
                 CodeInspection.toggleEnabled(false);

--- a/test/spec/CodeInspection-integ-test.js
+++ b/test/spec/CodeInspection-integ-test.js
@@ -556,12 +556,14 @@ define(function (require, exports, module) {
 
                 // Finish old (stale) linting session - verify results not shown
                 asyncProvider.futures[noErrorsJS][0].resolve(failLintResult());
+                await awaits(100);
                 expect($("#problems-panel").is(":visible")).toBe(false);
 
                 // Finish new (current) linting session - verify results are shown
                 asyncProvider.futures[noErrorsJS][1].resolve(failLintResult());
+                await awaits(100);
                 expect($("#problems-panel").is(":visible")).toBe(true);
-            });
+            }, 1000000);
 
             it("should ignore async results from previous run in same file - finishing reverse order", async function () {
                 CodeInspection.toggleEnabled(false);
@@ -583,10 +585,12 @@ define(function (require, exports, module) {
 
                 // Finish new (current) linting session - verify results are shown
                 asyncProvider.futures[noErrorsJS][1].resolve(failLintResult());
+                await awaits(100);
                 expect($("#problems-panel").is(":visible")).toBe(true);
 
                 // Finish old (stale) linting session - verify results don't replace current results
                 asyncProvider.futures[noErrorsJS][0].resolve(successfulLintResult());
+                await awaits(100);
                 expect($("#problems-panel").is(":visible")).toBe(true);
             });
 


### PR DESCRIPTION
* fix code inspection tests, the tests was failing as we moved to js promise with jquery deffered compatability instead of jquery deferred.
* Fix preferences base that was using deferred.then wrongly instead of deferred.done