### PR TITLE
feat: quick edit and quick docs workflow change

### DIFF
--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -304,7 +304,7 @@
         "Ctrl-E"
     ],
     "navigate.toggleQuickDocs":  [
-        "Ctrl-K"
+        "Ctrl-Shift-E"
     ],
     "navigate.previousMatch":  [
         {

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -414,12 +414,24 @@ define(function (require, exports, module) {
     };
 
     /**
+     * Gets the inline widgets below the current cursor position or null.
+     * @return {boolean}
+     */
+    Editor.prototype.getInlineWidgetsBelowCursor = function () {
+        let self = this;
+        let cursor = self.getCursorPos();
+        let line = cursor.line;
+        return  self.getAllInlineWidgetsForLine(line);
+    };
+
+    /**
      * returns true if the editor can do something an escape key event. Eg. Disable multi cursor escape
      */
     Editor.prototype.canConsumeEscapeKeyEvent = function () {
         let self = this;
         return (self.getSelections().length > 1) // multi cursor should go away on escape
             || (self.hasSelection()) // selection should go away on escape
+            || self.getInlineWidgetsBelowCursor() // inline widget is below cursor
             || self.getFocusedInlineWidget(); // inline widget
     };
 
@@ -1172,6 +1184,13 @@ define(function (require, exports, module) {
      * @param {number} lineNum The line number to modify
      */
     Editor.prototype.removeAllInlineWidgetsForLine = InlineWidgetHelper.removeAllInlineWidgetsForLine;
+
+    /**
+     * ****** Update actual public API doc in Editor.js *****
+     * Gets all inline widgets for a given line
+     * @param {number} lineNum The line number to modify
+     */
+    Editor.prototype.getAllInlineWidgetsForLine = InlineWidgetHelper.getAllInlineWidgetsForLine;
 
     /**
      * Returns a list of all inline widgets currently open in this editor. Each entry contains the

--- a/src/editor/EditorHelper/InlineWidgetHelper.js
+++ b/src/editor/EditorHelper/InlineWidgetHelper.js
@@ -186,6 +186,19 @@ define(function (require, exports, module) {
     }
 
     /**
+     * ****** Update actual public API doc in Editor.js *****
+     * Gets all inline widgets for a given line
+     * @param {number} lineNum The line number to modify
+     */
+    function getAllInlineWidgetsForLine(lineNum) {
+        // eslint-disable-next-line no-invalid-this
+        let self = this;
+        let lineInfo = self._codeMirror.lineInfo(lineNum),
+            widgetInfos = (lineInfo && lineInfo.widgets) ? [].concat(lineInfo.widgets) : null;
+        return widgetInfos;
+    }
+
+    /**
      * Cleans up the given inline widget from our internal list of widgets. It's okay
      * to call self multiple times for the same widget--it will just do nothing if
      * the widget has already been removed.
@@ -340,6 +353,7 @@ define(function (require, exports, module) {
     exports.removeAllInlineWidgets = removeAllInlineWidgets;
     exports.removeInlineWidget = removeInlineWidget;
     exports.removeAllInlineWidgetsForLine = removeAllInlineWidgetsForLine;
+    exports.getAllInlineWidgetsForLine = getAllInlineWidgetsForLine;
     exports.getInlineWidgets = getInlineWidgets;
     exports.getFocusedInlineWidget = getFocusedInlineWidget;
     exports.setInlineWidgetHeight = setInlineWidgetHeight;

--- a/src/view/WorkspaceManager.js
+++ b/src/view/WorkspaceManager.js
@@ -38,7 +38,7 @@ define(function (require, exports, module) {
         Resizer                 = require("utils/Resizer"),
         PluginPanelView         = require("view/PluginPanelView"),
         PanelView               = require("view/PanelView"),
-        EditorManager       = require("editor/EditorManager"),
+        EditorManager           = require("editor/EditorManager"),
         KeyEvent                = require("utils/KeyEvent");
 
     //constants
@@ -416,6 +416,9 @@ define(function (require, exports, module) {
 
     // pressing escape when focused on editor will toggle the last opened bottom panel
     function _handleKeydown(e) {
+        if(e.keyCode !== KeyEvent.DOM_VK_ESCAPE){
+            return;
+        }
         let focussedEditor = EditorManager.getFocusedEditor();
         if(!focussedEditor || EditorManager.getFocusedInlineEditor()){
             // if there is no editor in focus, we do no panel toggling
@@ -426,17 +429,15 @@ define(function (require, exports, module) {
         if(focussedEditor.canConsumeEscapeKeyEvent()){
             return;
         }
-        let handled = false;
+
         if (e.keyCode === KeyEvent.DOM_VK_ESCAPE  && e.shiftKey) {
-            handled = _handleShiftEscapeKey();
+            _handleShiftEscapeKey();
         } else if (e.keyCode === KeyEvent.DOM_VK_ESCAPE) {
-            handled = _handleEscapeKey();
+            _handleEscapeKey();
         }
 
-        if(handled){
-            e.stopPropagation();
-            e.preventDefault();
-        }
+        e.stopPropagation();
+        e.preventDefault();
     }
     window.document.body.addEventListener("keydown", _handleKeydown, true);
 


### PR DESCRIPTION
* change quick docs shortcut to `ctrl-shift-e` instead of `ctrl-k` to closely match quick edit shortcut- `ctrl-e`. This is so that user can do minimal hand movements between quick edit and quick docs.