### PR TITLE
editor error, warn,info markers and wire it to lint results

### DIFF
--- a/src/language/CodeInspection.js
+++ b/src/language/CodeInspection.js
@@ -351,6 +351,29 @@ define(function (require, exports, module) {
         StatusBar.updateIndicator(INDICATOR_ID, true, "inspection-errors", tooltip);
     }
 
+    function _getCSSClass(error){
+        switch (error.type) {
+        case Type.ERROR: return "editor-text-fragment-error";
+        case Type.WARNING: return "editor-text-fragment-warn";
+        case Type.META: return "editor-text-fragment-info";
+        }
+    }
+
+    function _updateEditorMarks(resultProviderEntries) {
+        let editor = EditorManager.getCurrentFullEditor();
+        if(editor && resultProviderEntries && resultProviderEntries.length){
+            for(let resultProvider of resultProviderEntries){
+                let errors = resultProvider.result.errors;
+                for(let error of errors){
+                    // error.message on hover
+                    editor.markToken(error.pos, {
+                        className: _getCSSClass(error)
+                    });
+                }
+            }
+        }
+    }
+
     /**
      * Run inspector applicable to current document. Updates status bar indicator and refreshes error list in
      * bottom panel. Does not run if inspection is disabled or if a providerName is given and does not
@@ -381,6 +404,7 @@ define(function (require, exports, module) {
 
             // run all the providers registered for this file type
             (_currentPromise = inspectFile(currentDoc.file, providerList)).then(function (results) {
+                _updateEditorMarks(results);
                 // check if promise has not changed while inspectFile was running
                 if (this !== _currentPromise) {
                     return;

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -73,28 +73,28 @@ html, body {
     text-decoration-style: wavy;
     text-decoration-line: underline;
     text-decoration-color: @error-underline-text;
-    text-decoration-thickness: auto;
+    text-decoration-thickness: 1px;
 }
 
 .editor-text-fragment-warn{
     text-decoration-style: wavy;
     text-decoration-line: underline;
     text-decoration-color: @warn-underline-text;
-    text-decoration-thickness: auto;
+    text-decoration-thickness: 1px;
 }
 
 .editor-text-fragment-info{
     text-decoration-style: dashed;
     text-decoration-line: underline;
     text-decoration-color: @info-underline-text;
-    text-decoration-thickness: auto;
+    text-decoration-thickness: 1px;
 }
 
 .editor-text-fragment-spell-error{
     text-decoration-style: wavy;
     text-decoration-line: underline;
     text-decoration-color: @spell-underline-text;
-    text-decoration-thickness: auto;
+    text-decoration-thickness: 1px;
 }
 
 .hidden-element{

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -69,6 +69,34 @@ html, body {
     }
 }
 
+.editor-text-fragment-error{
+    text-decoration-style: wavy;
+    text-decoration-line: underline;
+    text-decoration-color: @error-underline-text;
+    text-decoration-thickness: auto;
+}
+
+.editor-text-fragment-warn{
+    text-decoration-style: wavy;
+    text-decoration-line: underline;
+    text-decoration-color: @warn-underline-text;
+    text-decoration-thickness: auto;
+}
+
+.editor-text-fragment-info{
+    text-decoration-style: dashed;
+    text-decoration-line: underline;
+    text-decoration-color: @info-underline-text;
+    text-decoration-thickness: auto;
+}
+
+.editor-text-fragment-spell-error{
+    text-decoration-style: wavy;
+    text-decoration-line: underline;
+    text-decoration-color: @spell-underline-text;
+    text-decoration-thickness: auto;
+}
+
 .hidden-element{
     display: none !important;
 }

--- a/src/styles/brackets_core_ui_variables.less
+++ b/src/styles/brackets_core_ui_variables.less
@@ -177,6 +177,10 @@
 @dark-bc-text-quiet:                 #9a9a9a;
 @dark-bc-text-thin:                  #fff;
 @dark-bc-text-thin-quiet:            #bbb;
+@error-underline-text:               #f53838;
+@warn-underline-text:                #f5b938;
+@info-underline-text:                #1473e6;
+@spell-underline-text:               #5bf538;
 
 // Panel
 @dark-bc-panel-bg:                   #2c2c2c;


### PR DESCRIPTION
- feat: editor error, warn,info markers and wire it to lint results
- fix: recompute error markers on file save
- test: editor marking API unit tests
- test: error priority and code inspection integration tests

![image](https://user-images.githubusercontent.com/5336369/184379797-0de10d16-a0a1-4270-bee3-80a10d2c14f7.png)

![image](https://user-images.githubusercontent.com/5336369/184379870-61297009-939c-4a38-a685-a3589bebb503.png)
