### PR TITLE
editor gutter markers for error/warn/info line

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -112,6 +112,8 @@ define(function (require, exports, module) {
         INPUT_STYLE         = EditorPreferences.INPUT_STYLE;
 
     const LINE_NUMBER_GUTTER = EditorPreferences.LINE_NUMBER_GUTTER,
+        DEBUG_INFO_GUTTER    = EditorPreferences.DEBUG_INFO_GUTTER,
+        DEBUG_INFO_GUTTER_PRIORITY      = EditorPreferences.DEBUG_INFO_GUTTER_PRIORITY,
         LINE_NUMBER_GUTTER_PRIORITY     = EditorPreferences.LINE_NUMBER_GUTTER_PRIORITY,
         CODE_FOLDING_GUTTER_PRIORITY    = EditorPreferences.CODE_FOLDING_GUTTER_PRIORITY;
 
@@ -1032,6 +1034,20 @@ define(function (require, exports, module) {
     };
 
     /**
+     * Use This if you are making large number of editor changes in a single workflow to improve performance.
+     * The editor internally buffers changes and only updates its DOM structure after it has finished performing
+     * some operation. If you need to perform a lot of operations on a CodeMirror instance, you can call this method
+     * with a function argument. It will call the function, buffering up all changes, and only doing the expensive
+     * update after the function returns. This can be a lot faster. The return value from this method will be the
+     * return value of your function.
+     * @param execFn The function that will be called to make all editor changes.
+     * @return {*}
+     */
+    Editor.prototype.operation = function (execFn) {
+        return this._codeMirror.operation(execFn);
+    };
+
+    /**
      * Can be used to mark a range of text with a specific CSS class name. cursorFrom and cursorTo should be {line, ch}
      * objects. The options parameter is optional.
      *
@@ -1910,6 +1926,10 @@ define(function (require, exports, module) {
             registeredGutters.push({name: LINE_NUMBER_GUTTER, priority: LINE_NUMBER_GUTTER_PRIORITY});
         }
 
+        if (gutters.indexOf(DEBUG_INFO_GUTTER) < 0) {
+            registeredGutters.push({name: DEBUG_INFO_GUTTER, priority: DEBUG_INFO_GUTTER_PRIORITY});
+        }
+
         gutters = registeredGutters.sort(_sortByPriority)
             .filter(_filterByLanguages)
             .map(_getName);
@@ -1926,7 +1946,7 @@ define(function (require, exports, module) {
 
     /**
      * Sets the marker for the specified gutter on the specified line number
-     * @param   {string}   lineNumber The line number for the inserted gutter marker
+     * @param   {number}   lineNumber The line number for the inserted gutter marker
      * @param   {string}   gutterName The name of the gutter
      * @param   {object}   marker     The dom element representing the marker to the inserted in the gutter
      */
@@ -2198,6 +2218,8 @@ define(function (require, exports, module) {
 
     Editor.LINE_NUMBER_GUTTER_PRIORITY = LINE_NUMBER_GUTTER_PRIORITY;
     Editor.CODE_FOLDING_GUTTER_PRIORITY = CODE_FOLDING_GUTTER_PRIORITY;
+    Editor.DEBUG_INFO_GUTTER_PRIORITY = DEBUG_INFO_GUTTER_PRIORITY;
+    Editor.DEBUG_INFO_GUTTER = DEBUG_INFO_GUTTER;
 
     // Set up listeners for preference changes
     editorOptions.forEach(function (prefName) {

--- a/src/editor/EditorHelper/EditorPreferences.js
+++ b/src/editor/EditorHelper/EditorPreferences.js
@@ -62,7 +62,9 @@ define(function (require, exports, module) {
         MAX_TAB_SIZE            = 10;
 
     const LINE_NUMBER_GUTTER = "CodeMirror-linenumbers",
+        DEBUG_INFO_GUTTER = "phoenix-debug-info-gutter",
         LINE_NUMBER_GUTTER_PRIORITY     = 100,
+        DEBUG_INFO_GUTTER_PRIORITY      = 500,
         CODE_FOLDING_GUTTER_PRIORITY    = 1000;
 
     PreferencesManager.definePreference(CLOSE_BRACKETS,     "boolean", true, {
@@ -209,6 +211,8 @@ define(function (require, exports, module) {
     exports.MAX_TAB_SIZE            = MAX_TAB_SIZE;
 
     exports.LINE_NUMBER_GUTTER = LINE_NUMBER_GUTTER;
+    exports.DEBUG_INFO_GUTTER  = DEBUG_INFO_GUTTER;
+    exports.DEBUG_INFO_GUTTER_PRIORITY      = DEBUG_INFO_GUTTER_PRIORITY;
     exports.LINE_NUMBER_GUTTER_PRIORITY     = LINE_NUMBER_GUTTER_PRIORITY;
     exports.CODE_FOLDING_GUTTER_PRIORITY    = CODE_FOLDING_GUTTER_PRIORITY;
 

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -2258,6 +2258,34 @@ textarea.exclusions-editor {
     background: url(images/topcoat-okay-15.svg) 9px 5px no-repeat;
 }
 
+.line-icon-problem_type_error {
+    color: @error-underline-text;
+}
+.line-icon-problem_type_warning {
+    color: @warn-underline-text;
+}
+.line-icon-problem_type_meta {
+    color: @info-underline-text;
+}
+.line-icon-problem_type_spell {
+    color: @spell-underline-text;
+}
+
+.CodeMirror .phoenix-debug-info-gutter {
+    width: 1em;
+    background-color: transparent;
+}
+
+.brackets-inspection-gutter-marker {
+    cursor: default;
+    display: inline-flex;
+    line-height: 1em;
+    height: 1em;
+    width: 1em;
+    font-size: .8em;
+    pointer-events: auto;
+}
+
 #problems-panel {
     .user-select(text);  // allow selecting error messages for easy web searching
     .line {
@@ -2273,17 +2301,6 @@ textarea.exclusions-editor {
             background-image: url(images/topcoat-inactive-15.svg);
             background-repeat: no-repeat;
             background-position: 0px 1px;
-        }
-
-        // Add an image based on the type of the problem.
-        .line-icon-problem_type_error {
-            color: @error-underline-text;
-        }
-        .line-icon-problem_type_warning {
-            color: @warn-underline-text;
-        }
-        .line-icon-problem_type_meta {
-            color: @info-underline-text;
         }
     }
 

--- a/test/spec/Editor-test.js
+++ b/test/spec/Editor-test.js
@@ -2069,7 +2069,8 @@ define(function (require, exports, module) {
         describe("Gutter APIs", function () {
             var leftGutter = "left",
                 rightGutter = "right",
-                lineNumberGutter = "CodeMirror-linenumbers";
+                lineNumberGutter = "CodeMirror-linenumbers",
+                debugGutter = Editor.DEBUG_INFO_GUTTER;
 
             beforeEach(function () {
                 createTestEditor(defaultContent, "javascript");
@@ -2089,7 +2090,7 @@ define(function (require, exports, module) {
             });
 
             it("should register multiple gutters in the correct order", function () {
-                var expectedGutters = [leftGutter, lineNumberGutter, rightGutter];
+                var expectedGutters = [leftGutter, lineNumberGutter,  rightGutter, debugGutter];
                 var gutters  = myEditor._codeMirror.getOption("gutters");
                 var registeredGutters = Editor.getRegisteredGutters().map(function (gutter) {
                     return gutter.name;
@@ -2101,7 +2102,7 @@ define(function (require, exports, module) {
             it("should return gutters registered with the same priority in insertion order", function () {
                 var secondRightGutter = "second-right";
                 Editor.registerGutter(secondRightGutter, 101);
-                var expectedGutters = [leftGutter, lineNumberGutter, rightGutter, secondRightGutter];
+                var expectedGutters = [leftGutter, lineNumberGutter, rightGutter, secondRightGutter, debugGutter];
                 var gutters  = myEditor._codeMirror.getOption("gutters");
                 var registeredGutters = Editor.getRegisteredGutters().map(function (gutter) {
                     return gutter.name;
@@ -2113,8 +2114,8 @@ define(function (require, exports, module) {
             it("should have only gutters registered with the intended languageIds ", function () {
                 var lessOnlyGutter = "less-only-gutter";
                 Editor.registerGutter(lessOnlyGutter, 101, ["less"]);
-                var expectedGutters = [leftGutter, lineNumberGutter, rightGutter];
-                var expectedRegisteredGutters = [leftGutter, lineNumberGutter, rightGutter, lessOnlyGutter];
+                var expectedGutters = [leftGutter, lineNumberGutter, rightGutter, debugGutter];
+                var expectedRegisteredGutters = [leftGutter, lineNumberGutter, rightGutter, lessOnlyGutter, debugGutter];
                 var gutters  = myEditor._codeMirror.getOption("gutters");
                 var registeredGutters = Editor.getRegisteredGutters().map(function (gutter) {
                     return gutter.name;
@@ -2127,7 +2128,7 @@ define(function (require, exports, module) {
                 Editor.unregisterGutter(leftGutter);
                 Editor.unregisterGutter(rightGutter);
                 Editor.registerGutter(leftGutter, 1);
-                var expectedGutters = [leftGutter, lineNumberGutter];
+                var expectedGutters = [leftGutter, lineNumberGutter, debugGutter];
                 var gutters  = myEditor._codeMirror.getOption("gutters");
                 var registeredGutters = Editor.getRegisteredGutters().map(function (gutter) {
                     return gutter.name;


### PR DESCRIPTION
- fix: either JSHint take config from prefs or defaults but not mixes in both
- feat: editor gutter markers for error/warn/info line
- feat: hover on gutter markers will show all errors on line
- test: editor unit tests
![image](https://user-images.githubusercontent.com/5336369/184525944-b890b346-c29b-489a-8b6f-9438593b5331.png)
