### PR TITLE
refactor: quickview and F1 now bings quickdocs instead of ctrl-shift-e

### DIFF
--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -304,7 +304,7 @@
         "Ctrl-E"
     ],
     "navigate.toggleQuickDocs":  [
-        "Ctrl-Shift-E"
+        "F1"
     ],
     "navigate.previousMatch":  [
         {
@@ -325,6 +325,6 @@
         "Shift-F2"
     ],
     "help.support": [
-        "F1"
+        "Shift-F1"
     ]
 }

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -983,16 +983,17 @@ define(function (require, exports, module) {
      *
      * @param {?{line: number, ch: number}} [cursor] - Optional cursor position
      *      at which to retrieve a token. If not provided, the current position will be used.
+     * @param {boolean} [precise] If given, results in more current results. Suppresses caching.
      * @return {{end: number, start:number, string: string, type: string}} -
      * the CodeMirror token at the given cursor position
      */
-    Editor.prototype.getToken = function (cursor) {
+    Editor.prototype.getToken = function (cursor, precise) {
         let cm = this._codeMirror;
 
         if (cursor) {
-            return TokenUtils.getTokenAt(cm, cursor);
+            return TokenUtils.getTokenAt(cm, cursor, precise);
         }
-        return TokenUtils.getTokenAt(cm, this.getCursorPos());
+        return TokenUtils.getTokenAt(cm, this.getCursorPos(), precise);
     };
 
     /**
@@ -1001,12 +1002,13 @@ define(function (require, exports, module) {
      * @param {{line: number, ch: number}} [cursor] - Optional cursor position after
      *      which a token should be retrieved
      * @param {boolean} [skipWhitespace] - true if this should skip over whitespace tokens. Default is true.
+     * @param {boolean} [precise] If given, results in more current results. Suppresses caching.
      * @return {{end: number, start:number, string: string, type: string}} -
      * the CodeMirror token after the one at the given cursor position
      */
-    Editor.prototype.getNextToken = function (cursor, skipWhitespace = true) {
+    Editor.prototype.getNextToken = function (cursor, skipWhitespace = true, precise) {
         cursor = cursor || this.getCursorPos();
-        let token   = this.getToken(cursor),
+        let token   = this.getToken(cursor, precise),
             next    = token,
             doc     = this.document;
 
@@ -1020,7 +1022,7 @@ define(function (require, exports, module) {
                 next = null;
                 break;
             }
-            next = this.getToken(cursor);
+            next = this.getToken(cursor, precise);
         } while (skipWhitespace && !/\S/.test(next.string));
 
         return next;
@@ -1032,12 +1034,13 @@ define(function (require, exports, module) {
      * @param {{line: number, ch: number}} [cursor] - Optional cursor position before
      *      which a token should be retrieved
      * @param {boolean} [skipWhitespace] - true if this should skip over whitespace tokens. Default is true.
+     * @param {boolean} [precise] If given, results in more current results. Suppresses caching.
      * @return {{end: number, start:number, string: string, type: string}} - the CodeMirror token before
      * the one at the given cursor position
      */
-    Editor.prototype.getPreviousToken = function (cursor, skipWhitespace = true) {
+    Editor.prototype.getPreviousToken = function (cursor, skipWhitespace = true, precise) {
         cursor = cursor || this.getCursorPos();
-        let token   = this.getToken(cursor),
+        let token   = this.getToken(cursor, precise),
             prev    = token,
             doc     = this.document;
 
@@ -1050,7 +1053,7 @@ define(function (require, exports, module) {
             } else {
                 break;
             }
-            prev = this.getToken(cursor);
+            prev = this.getToken(cursor, precise);
         } while (skipWhitespace && !/\S/.test(prev.string));
 
         return prev;

--- a/src/extensions/default/QuickView/ImagePreviewProvider.js
+++ b/src/extensions/default/QuickView/ImagePreviewProvider.js
@@ -1,0 +1,211 @@
+/*
+ * GNU AGPL-3.0 License
+ *
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
+ * Original work Copyright (c) 2013 - 2021 Adobe Systems Incorporated. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
+ *
+ */
+
+/*jslint regexp: true */
+
+define(function (require, exports, module) {
+
+
+    // Brackets modules
+    let FileUtils           = brackets.getModule("file/FileUtils"),
+        FileSystem          = brackets.getModule("filesystem/FileSystem"),
+        PreferencesManager  = brackets.getModule("preferences/PreferencesManager"),
+        LanguageManager     = brackets.getModule("language/LanguageManager"),
+        Strings             = brackets.getModule("strings"),
+        PathUtils           = brackets.getModule("thirdparty/path-utils/path-utils");
+
+    var enabled,                             // Only show preview if true
+        prefs                      = null,   // Preferences
+        extensionlessImagePreview;           // Whether to try and preview extensionless URLs
+
+    // List of protocols which we will support for image preview urls
+    var validProtocols = ["data:", "http:", "https:", "ftp:", "file:"];
+
+    prefs = PreferencesManager.getExtensionPrefs("quickview");
+
+    // Whether or not to try and show image previews for URLs missing extensions
+    // (e.g., https://avatars2.githubusercontent.com/u/476009?v=3&s=200)
+    prefs.definePreference("extensionlessImagePreview", "boolean", true, {
+        description: Strings.DESCRIPTION_EXTENSION_LESS_IMAGE_PREVIEW
+    });
+
+
+    // Image preview provider -------------------------------------------------
+
+    function imagePreviewProvider($previewContainer, editor, pos, token, line) {
+        const $previewContent = $previewContainer.find(".preview-content");
+        var cm = editor._codeMirror;
+
+        // Check for image name
+        var urlRegEx = /url\(([^\)]*)\)/gi,
+            tokenString,
+            urlMatch;
+
+        if (token.type === "string") {
+            tokenString = token.string;
+        } else {
+            urlMatch = urlRegEx.exec(line);
+            while (urlMatch) {
+                if (pos.ch < urlMatch.index) {
+                    // match is past cursor, so stop looping
+                    break;
+                } else if (pos.ch <= urlMatch.index + urlMatch[0].length) {
+                    tokenString = urlMatch[1];
+                    break;
+                }
+                urlMatch = urlRegEx.exec(line);
+            }
+        }
+
+        if (!tokenString) {
+            return null;
+        }
+
+        // Strip leading/trailing quotes, if present
+        tokenString = tokenString.replace(/(^['"])|(['"]$)/g, "");
+
+        var sPos, ePos;
+        var docPath = editor.document.file.fullPath;
+        var imgPath;
+
+        // Determine whether or not this URL/path is likely to be an image.
+        var parsed = PathUtils.parseUrl(tokenString);
+        // If the URL has a protocol, check if it's one of the supported protocols
+        var hasProtocol = parsed.protocol !== "" && validProtocols.indexOf(parsed.protocol.trim().toLowerCase()) !== -1;
+        var ext = parsed.filenameExtension.replace(/^\./, '');
+        var language = LanguageManager.getLanguageForExtension(ext);
+        var id = language && language.getId();
+        var isImage = id === "image" || id === "svg";
+        var loadFromDisk = null;
+
+        // Use this URL if this is an absolute URL and either points to a
+        // filename with a known image extension, or lacks an extension (e.g.,
+        // a web service that returns an image). Honour the extensionlessImagePreview
+        // preference as well in the latter case.
+        if (hasProtocol && (isImage || (!ext && extensionlessImagePreview))) {
+            imgPath = tokenString;
+        }
+        // Use this filename if this is a path with a known image extension.
+        else if (!hasProtocol && isImage) {
+            imgPath = '';
+            loadFromDisk = window.path.normalize(FileUtils.getDirectoryPath(docPath) + tokenString);
+        }
+
+        if (!loadFromDisk && !imgPath) {
+            return null;
+        }
+
+        if (urlMatch) {
+            sPos = {line: pos.line, ch: urlMatch.index};
+            ePos = {line: pos.line, ch: urlMatch.index + urlMatch[0].length};
+        } else {
+            sPos = {line: pos.line, ch: token.start};
+            ePos = {line: pos.line, ch: token.end};
+        }
+
+        var imgPreview = "<div class='image-preview'>"          +
+            "    <img src=\"" + imgPath + "\">"    +
+            "</div>";
+        var coord = cm.charCoords(sPos);
+        var xpos = (cm.charCoords(ePos).left - coord.left) / 2 + coord.left;
+
+        function showHandlerWithImageURL(imageURL) {
+            return new Promise((resolve, reject)=>{
+                // Hide the preview container until the image is loaded.
+                $previewContainer.hide();
+                var img = $previewContainer.find(".image-preview > img");
+                if(imageURL){
+                    img[0].src = imageURL;
+                }
+
+                img.on("load", function () {
+                    $previewContent
+                        .append("<div class='img-size'>" +
+                            this.naturalWidth + " &times; " + this.naturalHeight + " " + Strings.UNIT_PIXELS +
+                            "</div>"
+                        );
+                    resolve();
+                }).on("error", function (e) {
+                    e.preventDefault();
+                    reject();
+                });
+            });
+        };
+
+        function _imageToDataURI(file, cb) {
+            let contentType = "data:image;base64,";
+            if(file.name.endsWith('.svg')){
+                contentType = "data:image/svg+xml;base64,";
+            }
+            file.read({encoding: window.fs.BYTE_ARRAY_ENCODING}, function (err, content, encoding, stat) {
+                var base64 = window.btoa(
+                    new Uint8Array(content)
+                        .reduce((data, byte) => data + String.fromCharCode(byte), '')
+                );
+                var dataURL= contentType + base64;
+                cb(null, dataURL);
+            });
+        }
+
+        var showHandler = function () {
+            return new Promise((resolve, reject)=>{
+                if(loadFromDisk){
+                    var imageFile = FileSystem.getFileForPath(loadFromDisk);
+                    _imageToDataURI(imageFile, function (err, dataURL){
+                        showHandlerWithImageURL(dataURL).then(resolve).catch(reject);
+                    });
+                } else {
+                    showHandlerWithImageURL().then(resolve).catch(reject);
+                }
+            });
+        };
+
+        return {
+            start: sPos,
+            end: ePos,
+            content: imgPreview,
+            onShow: showHandler,
+            xpos: xpos,
+            ytop: coord.top,
+            ybot: coord.bottom,
+            _imgPath: imgPath || loadFromDisk
+        };
+    }
+
+    function setExtensionlessImagePreview(_extensionlessImagePreview, doNotSave) {
+        if (extensionlessImagePreview !== _extensionlessImagePreview) {
+            extensionlessImagePreview = _extensionlessImagePreview;
+            if (!doNotSave) {
+                prefs.set("extensionlessImagePreview", enabled);
+                prefs.save();
+            }
+        }
+    }
+
+    setExtensionlessImagePreview(prefs.get("extensionlessImagePreview"), true);
+
+    prefs.on("change", "extensionlessImagePreview", function () {
+        setExtensionlessImagePreview(prefs.get("extensionlessImagePreview"));
+    });
+
+    exports.imagePreviewProvider = imagePreviewProvider;
+
+});

--- a/src/extensions/default/QuickView/QuickView.less
+++ b/src/extensions/default/QuickView/QuickView.less
@@ -25,7 +25,7 @@
     background: @bc-panel-bg;
     position: absolute;
     z-index: 5000;
-    pointer-events: none;
+    user-select: text;
 
     padding: 8px;
     text-align: center;

--- a/src/extensions/default/QuickView/colorGradientProvider.js
+++ b/src/extensions/default/QuickView/colorGradientProvider.js
@@ -1,0 +1,301 @@
+/*
+ * GNU AGPL-3.0 License
+ *
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
+ * Original work Copyright (c) 2013 - 2021 Adobe Systems Incorporated. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
+ *
+ */
+
+/*jslint regexp: true */
+
+define(function (require, exports, module) {
+
+
+    // Brackets modules
+    const ColorUtils          = brackets.getModule("utils/ColorUtils"),
+        CSSUtils            = brackets.getModule("language/CSSUtils"),
+        TokenUtils          = brackets.getModule("utils/TokenUtils");
+
+    let styleLanguages = ["css", "text/x-less", "sass", "text/x-scss", "stylus"];
+
+    function colorAndGradientPreviewProvider($previewContainer, editor, pos, token, line) {
+
+        // Check for gradient. -webkit-gradient() can have parens in parameters
+        // nested 2 levels. Other gradients can only nest 1 level.
+        var gradientRegEx = /-webkit-gradient\((?:[^\(]*?(?:\((?:[^\(]*?(?:\([^\)]*?\))*?)*?\))*?)*?\)|(?:(?:-moz-|-ms-|-o-|-webkit-|:|\s)((repeating-)?linear-gradient)|(?:-moz-|-ms-|-o-|-webkit-|:|\s)((repeating-)?radial-gradient))(\((?:[^\)]*?(?:\([^\)]*?\))*?)*?\))/gi,
+            colorRegEx    = new RegExp(ColorUtils.COLOR_REGEX),
+            mode          = TokenUtils.getModeAt(editor._codeMirror, pos, false),
+            isStyleSheet  = (styleLanguages.indexOf(mode) !== -1);
+
+        function areParensBalanced(str) {
+            var i,
+                nestLevel = 0,
+                len;
+
+            if (isStyleSheet) {
+                // Remove comments & strings from style sheets
+                str = CSSUtils.reduceStyleSheetForRegExParsing(str);
+            }
+            len = str.length;
+
+            for (i = 0; i < len; i++) {
+                switch (str[i]) {
+                    case "(":
+                        nestLevel++;
+                        break;
+                    case ")":
+                        nestLevel--;
+                        break;
+                    case "\\":
+                        i++;    // next char is escaped, so skip it
+                        break;
+                }
+            }
+
+            // if parens are balanced, nest level will be 0
+            return (nestLevel === 0);
+        }
+
+        function execGradientMatch(line, parensBalanced) {
+            // Unbalanced parens cause infinite loop (see issue #4650)
+            var gradientMatch = (parensBalanced ? gradientRegEx.exec(line) : null),
+                prefix = "",
+                colorValue;
+
+            if (gradientMatch) {
+                if (gradientMatch[0].indexOf("@") !== -1) {
+                    // If the gradient match has "@" in it, it is most likely a less or
+                    // sass variable. Ignore it since it won't be displayed correctly.
+                    gradientMatch = null;
+
+                } else {
+                    // If it was a linear-gradient or radial-gradient variant with a vendor prefix
+                    // add "-webkit-" so it shows up correctly in Brackets.
+                    if (gradientMatch[0].match(/-o-|-moz-|-ms-|-webkit-/i)) {
+                        prefix = "-webkit-";
+                    }
+
+                    // For prefixed gradients, use the non-prefixed value as the color value.
+                    // "-webkit-" will be added before this value later
+                    if (gradientMatch[1]) {
+                        colorValue = gradientMatch[1] + gradientMatch[5];    // linear gradiant
+                    } else if (gradientMatch[3]) {
+                        colorValue = gradientMatch[3] + gradientMatch[5];    // radial gradiant
+                    } else if (gradientMatch[0]) {
+                        colorValue = gradientMatch[0];                       // -webkit-gradient
+                        prefix = "";                                         // do not prefix
+                    }
+                }
+            }
+
+            return {
+                match: gradientMatch,
+                prefix: prefix,
+                colorValue: colorValue
+            };
+        }
+
+        function execColorMatch(editor, line, pos) {
+            var colorMatch,
+                ignoreNamedColors;
+
+            function hyphenOnMatchBoundary(match, line) {
+                var beforeIndex, afterIndex;
+                if (match) {
+                    beforeIndex = match.index - 1;
+                    if (beforeIndex >= 0 && line[beforeIndex] === "-") {
+                        return true;
+                    }
+                    afterIndex = match.index + match[0].length;
+                    if (afterIndex < line.length && line[afterIndex] === "-") {
+                        return true;
+                    }
+
+                }
+
+                return false;
+            }
+            function isNamedColor(match) {
+                if (match && match[0] && /^[a-z]+$/i.test(match[0])) { // only for color names, not for hex-/rgb-values
+                    return true;
+                }
+            }
+
+            // Hyphens do not count as a regex word boundary (\b), so check for those here
+            do {
+                colorMatch = colorRegEx.exec(line);
+                if (!colorMatch) {
+                    break;
+                }
+                if (ignoreNamedColors === undefined) {
+                    var mode = TokenUtils.getModeAt(editor._codeMirror, pos, false).name;
+                    ignoreNamedColors = styleLanguages.indexOf(mode) === -1;
+                }
+            } while (hyphenOnMatchBoundary(colorMatch, line) ||
+            (ignoreNamedColors && isNamedColor(colorMatch)));
+
+            return colorMatch;
+        }
+
+        // simple css property splitter (used to find color stop arguments in gradients)
+        function splitStyleProperty(property) {
+            var token = /((?:[^"']|".*?"|'.*?')*?)([(,)]|$)/g;
+            var recurse = function () {
+                var array = [];
+                for (;;) {
+                    var result = token.exec(property);
+                    if (result[2] === "(") {
+                        var str = result[1].trim() + "(" + recurse().join(",") + ")";
+                        result = token.exec(property);
+                        str += result[1];
+                        array.push(str);
+                    } else {
+                        array.push(result[1].trim());
+                    }
+                    if (result[2] !== ",") {
+                        return array;
+                    }
+                }
+            };
+            return (recurse());
+        }
+
+        // color stop helpers
+        function isGradientColorStop(args) {
+            return (args.length > 0 && args[0].match(colorRegEx) !== null);
+        }
+
+        function hasLengthInPixels(args) {
+            return (args.length > 1 && args[1].indexOf("px") > 0);
+        }
+
+        // Ensures that input is in usable hex format
+        function ensureHexFormat(str) {
+            return (/^0x/).test(str) ? str.replace("0x", "#") : str;
+        }
+
+        // Normalizes px color stops to %
+        function normalizeGradientExpressionForQuickview(expression) {
+            if (expression.indexOf("px") > 0) {
+                var paramStart = expression.indexOf("(") + 1,
+                    paramEnd = expression.lastIndexOf(")"),
+                    parameters = expression.substring(paramStart, paramEnd),
+                    params = splitStyleProperty(parameters),
+                    lowerBound = 0,
+                    upperBound = $previewContainer.width(),
+                    args,
+                    thisSize,
+                    i;
+
+                // find lower bound
+                for (i = 0; i < params.length; i++) {
+                    args = params[i].split(" ");
+
+                    if (hasLengthInPixels(args)) {
+                        thisSize = parseFloat(args[1]);
+
+                        upperBound = Math.max(upperBound, thisSize);
+                        // we really only care about converting negative
+                        //  pixel values -- so take the smallest negative pixel
+                        //  value and use that as baseline for display purposes
+                        if (thisSize < 0) {
+                            lowerBound = Math.min(lowerBound, thisSize);
+                        }
+                    }
+                }
+
+                // convert negative lower bound to positive and adjust all pixel values
+                //  so that -20px is now 0px and 100px is now 120px
+                lowerBound = Math.abs(lowerBound);
+
+                // Offset the upperbound by the lowerBound to give us a corrected context
+                upperBound += lowerBound;
+
+                // convert to %
+                for (i = 0; i < params.length; i++) {
+                    args = params[i].split(" ");
+                    if (isGradientColorStop(args) && hasLengthInPixels(args)) {
+                        if (upperBound === 0) {
+                            thisSize = 0;
+                        } else {
+                            thisSize = ((parseFloat(args[1]) + lowerBound) / upperBound) * 100;
+                        }
+                        args[1] = thisSize + "%";
+                    }
+                    params[i] = args.join(" ");
+                }
+
+                // put it back together.
+                expression = expression.substring(0, paramStart) + params.join(", ") + expression.substring(paramEnd);
+            }
+            return expression;
+        }
+
+        var parensBalanced = areParensBalanced(line),
+            gradientMatch = execGradientMatch(line, parensBalanced),
+            match = gradientMatch.match || execColorMatch(editor, line, pos),
+            cm = editor._codeMirror;
+
+        while (match) {
+            if (pos.ch < match.index) {
+                // Gradients are matched first, then colors, so...
+                if (gradientMatch.match) {
+                    // ... gradient match is past cursor -- stop looking for gradients, start searching for colors
+                    gradientMatch = { match: null, prefix: "", colorValue: null };
+                } else {
+                    // ... color match is past cursor -- stop looping
+                    break;
+                }
+            } else if (pos.ch <= match.index + match[0].length) {
+                // build the css for previewing the gradient from the regex result
+                var previewCSS = gradientMatch.prefix + (gradientMatch.colorValue || match[0]);
+
+                // normalize the arguments to something that we can display to the user
+                // NOTE: we need both the div and the popover's _previewCSS member
+                //          (used by unit tests) to match so normalize the css for both
+                previewCSS = normalizeGradientExpressionForQuickview(ensureHexFormat(previewCSS));
+
+                var preview = "<div class='color-swatch' style='background:" + previewCSS + "'>" + "</div>";
+                var startPos = {line: pos.line, ch: match.index},
+                    endPos = {line: pos.line, ch: match.index + match[0].length},
+                    startCoords = cm.charCoords(startPos),
+                    xPos;
+
+                xPos = (cm.charCoords(endPos).left - startCoords.left) / 2 + startCoords.left;
+
+                return {
+                    start: startPos,
+                    end: endPos,
+                    content: preview,
+                    xpos: xPos,
+                    ytop: startCoords.top,
+                    ybot: startCoords.bottom,
+                    _previewCSS: previewCSS
+                };
+            }
+
+            // Get next match
+            if (gradientMatch.match) {
+                gradientMatch = execGradientMatch(line, parensBalanced);
+            }
+            match = gradientMatch.match || execColorMatch(editor, line, pos);
+        }
+
+        return null;
+    }
+
+    exports.colorAndGradientPreviewProvider = colorAndGradientPreviewProvider;
+});

--- a/src/extensions/default/QuickView/main.js
+++ b/src/extensions/default/QuickView/main.js
@@ -25,21 +25,17 @@ define(function (require, exports, module) {
 
 
     // Brackets modules
-    var ColorUtils          = brackets.getModule("utils/ColorUtils"),
+    var colorGradientProvider          = require("./colorGradientProvider"),
+        ImagePreviewProvider           = require("./ImagePreviewProvider"),
         CommandManager      = brackets.getModule("command/CommandManager"),
         Commands            = brackets.getModule("command/Commands"),
-        CSSUtils            = brackets.getModule("language/CSSUtils"),
         EditorManager       = brackets.getModule("editor/EditorManager"),
         ExtensionUtils      = brackets.getModule("utils/ExtensionUtils"),
-        FileUtils           = brackets.getModule("file/FileUtils"),
-        FileSystem          = brackets.getModule("filesystem/FileSystem"),
         Menus               = brackets.getModule("command/Menus"),
         PreferencesManager  = brackets.getModule("preferences/PreferencesManager"),
-        LanguageManager     = brackets.getModule("language/LanguageManager"),
         Strings             = brackets.getModule("strings"),
         ViewUtils           = brackets.getModule("utils/ViewUtils"),
-        TokenUtils          = brackets.getModule("utils/TokenUtils"),
-        PathUtils           = brackets.getModule("thirdparty/path-utils/path-utils");
+        TokenUtils          = brackets.getModule("utils/TokenUtils");
 
     var previewContainerHTML       = require("text!QuickViewTemplate.html");
 
@@ -48,8 +44,7 @@ define(function (require, exports, module) {
         $previewContainer,                   // Preview container
         $previewContent,                     // Preview content holder
         lastMousePos,                        // Last mouse position
-        animationRequest,                    // Request for animation frame
-        extensionlessImagePreview;           // Whether to try and preview extensionless URLs
+        animationRequest;
 
     // Constants
     var CMD_ENABLE_QUICK_VIEW       = "view.enableQuickView",
@@ -57,20 +52,9 @@ define(function (require, exports, module) {
         POINTER_HEIGHT              = 15,   // Pointer height, used to shift popover above pointer (plus a little bit of space)
         POPOVER_HORZ_MARGIN         =  5;   // Horizontal margin
 
-    var styleLanguages = ["css", "text/x-less", "sass", "text/x-scss", "stylus"];
-
-    // List of protocols which we will support for image preview urls
-    var validProtocols = ["data:", "http:", "https:", "ftp:", "file:"];
-
     prefs = PreferencesManager.getExtensionPrefs("quickview");
     prefs.definePreference("enabled", "boolean", true, {
         description: Strings.DESCRIPTION_QUICK_VIEW_ENABLED
-    });
-
-    // Whether or not to try and show image previews for URLs missing extensions
-    // (e.g., https://avatars2.githubusercontent.com/u/476009?v=3&s=200)
-    prefs.definePreference("extensionlessImagePreview", "boolean", true, {
-        description: Strings.DESCRIPTION_EXTENSION_LESS_IMAGE_PREVIEW
     });
 
     /**
@@ -171,415 +155,6 @@ define(function (require, exports, module) {
                 mousePos.clientY <= offset.top + $div.height());
     }
 
-
-    // Color & gradient preview provider --------------------------------------
-
-    function colorAndGradientPreviewProvider(editor, pos, token, line) {
-
-        // Check for gradient. -webkit-gradient() can have parens in parameters
-        // nested 2 levels. Other gradients can only nest 1 level.
-        var gradientRegEx = /-webkit-gradient\((?:[^\(]*?(?:\((?:[^\(]*?(?:\([^\)]*?\))*?)*?\))*?)*?\)|(?:(?:-moz-|-ms-|-o-|-webkit-|:|\s)((repeating-)?linear-gradient)|(?:-moz-|-ms-|-o-|-webkit-|:|\s)((repeating-)?radial-gradient))(\((?:[^\)]*?(?:\([^\)]*?\))*?)*?\))/gi,
-            colorRegEx    = new RegExp(ColorUtils.COLOR_REGEX),
-            mode          = TokenUtils.getModeAt(editor._codeMirror, pos, false),
-            isStyleSheet  = (styleLanguages.indexOf(mode) !== -1);
-
-        function areParensBalanced(str) {
-            var i,
-                nestLevel = 0,
-                len;
-
-            if (isStyleSheet) {
-                // Remove comments & strings from style sheets
-                str = CSSUtils.reduceStyleSheetForRegExParsing(str);
-            }
-            len = str.length;
-
-            for (i = 0; i < len; i++) {
-                switch (str[i]) {
-                case "(":
-                    nestLevel++;
-                    break;
-                case ")":
-                    nestLevel--;
-                    break;
-                case "\\":
-                    i++;    // next char is escaped, so skip it
-                    break;
-                }
-            }
-
-            // if parens are balanced, nest level will be 0
-            return (nestLevel === 0);
-        }
-
-        function execGradientMatch(line, parensBalanced) {
-            // Unbalanced parens cause infinite loop (see issue #4650)
-            var gradientMatch = (parensBalanced ? gradientRegEx.exec(line) : null),
-                prefix = "",
-                colorValue;
-
-            if (gradientMatch) {
-                if (gradientMatch[0].indexOf("@") !== -1) {
-                    // If the gradient match has "@" in it, it is most likely a less or
-                    // sass variable. Ignore it since it won't be displayed correctly.
-                    gradientMatch = null;
-
-                } else {
-                    // If it was a linear-gradient or radial-gradient variant with a vendor prefix
-                    // add "-webkit-" so it shows up correctly in Brackets.
-                    if (gradientMatch[0].match(/-o-|-moz-|-ms-|-webkit-/i)) {
-                        prefix = "-webkit-";
-                    }
-
-                    // For prefixed gradients, use the non-prefixed value as the color value.
-                    // "-webkit-" will be added before this value later
-                    if (gradientMatch[1]) {
-                        colorValue = gradientMatch[1] + gradientMatch[5];    // linear gradiant
-                    } else if (gradientMatch[3]) {
-                        colorValue = gradientMatch[3] + gradientMatch[5];    // radial gradiant
-                    } else if (gradientMatch[0]) {
-                        colorValue = gradientMatch[0];                       // -webkit-gradient
-                        prefix = "";                                         // do not prefix
-                    }
-                }
-            }
-
-            return {
-                match: gradientMatch,
-                prefix: prefix,
-                colorValue: colorValue
-            };
-        }
-
-        function execColorMatch(editor, line, pos) {
-            var colorMatch,
-                ignoreNamedColors;
-
-            function hyphenOnMatchBoundary(match, line) {
-                var beforeIndex, afterIndex;
-                if (match) {
-                    beforeIndex = match.index - 1;
-                    if (beforeIndex >= 0 && line[beforeIndex] === "-") {
-                        return true;
-                    }
-                    afterIndex = match.index + match[0].length;
-                    if (afterIndex < line.length && line[afterIndex] === "-") {
-                        return true;
-                    }
-
-                }
-
-                return false;
-            }
-            function isNamedColor(match) {
-                if (match && match[0] && /^[a-z]+$/i.test(match[0])) { // only for color names, not for hex-/rgb-values
-                    return true;
-                }
-            }
-
-            // Hyphens do not count as a regex word boundary (\b), so check for those here
-            do {
-                colorMatch = colorRegEx.exec(line);
-                if (!colorMatch) {
-                    break;
-                }
-                if (ignoreNamedColors === undefined) {
-                    var mode = TokenUtils.getModeAt(editor._codeMirror, pos, false).name;
-                    ignoreNamedColors = styleLanguages.indexOf(mode) === -1;
-                }
-            } while (hyphenOnMatchBoundary(colorMatch, line) ||
-                    (ignoreNamedColors && isNamedColor(colorMatch)));
-
-            return colorMatch;
-        }
-
-        // simple css property splitter (used to find color stop arguments in gradients)
-        function splitStyleProperty(property) {
-            var token = /((?:[^"']|".*?"|'.*?')*?)([(,)]|$)/g;
-            var recurse = function () {
-                var array = [];
-                for (;;) {
-                    var result = token.exec(property);
-                    if (result[2] === "(") {
-                        var str = result[1].trim() + "(" + recurse().join(",") + ")";
-                        result = token.exec(property);
-                        str += result[1];
-                        array.push(str);
-                    } else {
-                        array.push(result[1].trim());
-                    }
-                    if (result[2] !== ",") {
-                        return array;
-                    }
-                }
-            };
-            return (recurse());
-        }
-
-        // color stop helpers
-        function isGradientColorStop(args) {
-            return (args.length > 0 && args[0].match(colorRegEx) !== null);
-        }
-
-        function hasLengthInPixels(args) {
-            return (args.length > 1 && args[1].indexOf("px") > 0);
-        }
-
-        // Ensures that input is in usable hex format
-        function ensureHexFormat(str) {
-            return (/^0x/).test(str) ? str.replace("0x", "#") : str;
-        }
-
-        // Normalizes px color stops to %
-        function normalizeGradientExpressionForQuickview(expression) {
-            if (expression.indexOf("px") > 0) {
-                var paramStart = expression.indexOf("(") + 1,
-                    paramEnd = expression.lastIndexOf(")"),
-                    parameters = expression.substring(paramStart, paramEnd),
-                    params = splitStyleProperty(parameters),
-                    lowerBound = 0,
-                    upperBound = $previewContainer.width(),
-                    args,
-                    thisSize,
-                    i;
-
-                // find lower bound
-                for (i = 0; i < params.length; i++) {
-                    args = params[i].split(" ");
-
-                    if (hasLengthInPixels(args)) {
-                        thisSize = parseFloat(args[1]);
-
-                        upperBound = Math.max(upperBound, thisSize);
-                        // we really only care about converting negative
-                        //  pixel values -- so take the smallest negative pixel
-                        //  value and use that as baseline for display purposes
-                        if (thisSize < 0) {
-                            lowerBound = Math.min(lowerBound, thisSize);
-                        }
-                    }
-                }
-
-                // convert negative lower bound to positive and adjust all pixel values
-                //  so that -20px is now 0px and 100px is now 120px
-                lowerBound = Math.abs(lowerBound);
-
-                // Offset the upperbound by the lowerBound to give us a corrected context
-                upperBound += lowerBound;
-
-                // convert to %
-                for (i = 0; i < params.length; i++) {
-                    args = params[i].split(" ");
-                    if (isGradientColorStop(args) && hasLengthInPixels(args)) {
-                        if (upperBound === 0) {
-                            thisSize = 0;
-                        } else {
-                            thisSize = ((parseFloat(args[1]) + lowerBound) / upperBound) * 100;
-                        }
-                        args[1] = thisSize + "%";
-                    }
-                    params[i] = args.join(" ");
-                }
-
-                // put it back together.
-                expression = expression.substring(0, paramStart) + params.join(", ") + expression.substring(paramEnd);
-            }
-            return expression;
-        }
-
-        var parensBalanced = areParensBalanced(line),
-            gradientMatch = execGradientMatch(line, parensBalanced),
-            match = gradientMatch.match || execColorMatch(editor, line, pos),
-            cm = editor._codeMirror;
-
-        while (match) {
-            if (pos.ch < match.index) {
-                // Gradients are matched first, then colors, so...
-                if (gradientMatch.match) {
-                    // ... gradient match is past cursor -- stop looking for gradients, start searching for colors
-                    gradientMatch = { match: null, prefix: "", colorValue: null };
-                } else {
-                    // ... color match is past cursor -- stop looping
-                    break;
-                }
-            } else if (pos.ch <= match.index + match[0].length) {
-                // build the css for previewing the gradient from the regex result
-                var previewCSS = gradientMatch.prefix + (gradientMatch.colorValue || match[0]);
-
-                // normalize the arguments to something that we can display to the user
-                // NOTE: we need both the div and the popover's _previewCSS member
-                //          (used by unit tests) to match so normalize the css for both
-                previewCSS = normalizeGradientExpressionForQuickview(ensureHexFormat(previewCSS));
-
-                var preview = "<div class='color-swatch' style='background:" + previewCSS + "'>" + "</div>";
-                var startPos = {line: pos.line, ch: match.index},
-                    endPos = {line: pos.line, ch: match.index + match[0].length},
-                    startCoords = cm.charCoords(startPos),
-                    xPos;
-
-                xPos = (cm.charCoords(endPos).left - startCoords.left) / 2 + startCoords.left;
-
-                return {
-                    start: startPos,
-                    end: endPos,
-                    content: preview,
-                    xpos: xPos,
-                    ytop: startCoords.top,
-                    ybot: startCoords.bottom,
-                    _previewCSS: previewCSS
-                };
-            }
-
-            // Get next match
-            if (gradientMatch.match) {
-                gradientMatch = execGradientMatch(line, parensBalanced);
-            }
-            match = gradientMatch.match || execColorMatch(editor, line, pos);
-        }
-
-        return null;
-    }
-
-
-    // Image preview provider -------------------------------------------------
-
-    function imagePreviewProvider(editor, pos, token, line) {
-        var cm = editor._codeMirror;
-
-        // Check for image name
-        var urlRegEx = /url\(([^\)]*)\)/gi,
-            tokenString,
-            urlMatch;
-
-        if (token.type === "string") {
-            tokenString = token.string;
-        } else {
-            urlMatch = urlRegEx.exec(line);
-            while (urlMatch) {
-                if (pos.ch < urlMatch.index) {
-                    // match is past cursor, so stop looping
-                    break;
-                } else if (pos.ch <= urlMatch.index + urlMatch[0].length) {
-                    tokenString = urlMatch[1];
-                    break;
-                }
-                urlMatch = urlRegEx.exec(line);
-            }
-        }
-
-        if (!tokenString) {
-            return null;
-        }
-
-        // Strip leading/trailing quotes, if present
-        tokenString = tokenString.replace(/(^['"])|(['"]$)/g, "");
-
-        var sPos, ePos;
-        var docPath = editor.document.file.fullPath;
-        var imgPath;
-
-        // Determine whether or not this URL/path is likely to be an image.
-        var parsed = PathUtils.parseUrl(tokenString);
-        // If the URL has a protocol, check if it's one of the supported protocols
-        var hasProtocol = parsed.protocol !== "" && validProtocols.indexOf(parsed.protocol.trim().toLowerCase()) !== -1;
-        var ext = parsed.filenameExtension.replace(/^\./, '');
-        var language = LanguageManager.getLanguageForExtension(ext);
-        var id = language && language.getId();
-        var isImage = id === "image" || id === "svg";
-        var loadFromDisk = null;
-
-        // Use this URL if this is an absolute URL and either points to a
-        // filename with a known image extension, or lacks an extension (e.g.,
-        // a web service that returns an image). Honour the extensionlessImagePreview
-        // preference as well in the latter case.
-        if (hasProtocol && (isImage || (!ext && extensionlessImagePreview))) {
-            imgPath = tokenString;
-        }
-        // Use this filename if this is a path with a known image extension.
-        else if (!hasProtocol && isImage) {
-            imgPath = '';
-            loadFromDisk = window.path.normalize(FileUtils.getDirectoryPath(docPath) + tokenString);
-        }
-
-        if (!loadFromDisk && !imgPath) {
-            return null;
-        }
-
-        if (urlMatch) {
-            sPos = {line: pos.line, ch: urlMatch.index};
-            ePos = {line: pos.line, ch: urlMatch.index + urlMatch[0].length};
-        } else {
-            sPos = {line: pos.line, ch: token.start};
-            ePos = {line: pos.line, ch: token.end};
-        }
-
-        var imgPreview = "<div class='image-preview'>"          +
-                         "    <img src=\"" + imgPath + "\">"    +
-                         "</div>";
-        var coord = cm.charCoords(sPos);
-        var xpos = (cm.charCoords(ePos).left - coord.left) / 2 + coord.left;
-
-        function showHandlerWithImageURL(imageURL) {
-            // Hide the preview container until the image is loaded.
-            $previewContainer.hide();
-            var img = $previewContainer.find(".image-preview > img");
-            if(imageURL){
-                img[0].src = imageURL;
-            }
-
-            img.on("load", function () {
-                $previewContent
-                    .append("<div class='img-size'>" +
-                        this.naturalWidth + " &times; " + this.naturalHeight + " " + Strings.UNIT_PIXELS +
-                        "</div>"
-                    );
-                $previewContainer.show();
-                positionPreview(editor, popoverState.xpos, popoverState.ytop, popoverState.ybot);
-            }).on("error", function (e) {
-                e.preventDefault();
-                hidePreview();
-            });
-        };
-
-        function _imageToDataURI(file, cb) {
-            let contentType = "data:image;base64,";
-            if(file.name.endsWith('.svg')){
-                contentType = "data:image/svg+xml;base64,";
-            }
-            file.read({encoding: window.fs.BYTE_ARRAY_ENCODING}, function (err, content, encoding, stat) {
-                var base64 = window.btoa(
-                    new Uint8Array(content)
-                        .reduce((data, byte) => data + String.fromCharCode(byte), '')
-                );
-                var dataURL= contentType + base64;
-                cb(null, dataURL);
-            });
-        }
-
-        var showHandler = function () {
-            if(loadFromDisk){
-                var imageFile = FileSystem.getFileForPath(loadFromDisk);
-                _imageToDataURI(imageFile, function (err, dataURL){
-                    showHandlerWithImageURL(dataURL);
-                });
-            } else {
-                showHandlerWithImageURL();
-            }
-        };
-
-        return {
-            start: sPos,
-            end: ePos,
-            content: imgPreview,
-            onShow: showHandler,
-            xpos: xpos,
-            ytop: coord.top,
-            ybot: coord.bottom,
-            _imgPath: imgPath || loadFromDisk
-        };
-    }
-
-
     // Preview hide/show logic ------------------------------------------------
 
     /**
@@ -591,8 +166,8 @@ define(function (require, exports, module) {
         var line = editor.document.getLine(pos.line);
 
         // FUTURE: Support plugin providers. For now we just hard-code...
-        var popover = colorAndGradientPreviewProvider(editor, pos, token, line) ||
-                      imagePreviewProvider(editor, pos, token, line);
+        var popover = colorGradientProvider.colorAndGradientPreviewProvider($previewContainer, editor, pos, token, line) ||
+            ImagePreviewProvider.imagePreviewProvider($previewContainer, editor, pos, token, line);
 
         if (popover) {
             // Providers return just { start, end, content, ?onShow, xpos, ytop, ybot }
@@ -688,7 +263,12 @@ define(function (require, exports, module) {
             popoverState.visible = true;
 
             if (popoverState.onShow) {
-                popoverState.onShow();
+                popoverState.onShow()
+                    .then(()=>{
+                        $previewContainer.show();
+                        positionPreview(editor, popoverState.xpos, popoverState.ytop, popoverState.ybot);
+                    })
+                    .catch(hidePreview);
             } else {
                 positionPreview(editor, popoverState.xpos, popoverState.ytop, popoverState.ybot);
             }
@@ -784,16 +364,6 @@ define(function (require, exports, module) {
         CommandManager.get(CMD_ENABLE_QUICK_VIEW).setChecked(enabled);
     }
 
-    function setExtensionlessImagePreview(_extensionlessImagePreview, doNotSave) {
-        if (extensionlessImagePreview !== _extensionlessImagePreview) {
-            extensionlessImagePreview = _extensionlessImagePreview;
-            if (!doNotSave) {
-                prefs.set("extensionlessImagePreview", enabled);
-                prefs.save();
-            }
-        }
-    }
-
     function setEnabled(_enabled, doNotSave) {
         if (enabled !== _enabled) {
             enabled = _enabled;
@@ -856,14 +426,9 @@ define(function (require, exports, module) {
 
     // Setup initial UI state
     setEnabled(prefs.get("enabled"), true);
-    setExtensionlessImagePreview(prefs.get("extensionlessImagePreview"), true);
 
     prefs.on("change", "enabled", function () {
         setEnabled(prefs.get("enabled"), true);
-    });
-
-    prefs.on("change", "extensionlessImagePreview", function () {
-        setExtensionlessImagePreview(prefs.get("extensionlessImagePreview"));
     });
 
     // For unit testing

--- a/src/language/CodeInspection.js
+++ b/src/language/CodeInspection.js
@@ -141,6 +141,12 @@ define(function (require, exports, module) {
 
     /**
      * @private
+     * @type
+     */
+    let _registeredLanguageIDs = [];
+
+    /**
+     * @private
      * @type {boolean}
      */
     var _hasErrors;
@@ -680,6 +686,12 @@ define(function (require, exports, module) {
         }
 
         _providers[languageId].push(provider);
+
+        if(!_registeredLanguageIDs.includes(languageId)){
+            _registeredLanguageIDs.push(languageId);
+            Editor.unregisterGutter(CODE_INSPECTION_GUTTER);
+            Editor.registerGutter(CODE_INSPECTION_GUTTER, CODE_INSPECTION_GUTTER_PRIORITY, _registeredLanguageIDs);
+        }
 
         run();  // in case a file of this type is open currently
     }


### PR DESCRIPTION
* Refactor quickview as we are moving the base feature into core for generic hover popup support.
* Change QuickDocs shortcut to `F1` instead of `ctrl-shift-e`.` F1` used to open Phoenix discussion forum which was quite rarely used. So Remapped it to `shift-F1`. Also help and support has its dedicated icon in the plugin panel.
* ADD precise flag to editor getToken APIs.
* CodeInspection gutter will only be shown in supported languages to improve screen real-estate use.