### PR TITLE
feat: improve js code intelligence

### DIFF
--- a/src/JSUtils/worker/tern-main.js
+++ b/src/JSUtils/worker/tern-main.js
@@ -604,7 +604,9 @@ importScripts(`${Phoenix.baseURL}JSUtils/worker/testTern.js`);
             let result;
 
             if (inferType instanceof Tern.AVal) {
-                inferType = inferType.types[0];
+                // if there are multiple types, we take only the last, the first one is usually the current
+                // function itself inferred types which may be not what the user wants.
+                inferType = inferType.types[inferType.types.length-1];
             }
 
             if (inferType instanceof Tern.Prim) {

--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -63,11 +63,7 @@
     ],
     "edit.splitSelIntoLines": [
         {
-           "key": "Ctrl-Alt-L"
-        },
-        {
-           "key":"Ctrl-Shift-L",
-           "platform": "linux"
+           "key": "Ctrl-Shift-L"
         }
     ],
     "edit.addCursorToPrevLine": [

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -676,6 +676,8 @@ define(function (require, exports, module) {
      * @param {Editor} editor
      */
     function _startNewSession(editor) {
+        const SHOW_PARAMETER_HINT_CMD_ID = "showParameterHint";
+        CommandManager.execute(SHOW_PARAMETER_HINT_CMD_ID);
         if (isOpen()) {
             return;
         }

--- a/src/features/JumpToDefManager.js
+++ b/src/features/JumpToDefManager.js
@@ -42,42 +42,43 @@ define(function (require, exports, module) {
      * provider responded or the provider that responded failed.
      */
     function _doJumpToDef() {
-        var request = null,
+        let request = null,
             result = new $.Deferred(),
             jumpToDefProvider = null,
             editor = EditorManager.getActiveEditor();
 
-        if (editor) {
-            // Find a suitable provider, if any
-            var language = editor.getLanguageForSelection(),
-                enabledProviders = _providerRegistrationHandler.getProvidersForLanguageId(language.getId());
-
-
-            enabledProviders.some(function (item, index) {
-                if (item.provider.canJumpToDef(editor)) {
-                    jumpToDefProvider = item.provider;
-                    return true;
-                }
-            });
-
-            if (jumpToDefProvider) {
-                request = jumpToDefProvider.doJumpToDef(editor);
-
-                if (request) {
-                    request.done(function () {
-                        result.resolve();
-                    }).fail(function () {
-                        result.reject();
-                    });
-                } else {
-                    result.reject();
-                }
-            } else {
-                result.reject();
-            }
-        } else {
+        if (!editor) {
             result.reject();
+            return result.promise();
         }
+        // Find a suitable provider, if any
+        let language = editor.getLanguageForSelection(),
+            enabledProviders = _providerRegistrationHandler.getProvidersForLanguageId(language.getId());
+
+
+        enabledProviders.some(function (item, index) {
+            if (item.provider.canJumpToDef(editor)) {
+                jumpToDefProvider = item.provider;
+                return true;
+            }
+        });
+
+        if (!jumpToDefProvider) {
+            result.reject();
+            return result.promise();
+        }
+        request = jumpToDefProvider.doJumpToDef(editor);
+
+        if (!request) {
+            result.reject();
+            return result.promise();
+        }
+
+        request.done(function () {
+            result.resolve();
+        }).fail(function () {
+            result.reject();
+        });
 
         return result.promise();
     }

--- a/test/spec/KeyBindingManager-test.js
+++ b/test/spec/KeyBindingManager-test.js
@@ -45,7 +45,7 @@ define(function (require, exports, module) {
 
     var defaultKeyBindings = {
             "Ctrl-L": "edit.selectLine",
-            "Ctrl-Alt-L": "edit.splitSelIntoLines",
+            "Ctrl-Shift-L": "edit.splitSelIntoLines",
             "Alt-Shift-Down": "edit.addCursorToNextLine",
             "Alt-Shift-Up": "edit.addCursorToPrevLine",
             "F8": "navigate.gotoFirstProblem",

--- a/test/spec/MainViewManager-integ-test.js
+++ b/test/spec/MainViewManager-integ-test.js
@@ -76,7 +76,7 @@ define(function (require, exports, module) {
             EditorManager           = null;
             ProjectManager          = null;
             FileSystem              = null;
-            await SpecRunnerUtils.closeTestWindow();
+            //await SpecRunnerUtils.closeTestWindow();
         });
 
         beforeEach(async function () {


### PR DESCRIPTION
* We will now display function parameter hints when `ctrl-space` is typed.
* Ctrl-click to jump to definition. - UI underline update pending.
* change `edit.splitSelIntoLines` short cut to `Ctrl-Shift-L`
* Change key binding manager to not blindly swallow undo/copy paste related commands

![image](https://user-images.githubusercontent.com/5336369/185440965-02afd48d-fce8-4c30-97ec-2c6d9d53ec99.png)

![image](https://user-images.githubusercontent.com/5336369/185441103-3b4003e6-7ca1-4b14-8eb1-7ea8a869f48a.png)

