### PR TITLE
feat: code inspection hover error quickview

### DIFF
--- a/src/extensions/default/JSHint/main.js
+++ b/src/extensions/default/JSHint/main.js
@@ -96,7 +96,7 @@ define(function (require, exports, module) {
                     errors = errors.map(function (lintError) {
                         return {
                             // JSLint returns 1-based line/col numbers
-                            pos: { line: lintError.line - 1, ch: lintError.character - 1 },
+                            pos: { line: lintError.line - 1, ch: lintError.character },
                             message: `${lintError.reason} jshint (${lintError.code})`,
                             type: CodeInspection.Type.ERROR
                         };

--- a/src/features/QuickViewManager.js
+++ b/src/features/QuickViewManager.js
@@ -175,7 +175,7 @@ define(function (require, exports, module) {
         // Time (ms) mouse must remain over a provider's matched text before popover appears
         HOVER_DELAY                 = 500,
         // Pointer height, used to shift popover above pointer (plus a little bit of space)
-        POINTER_HEIGHT              = 15,
+        POINTER_HEIGHT              = 10,
         POPOVER_HORZ_MARGIN         =  5;   // Horizontal margin
 
     prefs = PreferencesManager.getExtensionPrefs("quickview");
@@ -222,10 +222,6 @@ define(function (require, exports, module) {
         if (!popoverState) {
             return;
         }
-        if(popoverState.resizeObserver){
-            popoverState.resizeObserver.disconnect();
-        }
-        popoverState.resizeObserver = null;
 
         if (popoverState.visible) {
             popoverState.marker.clear();
@@ -376,10 +372,9 @@ define(function (require, exports, module) {
             popoverState.visible = true;
             positionPreview(editor, popoverState.xpos, popoverState.ytop, popoverState.ybot);
 
-            popoverState.resizeObserver = new ResizeObserver(() => {
+            $popoverContent[0].addEventListener('DOMSubtreeModified', ()=>{
                 positionPreview(editor, popoverState.xpos, popoverState.ytop, popoverState.ybot);
-            });
-            popoverState.resizeObserver.observe($popoverContent[0]);
+            }, false);
         }
     }
 

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -1672,6 +1672,8 @@ a, img {
 
     padding: 8px;
     text-align: center;
+    max-width: 75%;
+    max-height: 75%;
 
     border-radius: 4px;
     box-shadow: 0 4px 15px @bc-shadow-large;
@@ -1693,27 +1695,6 @@ a, img {
 
 #quick-view-container.preview-bubble-above:before {
     display: none;
-}
-
-#quick-view-container.preview-bubble-above:after,
-#quick-view-container.preview-bubble-below:before {
-    width: 0;
-    height: 0;
-    content: '';
-    position: absolute;
-    left: 50%;
-    bottom: -9px;
-    margin-left: -10px;
-    z-index: 999;
-    display: block;
-    border-top: 10px solid @bc-panel-bg;
-    border-left: 10px solid transparent;
-    border-right: 10px solid transparent;
-    -webkit-filter: drop-shadow(0px 1px 0 rgba(0, 0, 0, 0.18));
-
-    .dark & {
-        border-top: 10px solid @dark-bc-panel-bg;
-    }
 }
 
 #quick-view-container.preview-bubble-below {


### PR DESCRIPTION
* wired code inspection error messages to quickview
* Fix bug where js hint errors where being offset by 1 char
* removed the pointy thing as aligning it to ui anchor editor chars were proving difficult.

![code error hover](https://user-images.githubusercontent.com/5336369/186202562-5268f4e4-a72a-44e9-98d9-dfa9404f7393.gif)
