### PR TITLE
fix: selecting text with double click should not show references highlight

### DIFF
--- a/src/extensions/default/JavaScriptRefactoring/HighLightReferences.js
+++ b/src/extensions/default/JavaScriptRefactoring/HighLightReferences.js
@@ -104,6 +104,11 @@ define(function (require, exports, module) {
             return;
         }
 
+        if(!_hasASingleCursor(editor)){
+            editor.clearAllMarks(HIGHLIGHT_REFS_MARKER);
+            return;
+        }
+
         let token = editor.getToken();
         if(lastHighlightToken === token) {
             return;
@@ -116,10 +121,6 @@ define(function (require, exports, module) {
         }
 
         let offset = session.getOffset();
-
-        if(!_hasASingleCursor(editor)){
-            return;
-        }
 
         // only do this request if token under cursor is a variable type
         requestFindRefs(session, session.editor.document, offset).promise

--- a/src/extensions/default/JavaScriptRefactoring/unittests.js
+++ b/src/extensions/default/JavaScriptRefactoring/unittests.js
@@ -699,6 +699,17 @@ define(function (require, exports, module) {
                 expect(testEditor.getAllMarks(HighLightReferences.HIGHLIGHT_REFS_MARKER).length).toBe(0);
             });
 
+            it("should not highlight if selection range changes within same token", async function() {
+                // selection at `test1`
+                testEditor.setSelection({line: 18, ch: 4}, {line: 18, ch: 9});
+                await awaits(500); // wait for code indexing workers to prime
+                expect(testEditor.getAllMarks(HighLightReferences.HIGHLIGHT_REFS_MARKER).length).toBe(0);
+                // now change selection to `est`
+                testEditor.setSelection({line: 18, ch: 5}, {line: 18, ch: 8});
+                await awaits(500); // wait for code indexing workers to prime
+                expect(testEditor.getAllMarks(HighLightReferences.HIGHLIGHT_REFS_MARKER).length).toBe(0);
+            });
+
             it("should not highlight if multiple cursors present", async function() {
                 testEditor.setSelections([{start:{line: 18, ch: 7}}, {start:{line: 18, ch: 8}}]);
                 await awaits(500); // wait for code indexing workers to prime


### PR DESCRIPTION
## before
![image](https://user-images.githubusercontent.com/5336369/186340964-e283495c-f533-44da-baea-5589b40d0cdf.png)

## with fix
![image](https://user-images.githubusercontent.com/5336369/186341091-9cad7bc7-65e2-4b69-8345-95cf6050274d.png)
