### PR TITLE
feat: selection view now follows the last mouse cursor

### DIFF
--- a/src/features/QuickViewManager.js
+++ b/src/features/QuickViewManager.js
@@ -154,7 +154,6 @@ define(function (require, exports, module) {
         Strings             = require("strings"),
         ViewUtils           = require("utils/ViewUtils"),
         AppInit             = require("utils/AppInit"),
-        SelectionViewManager= require("features/SelectionViewManager"),
         ProviderRegistrationHandler = require("features/PriorityBasedRegistration").RegistrationHandler;
 
     const previewContainerHTML       = '<div id="quick-view-container">\n' +

--- a/src/features/SelectionViewManager.js
+++ b/src/features/SelectionViewManager.js
@@ -171,6 +171,8 @@ define(function (require, exports, module) {
     let enabled,                             // Only show preview if true
         prefs                      = null,   // Preferences
         $previewContainer,                   // Preview container
+        lastMouseX = 0,
+        lastMouseY = 0,
         $previewContent;                     // Preview content holder
 
     // Constants
@@ -229,16 +231,14 @@ define(function (require, exports, module) {
     }
 
     function positionPreview(editor) {
-        let xpos = popoverState.xpos,
-            ypos = popoverState.ytop,
-            ybot = popoverState.ybot;
+        let ybot = popoverState.ybot;
         if ($previewContent.find("#selection-view-popover-root").is(':empty')){
             hidePreview();
             return;
         }
         let previewWidth  = $previewContainer.outerWidth(),
-            top           = ypos - $previewContainer.outerHeight() - POINTER_HEIGHT,
-            left          = xpos - previewWidth / 2,
+            top           = lastMouseY - $previewContainer.outerHeight() - POINTER_HEIGHT,
+            left          = lastMouseX - previewWidth / 2,
             elementRect = {
                 top: top,
                 left: left - POPOVER_HORZ_MARGIN,
@@ -403,6 +403,8 @@ define(function (require, exports, module) {
     }
 
     function _processMouseMove(event) {
+        lastMouseX= event.clientX;
+        lastMouseY= event.clientY;
         if (event.buttons !== 0) {
             // Button is down - don't show popovers while dragging
             return;
@@ -424,8 +426,7 @@ define(function (require, exports, module) {
                 //this is just a cursor
                 return;
             }
-            if (editor.posWithinRange(mousePos, selection.start, selection.end, true) &&
-                (mousePos.ch < editor.document.getLine(mousePos.line).length)) {
+            if (editor.posWithinRange(mousePos, selection.start, selection.end, true)) {
                 popoverState = {};
                 showPreview(editor, selectionObj);
             }


### PR DESCRIPTION
* The selection view will be displayed near the mouse position to ensure minimal hand movement to click the selection view

# before
![image](https://user-images.githubusercontent.com/5336369/186463980-3a0b4f62-bc64-4ea0-a496-fd0ce3e54c6d.png)

# now
![selection view mouse](https://user-images.githubusercontent.com/5336369/186463332-98cf2509-3287-4412-826c-0c1ce16f5b90.gif)

