### PR TITLE
dev.phcode.dev will be deployed to its own repo

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -1,8 +1,8 @@
-name: Deploy Notification To staging.phcode.dev
+name: Deploy Notification To dev.phcode.dev
 
 on:
   push:
-    branches: [ staging ]
+    branches: [ main ]
 
 jobs:
   build-tasks:
@@ -14,11 +14,11 @@ jobs:
           npm install
       - name: Verifying release artifact build
         run: |
-          npm run release:staging
-      - name: Deploy Notification To staging.phcode.dev repository
+          npm run release:dev
+      - name: Deploy Notification To dev.phcode.dev repository
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.PAT_PHOENIX_BOT_PUBLIC_REPO_ACCESS }}
-          repository: phcode-dev/staging.phcode.dev
-          event-type: deploy-staging
+          repository: phcode-dev/dev.phcode.dev
+          event-type: deploy-dev
           client-payload: '{"source":"${{github.repositoryUrl}}", "workflow":"${{github.workflow}}", "run_id":"${{github.run_id}}", "run_number":"${{github.run_number}}", "ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -1,29 +1,24 @@
-name: Deploying to dev.phcode.dev for dev testing in this repo
-# All changes to the main branch is instantly deployed to dev in this repo
+name: Deploy Notification To staging.phcode.dev
+
 on:
   push:
-    branches: [ main ]
+    branches: [ staging ]
 
 jobs:
   build-tasks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-
-      - name: Building phoenix release artifacts
+      - uses: actions/checkout@v2
+      - name: Npm Install
         run: |
           npm install
-          npm run release:dev
-          npm run test
-          cp -r dist distToDeploy/
-          cp -r dist distToDeploy/src/
-          cp -r test distToDeploy/test/
-        shell: bash
-
-      - name: Deploy dist folder to Github Pages
-        uses: peaceiris/actions-gh-pages@v3
-        if: github.ref == 'refs/heads/main'
+      - name: Verifying release artifact build
+        run: |
+          npm run release:staging
+      - name: Deploy Notification To staging.phcode.dev repository
+        uses: peter-evans/repository-dispatch@v2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./distToDeploy
-          cname: dev.phcode.dev
+          token: ${{ secrets.PAT_PHOENIX_BOT_PUBLIC_REPO_ACCESS }}
+          repository: phcode-dev/staging.phcode.dev
+          event-type: deploy-staging
+          client-payload: '{"source":"${{github.repositoryUrl}}", "workflow":"${{github.workflow}}", "run_id":"${{github.run_id}}", "run_number":"${{github.run_number}}", "ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-phoenix.core.ai


### PR DESCRIPTION
- ci: dev.phcode.dev will be deployed to its own repo

Currently, all the release artifacts are deployed to a branch in the main phcode src repo itself which is consuming unwanted binary space in this repo. The repo size is bloating to over 140 mb. So we are moving built artifacts into its own repo.
