### PR TITLE
feat: Report os triggered light/dark mode change to EventDispacher

### DIFF
--- a/src/view/ThemeManager.js
+++ b/src/view/ThemeManager.js
@@ -409,6 +409,9 @@ define(function (require, exports, module) {
         // listen to system dark/light theme changes
         console.log(`System theme changed to ${e.matches ? "dark" : "light"} mode`);
         refresh(true);
+        
+        // Report os preference change also as a theme change
+        exports.trigger("themeChange", getCurrentTheme());
     });
 
     prefs.on("change", "theme", function () {


### PR DESCRIPTION
The theme change triggered by, os preference change is handled slightly differently(as compared to user switching). hence, it does not get reported to the event dispatcher. This commit fixed that.

- current state ( os triggered theme change is not reported to the event Dispatcher)
![Screenrecorder-2022-09-04-13-19-45-251_AdobeExpress](https://user-images.githubusercontent.com/78793827/188305408-f8d90440-a1a4-4658-b13d-d8a61cb96c22.gif)


- with this change ( dark /light mode change is reported to event dispatcher)
![Screenrecorder-2022-09-04-13-23-27-808_AdobeExpress](https://user-images.githubusercontent.com/78793827/188305063-02a24aeb-187a-4c41-a335-cfa50e223d18.gif)

