### PR TITLE
fix: inconsistant load failures on very slow networks

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -66,6 +66,7 @@ define(function (require, exports, module) {
     require("thirdparty/CodeMirror/addon/selection/mark-selection");
     require("thirdparty/CodeMirror/keymap/sublime");
 
+    // Event dispatcher must be loaded before worker comm https://github.com/phcode-dev/phoenix/pull/678
     require("utils/EventDispatcher");
     require("worker/WorkerComm");
 

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -66,6 +66,9 @@ define(function (require, exports, module) {
     require("thirdparty/CodeMirror/addon/selection/mark-selection");
     require("thirdparty/CodeMirror/keymap/sublime");
 
+    require("utils/EventDispatcher");
+    require("worker/WorkerComm");
+
     // Load dependent modules
     const AppInit             = require("utils/AppInit"),
         LanguageManager     = require("language/LanguageManager"),

--- a/src/worker/ExtensionsWorker.js
+++ b/src/worker/ExtensionsWorker.js
@@ -63,8 +63,8 @@
  * @module worker/ExtensionsWorker
  */
 define(function (require, exports, module) {
-    const WorkerComm = require("worker/WorkerComm"),
-        EventDispatcher = require("utils/EventDispatcher");
+    const EventDispatcher = require("utils/EventDispatcher"),
+        WorkerComm = require("worker/WorkerComm");
 
     const _ExtensionsWorker = new Worker(
         `${Phoenix.baseURL}worker/extensions-worker-thread.js?debug=${window.logToConsolePref === 'true'}`);

--- a/src/worker/IndexingWorker.js
+++ b/src/worker/IndexingWorker.js
@@ -66,8 +66,8 @@
  * @module worker/IndexingWorker
  */
 define(function (require, exports, module) {
-    const WorkerComm = require("worker/WorkerComm"),
-        EventDispatcher = require("utils/EventDispatcher");
+    const EventDispatcher = require("utils/EventDispatcher"),
+        WorkerComm = require("worker/WorkerComm");
 
     const _FileIndexingWorker = new Worker(
         `${Phoenix.baseURL}worker/file-Indexing-Worker-thread.js?debug=${window.logToConsolePref === 'true'}`);


### PR DESCRIPTION
* EventDispatcher module must be loaded before workerComm Module.
* Sometimes, in slow networks this load was done out of order. Now during brackets.js app start, we do the pre- require load in correct order so that modules may load in any order.
