### PR TITLE
chore: live preview use broadcast channel instead of service worker for inter window messaging

### DIFF
--- a/src/virtual-server-main.js
+++ b/src/virtual-server-main.js
@@ -284,6 +284,7 @@ addEventListener('message', (event) => {
             event.ports[0].postMessage({baseURL}); break;
         case 'CLEAR_CACHE': _clearCache(); break;
         case 'REFRESH_CACHE': _refreshCache(event); break;
+        case 'setInstrumentedURLs': self.Serve.setInstrumentedURLs(event); return true;
         default:
             let msgProcessed = self.Serve && self.Serve.processVirtualServerMessage &&
                 self.Serve.processVirtualServerMessage(event);


### PR DESCRIPTION
* improves stability as the service woker may be killed anytime by the browser as needed and we do not need to constantly ping the reliability if the service worker