### PR TITLE
fix: live preview will not close while navigating to md/svg or other non html live previews

### DIFF
--- a/src/LiveDevelopment/LiveDevMultiBrowser.js
+++ b/src/LiveDevelopment/LiveDevMultiBrowser.js
@@ -545,15 +545,9 @@ define(function (require, exports, module) {
                         }
                     })
                     .on("ConnectionClose.livedev", function (event, msg) {
-                        // close session when the last connection was closed
-                        if (_protocol.getConnectionIds().length === 0) {
-                            setTimeout(function () {
-                                if (_protocol.getConnectionIds().length === 0 &&
-                                        exports.status <= STATUS_ACTIVE) {
-                                    _close(false, "detached_target_closed");
-                                }
-                            }, 5000);
-                        }
+                        window.loggingOptions.livePreview.log(
+                            "Live Preview: Phoenix received ConnectionClose, live preview left: ",
+                            _protocol.getConnectionIds().length);
                     })
                     // extract stylesheets and create related LiveCSSDocument instances
                     .on("DocumentRelated.livedev", function (event, msg) {

--- a/src/LiveDevelopment/MultiBrowserImpl/transports/ServiceWorkerTransport.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/transports/ServiceWorkerTransport.js
@@ -61,9 +61,8 @@ define(function (require, exports, module) {
             });
         });
         _broadcastChannel.onmessage = (event) => {
-            if(window.loggingOptions.logLivePreview){
-                console.log("Live Preview: Phoenix received event from Browser preview tab/iframe: ", event.data);
-            }
+            window.loggingOptions.livePreview.log(
+                "Live Preview: Phoenix received event from Browser preview tab/iframe: ", event.data);
             const type = event.data.type;
             switch (type) {
             case 'BROWSER_CONNECT': exports.trigger('connect', [event.data.clientID, event.data.url]); break;

--- a/src/index.html
+++ b/src/index.html
@@ -89,6 +89,13 @@
             LOCAL_STORAGE_KEYS: {
                 LOG_LIVE_PREVIEW: "logLivePreview"
             },
+            livePreview: {
+                log: function (...args) {
+                    if(window.loggingOptions.logLivePreview){
+                        console.log(...args);
+                    }
+                }
+            }
         };
         window.loggingOptions.logLivePreview = window.isLoggingEnabled(
             window.loggingOptions.LOCAL_STORAGE_KEYS.LOG_LIVE_PREVIEW);


### PR DESCRIPTION
Earlier, when we navigated to a non HTML/CSS file (Eg. markdown file), after 5 seconds, live preview session used to close. Since Phoenix live previews are always on, removed the code.

Minor refactor of live preview logging.