### PR TITLE
fix: live preview panel long title trim

### DIFF
--- a/src/extensions/default/Phoenix-live-preview/live-preview.css
+++ b/src/extensions/default/Phoenix-live-preview/live-preview.css
@@ -12,6 +12,13 @@
     background-color: white;
 }
 
+#panel-live-preview-title {
+    max-width: 50%;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+}
+
 .frame-container {
     display: flex;
     width: 100%;

--- a/src/extensions/default/Phoenix-live-preview/main.js
+++ b/src/extensions/default/Phoenix-live-preview/main.js
@@ -136,11 +136,14 @@ define(function (require, exports, module) {
     }
 
     function _setTitle(fileName) {
-        let message = Strings.LIVE_DEV_SELECT_FILE_TO_PREVIEW;
+        let message = Strings.LIVE_DEV_SELECT_FILE_TO_PREVIEW,
+            tooltip = message;
         if(fileName){
             message = `${fileName} - ${Strings.LIVE_DEV_STATUS_TIP_OUT_OF_SYNC}`;
+            tooltip = `${Strings.LIVE_DEV_STATUS_TIP_OUT_OF_SYNC} - ${fileName}`;
         }
-        document.getElementById("panel-live-preview-title").textContent = `${message}`;
+        document.getElementById("panel-live-preview-title").textContent = message;
+        document.getElementById("live-preview-plugin-toolbar").title = tooltip;
     }
 
     async function _createExtensionPanel() {

--- a/src/extensions/default/Phoenix-live-preview/panel.html
+++ b/src/extensions/default/Phoenix-live-preview/panel.html
@@ -1,5 +1,5 @@
 <div id="panel-live-preview">
-    <div class="plugin-toolbar" title="Live Preview (experimental)" style="display: flex; align-items: center; flex-direction: row;">
+    <div id="live-preview-plugin-toolbar" class="plugin-toolbar" title="Live Preview" style="display: flex; align-items: center; flex-direction: row;">
         <div id="left-buttons" style="position: absolute; left: 0px;">
             <button id="reloadButton" title="{{clickToReload}}" class="btn-alt-quiet toolbar-button reload-icon"></button>
         </div>


### PR DESCRIPTION
![trim live preview title](https://user-images.githubusercontent.com/5336369/205447401-74c7e472-209a-43dd-bffe-8a798ce6b03a.gif)

Live preview titles are now trimmed to 50% of available width after which its ellipsed.