### PR TITLE
live preview auto enable and disable based on UX context

### DIFF
--- a/src/LiveDevelopment/LiveDevMultiBrowser.js
+++ b/src/LiveDevelopment/LiveDevMultiBrowser.js
@@ -68,6 +68,7 @@ define(function (require, exports, module) {
 
     // events
     const EVENT_OPEN_PREVIEW_URL = "openPreviewURL",
+        EVENT_CONNECTION_CLOSE = "ConnectionClose",
         EVENT_STATUS_CHANGE = "statusChange";
 
     const CommandManager       = require("command/CommandManager"),
@@ -542,10 +543,11 @@ define(function (require, exports, module) {
                             }
                         }
                     })
-                    .on("ConnectionClose.livedev", function (event, msg) {
+                    .on("ConnectionClose.livedev", function (event, {clientId}) {
+                        exports.trigger(EVENT_CONNECTION_CLOSE, {clientId});
                         window.loggingOptions.livePreview.log(
                             "Live Preview: Phoenix received ConnectionClose, live preview left: ",
-                            _protocol.getConnectionIds().length);
+                            _protocol.getConnectionIds().length, clientId);
                     })
                     // extract stylesheets and create related LiveCSSDocument instances
                     .on("DocumentRelated.livedev", function (event, msg) {
@@ -886,6 +888,14 @@ define(function (require, exports, module) {
         return _liveDocument;
     }
 
+    /**
+     * Returns an array of the client IDs that are being managed by this live document.
+     * @return {Array.<number>}
+     */
+    function getConnectionIds() {
+        return _protocol.getConnectionIds();
+    }
+
     EventDispatcher.makeEventDispatcher(exports);
 
     // For unit testing
@@ -894,6 +904,7 @@ define(function (require, exports, module) {
 
     // Events
     exports.EVENT_OPEN_PREVIEW_URL = EVENT_OPEN_PREVIEW_URL;
+    exports.EVENT_CONNECTION_CLOSE = EVENT_CONNECTION_CLOSE;
     exports.EVENT_STATUS_CHANGE = EVENT_STATUS_CHANGE;
 
     // Export public functions
@@ -911,5 +922,6 @@ define(function (require, exports, module) {
     exports.getServerBaseUrl    = getServerBaseUrl;
     exports.getCurrentLiveDoc   = getCurrentLiveDoc;
     exports.getCurrentProjectServerConfig = getCurrentProjectServerConfig;
+    exports.getConnectionIds = getConnectionIds;
     exports.setTransport        = setTransport;
 });

--- a/src/LiveDevelopment/main.js
+++ b/src/LiveDevelopment/main.js
@@ -136,6 +136,10 @@ define(function main(require, exports, module) {
         }
     }
 
+    function isInactive() {
+        return MultiBrowserLiveDev.status <= MultiBrowserLiveDev.STATUS_INACTIVE;
+    }
+
     function setLivePreviewPinned(urlPinned) {
         MultiBrowserLiveDev.setLivePreviewPinned(urlPinned);
     }
@@ -270,6 +274,9 @@ define(function main(require, exports, module) {
         MultiBrowserLiveDev.on(MultiBrowserLiveDev.EVENT_OPEN_PREVIEW_URL, function (event, previewDetails) {
             exports.trigger(exports.EVENT_OPEN_PREVIEW_URL, previewDetails);
         });
+        MultiBrowserLiveDev.on(MultiBrowserLiveDev.EVENT_CONNECTION_CLOSE, function (event, {clientId}) {
+            exports.trigger(exports.EVENT_CONNECTION_CLOSE, {clientId});
+        });
 
     });
 
@@ -292,9 +299,12 @@ define(function main(require, exports, module) {
 
     // public events
     exports.EVENT_OPEN_PREVIEW_URL = MultiBrowserLiveDev.EVENT_OPEN_PREVIEW_URL;
+    exports.EVENT_CONNECTION_CLOSE = MultiBrowserLiveDev.EVENT_CONNECTION_CLOSE;
 
     // Export public functions
     exports.openLivePreview = openLivePreview;
     exports.closeLivePreview = closeLivePreview;
+    exports.isInactive = isInactive;
     exports.setLivePreviewPinned = setLivePreviewPinned;
+    exports.getConnectionIds = MultiBrowserLiveDev.getConnectionIds;
 });

--- a/src/extensions/default/Phoenix-live-preview/utils.js
+++ b/src/extensions/default/Phoenix-live-preview/utils.js
@@ -78,7 +78,8 @@ define(function (require, exports, module) {
                         const relativePath = path.relative(projectRoot, file.fullPath);
                         resolve({
                             URL: `${projectRootUrl}${relativePath}`,
-                            filePath: relativePath
+                            filePath: relativePath,
+                            fullPath: file.fullPath
                         });
                         return;
                     }


### PR DESCRIPTION
- Open the appropriate document in the editor if a user clicks on the live preview and that doc is not open in the editor.
- feat: live preview auto enable and disable based on UX context
- feat: stop live preview if there is no live preview tab/iframe open
