### PR TITLE
chore: live preview metrics

### DIFF
--- a/src/LiveDevelopment/LiveDevMultiBrowser.js
+++ b/src/LiveDevelopment/LiveDevMultiBrowser.js
@@ -88,7 +88,7 @@ define(function (require, exports, module) {
         LiveDevServerManager = require("LiveDevelopment/LiveDevServerManager"),
         ServiceWorkerTransport  = require("LiveDevelopment/MultiBrowserImpl/transports/ServiceWorkerTransport"),
         LiveDevProtocol      = require("LiveDevelopment/MultiBrowserImpl/protocol/LiveDevProtocol"),
-        Metrics              = require("utils/Metrics");;
+        Metrics              = require("utils/Metrics");
 
     // Documents
     const LiveCSSDocument      = require("LiveDevelopment/MultiBrowserImpl/documents/LiveCSSDocument"),

--- a/src/LiveDevelopment/LiveDevMultiBrowser.js
+++ b/src/LiveDevelopment/LiveDevMultiBrowser.js
@@ -87,7 +87,8 @@ define(function (require, exports, module) {
         LiveDevelopmentUtils = require("LiveDevelopment/LiveDevelopmentUtils"),
         LiveDevServerManager = require("LiveDevelopment/LiveDevServerManager"),
         ServiceWorkerTransport  = require("LiveDevelopment/MultiBrowserImpl/transports/ServiceWorkerTransport"),
-        LiveDevProtocol      = require("LiveDevelopment/MultiBrowserImpl/protocol/LiveDevProtocol");
+        LiveDevProtocol      = require("LiveDevelopment/MultiBrowserImpl/protocol/LiveDevProtocol"),
+        Metrics              = require("utils/Metrics");;
 
     // Documents
     const LiveCSSDocument      = require("LiveDevelopment/MultiBrowserImpl/documents/LiveCSSDocument"),
@@ -542,6 +543,8 @@ define(function (require, exports, module) {
                                 _setStatus(STATUS_ACTIVE);
                             }
                         }
+                        Metrics.countEvent(Metrics.EVENT_TYPE.LIVE_PREVIEW, "connect",
+                            `${_protocol.getConnectionIds().length}-preview`);
                     })
                     .on("ConnectionClose.livedev", function (event, {clientId}) {
                         exports.trigger(EVENT_CONNECTION_CLOSE, {clientId});

--- a/src/extensions/default/Phoenix-live-preview/main.js
+++ b/src/extensions/default/Phoenix-live-preview/main.js
@@ -136,6 +136,7 @@ define(function (require, exports, module) {
         urlPinned = !pinStatus;
         LiveDevelopment.setLivePreviewPinned(urlPinned);
         _loadPreview();
+        Metrics.countEvent(Metrics.EVENT_TYPE.LIVE_PREVIEW, "pinURLBtn", "click");
     }
 
     function _popoutLivePreview() {
@@ -188,6 +189,7 @@ define(function (require, exports, module) {
             LiveDevelopment.closeLivePreview();
             LiveDevelopment.openLivePreview();
             _loadPreview(true);
+            Metrics.countEvent(Metrics.EVENT_TYPE.LIVE_PREVIEW, "reloadBtn", "click");
         });
     }
 

--- a/src/extensions/default/Phoenix-live-preview/main.js
+++ b/src/extensions/default/Phoenix-live-preview/main.js
@@ -141,6 +141,7 @@ define(function (require, exports, module) {
     function _popoutLivePreview() {
         if(!tab || tab.closed){
             tab = open();
+            Metrics.countEvent(Metrics.EVENT_TYPE.LIVE_PREVIEW, "popoutBtn", "click");
         }
         _loadPreview(true);
     }


### PR DESCRIPTION
* Added metrics for the number and size of live preview transport messages sent. Will help to identify the scale of backend needed for advanced live preview services.
* Metrics for live preview tab popout, reload and pin
* Number of concurrent live previews used.