### PR TITLE
feat: live preview will not reload on save for html files

### DIFF
--- a/src/extensions/default/Phoenix-live-preview/main.js
+++ b/src/extensions/default/Phoenix-live-preview/main.js
@@ -281,11 +281,16 @@ define(function (require, exports, module) {
         }
     }
 
-    function _projectFileChanges(evt, changedFile) {
+    async function _projectFileChanges(evt, changedFile) {
         if(changedFile && changedFile.isFile && changedFile.fullPath && changedFile.fullPath !== '/fs/app/state.json'){
             // we are getting this change event somehow.
             // bug, investigate why we get this change event as a project file change.
-            _loadPreview(true);
+            const previewDetails = await utils.getPreviewDetails();
+            if(!(LiveDevelopment.isActive() && previewDetails.isHTMLFile)) {
+                // We force reload live preview on save for all non html preview-able file or
+                // if html file and live preview isnt active.
+                _loadPreview(true);
+            }
             _showPopoutNotificationIfNeeded(changedFile.fullPath);
         }
     }

--- a/src/extensions/default/Phoenix-live-preview/utils.js
+++ b/src/extensions/default/Phoenix-live-preview/utils.js
@@ -61,6 +61,11 @@ define(function (require, exports, module) {
         return ['md', 'markdown'].includes(extension.toLowerCase());
     }
 
+    function _isHTMLFile(filePath) {
+        let extension = getExtension(filePath);
+        return ['html', 'htm'].includes(extension.toLowerCase());
+    }
+
     function getNoPreviewURL(){
         return `${window.Phoenix.baseURL}assets/phoenix-splash/no-preview.html`;
     }
@@ -79,7 +84,8 @@ define(function (require, exports, module) {
                         resolve({
                             URL: `${projectRootUrl}${relativePath}`,
                             filePath: relativePath,
-                            fullPath: file.fullPath
+                            fullPath: file.fullPath,
+                            isHTMLFile: _isHTMLFile(file.fullPath)
                         });
                         return;
                     }
@@ -116,7 +122,8 @@ define(function (require, exports, module) {
                             URL: httpFilePath || `${projectRootUrl}${filePath}`,
                             filePath: filePath,
                             fullPath: fullPath,
-                            isMarkdownFile: _isMarkdownFile(fullPath)
+                            isMarkdownFile: _isMarkdownFile(fullPath),
+                            isHTMLFile: _isHTMLFile(fullPath)
                         });
                     } else {
                         resolve({}); // not a previewable file


### PR DESCRIPTION
Earlier for every save live preview used to get reloaded, causing flickering and bad UX. 
With this change, we force reload live preview on save
* for all non-HTML preview-able files only
* or if HTML file and live preview isn't active.