### PR TITLE
ctrl-click to jump to definition on html files

### DIFF
--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -268,6 +268,7 @@ define(function (require, exports, module) {
         // editor_cmenu.addMenuItem(Commands.NAVIGATE_JUMPTO_DEFINITION);
         editor_cmenu.addMenuItem(Commands.TOGGLE_QUICK_EDIT);
         editor_cmenu.addMenuItem(Commands.TOGGLE_QUICK_DOCS);
+        editor_cmenu.addMenuItem(Commands.NAVIGATE_JUMPTO_DEFINITION);
         editor_cmenu.addMenuItem(Commands.CMD_FIND_ALL_REFERENCES);
         editor_cmenu.addMenuDivider();
         editor_cmenu.addMenuItem(Commands.EDIT_CUT);

--- a/src/extensions/default/HTMLCodeHints/HTMLJumpToDef.js
+++ b/src/extensions/default/HTMLCodeHints/HTMLJumpToDef.js
@@ -1,0 +1,87 @@
+/*
+ * GNU AGPL-3.0 License
+ *
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
+ *
+ */
+
+/*global path */
+
+define(function (require, exports, module) {
+
+    const AppInit = brackets.getModule("utils/AppInit"),
+        JumpToDefManager = brackets.getModule("features/JumpToDefManager"),
+        CommandManager     = brackets.getModule("command/CommandManager"),
+        Commands           = brackets.getModule("command/Commands"),
+        FileViewController = brackets.getModule("project/FileViewController");
+
+    function HTMLJumpToDefProvider() {
+    }
+
+    /**
+     * Check to see if the html token under token os of the form href="file" or src="file"
+     * @param editor
+     * @param token
+     * @private
+     */
+    function _isSrcOrHrefString(editor, token) {
+        if(token.type !== "string"){
+            return false;
+        }
+        const equalsToken = editor.getPreviousToken({line: token.line, ch: token.start+1}); // possble = token
+        const hrefOrSrcToken = editor.getPreviousToken({line: equalsToken.line, ch: equalsToken.start+1});
+        return (equalsToken.string === "=" && ["href", "src"].includes(hrefOrSrcToken.string));
+    }
+
+    const jumpTokenTypes = ["tag", "string"];
+
+    HTMLJumpToDefProvider.prototype.canJumpToDef = function (editor, optionalPosition) {
+        let pos = optionalPosition || editor.getCursorPos();
+        let token = editor.getToken(pos);
+        if(token && token.type && jumpTokenTypes.includes(token.type)){
+            return true;
+        }
+        return false;
+    };
+
+    function _openFile(fileRelativePath, mainDocPath) {
+        if(fileRelativePath.startsWith("http://") || fileRelativePath.startsWith("https://")){
+            return FileViewController.openAndSelectDocument(fileRelativePath, FileViewController.PROJECT_MANAGER);
+        }
+        const targetPath = path.resolve(mainDocPath, fileRelativePath);
+        return FileViewController.openAndSelectDocument(targetPath, FileViewController.PROJECT_MANAGER);
+    }
+
+    /**
+     * Method to handle jump to definition feature.
+     */
+    HTMLJumpToDefProvider.prototype.doJumpToDef = function (editor) {
+        if(!this.canJumpToDef(editor)){
+            return new $.Deferred().reject().promise();
+        }
+        const token = editor.getToken();
+        if(_isSrcOrHrefString(editor, token)) {
+            return _openFile(token.string.replace(/['"]+/g, ''), editor.document.file.parentPath);
+        }
+        return CommandManager.execute(Commands.TOGGLE_QUICK_EDIT);
+    };
+
+    AppInit.appReady(function () {
+        var jdProvider = new HTMLJumpToDefProvider();
+        JumpToDefManager.registerJumpToDefProvider(jdProvider, ["html"], 0);
+    });
+
+});

--- a/src/extensions/default/HTMLCodeHints/integ-tests.js
+++ b/src/extensions/default/HTMLCodeHints/integ-tests.js
@@ -1,0 +1,153 @@
+/*
+ * GNU AGPL-3.0 License
+ *
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
+ * Original work Copyright (c) 2012 - 2021 Adobe Systems Incorporated. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
+ *
+ */
+
+/*global describe, it, expect, beforeAll, afterAll, awaitsForDone, awaitsForFail */
+
+define(function (require, exports, module) {
+    // Recommended to avoid reloading the integration test window Phoenix instance for each test.
+
+    const SpecRunnerUtils     = brackets.getModule("spec/SpecRunnerUtils");
+
+    describe("integration:HTML Code Hints integration tests", function () {
+
+        const testPath = SpecRunnerUtils.getTestPath("/spec/LiveDevelopment-MultiBrowser-test-files");
+
+        let FileViewController,     // loaded from brackets.test
+            ProjectManager,         // loaded from brackets.test;
+            CommandManager,
+            Commands,
+            testWindow,
+            EditorManager,
+            MainViewManager,
+            brackets;
+
+
+        beforeAll(async function () {
+            testWindow = await SpecRunnerUtils.createTestWindowAndRun();
+            brackets            = testWindow.brackets;
+            FileViewController  = brackets.test.FileViewController;
+            ProjectManager      = brackets.test.ProjectManager;
+            CommandManager      = brackets.test.CommandManager;
+            Commands            = brackets.test.Commands;
+            EditorManager       = brackets.test.EditorManager;
+            MainViewManager     = brackets.test.MainViewManager;
+
+            await SpecRunnerUtils.loadProjectInTestWindow(testPath);
+        }, 30000);
+
+        afterAll(function () {
+            FileViewController  = null;
+            ProjectManager      = null;
+            testWindow = null;
+            brackets = null;
+            // comment out below line if you want to debug the test window post running tests
+            //SpecRunnerUtils.closeTestWindow();
+        });
+
+        async function closeSession() {
+            await awaitsForDone(CommandManager.execute(Commands.FILE_CLOSE_ALL, { _forceClose: true }),
+                "closing all file");
+        }
+
+        it("Should jump to definition on div tag", async function () {
+            await awaitsForDone(
+                FileViewController.openAndSelectDocument(
+                    testPath + "/jumpToDef.html",
+                    FileViewController.PROJECT_MANAGER
+                ));
+            const selected = ProjectManager.getSelectedItem();
+            expect(selected.fullPath).toBe(testPath + "/jumpToDef.html");
+
+            let editor = EditorManager.getActiveEditor();
+            editor.setCursorPos({ line: 5, ch: 6 });
+
+            await awaitsForDone(CommandManager.execute(Commands.NAVIGATE_JUMPTO_DEFINITION),
+                "jump to def on div");
+
+            editor = EditorManager.getFocusedInlineEditor();
+            expect(editor.document.file.fullPath.endsWith("LiveDevelopment-MultiBrowser-test-files/simpleShared.css"))
+                .toBeTrue();
+            await closeSession();
+        });
+
+        it("Should jump to definition on css class", async function () {
+            await awaitsForDone(
+                FileViewController.openAndSelectDocument(
+                    testPath + "/jumpToDef.html",
+                    FileViewController.PROJECT_MANAGER
+                ));
+            const selected = ProjectManager.getSelectedItem();
+            expect(selected.fullPath).toBe(testPath + "/jumpToDef.html");
+
+            let editor = EditorManager.getActiveEditor();
+            editor.setCursorPos({ line: 6, ch: 23 });
+
+            await awaitsForDone(CommandManager.execute(Commands.NAVIGATE_JUMPTO_DEFINITION),
+                "jump to def on div");
+
+            editor = EditorManager.getFocusedInlineEditor();
+            expect(editor.document.file.fullPath.endsWith("LiveDevelopment-MultiBrowser-test-files/sub/test.css"))
+                .toBeTrue();
+            await closeSession();
+        });
+
+        async function verifySrcJumpToDef(location, targetFileName, jumpShouldFail) {
+            await awaitsForDone(
+                FileViewController.openAndSelectDocument(
+                    testPath + "/jumpToDef.html",
+                    FileViewController.PROJECT_MANAGER
+                ));
+            const selected = ProjectManager.getSelectedItem();
+            expect(selected.fullPath).toBe(testPath + "/jumpToDef.html");
+
+            let editor = EditorManager.getActiveEditor();
+            editor.setCursorPos(location);
+
+            if(jumpShouldFail){
+                await awaitsForFail(CommandManager.execute(Commands.NAVIGATE_JUMPTO_DEFINITION),
+                    "jump to def on div");
+            } else {
+                await awaitsForDone(CommandManager.execute(Commands.NAVIGATE_JUMPTO_DEFINITION),
+                    "jump to def on div");
+            }
+
+            let currentFile = MainViewManager.getCurrentlyViewedFile();
+            expect(currentFile.fullPath.endsWith(targetFileName))
+                .toBeTrue();
+            await closeSession();
+        }
+
+        it("Should jump to files on href/src attributes", async function () {
+            await verifySrcJumpToDef({ line: 3, ch: 44 }, "sub/test.css");
+            await verifySrcJumpToDef({ line: 13, ch: 29 }, "blank.css");
+            await verifySrcJumpToDef({ line: 11, ch: 32 }, "sub/icon_chevron.png");
+            await closeSession();
+        });
+
+        it("Should not jump to files on non href/src attributes", async function () {
+            await verifySrcJumpToDef({ line: 14, ch: 47 }, "jumpToDef.html", true);
+            await verifySrcJumpToDef({ line: 7, ch: 20 }, "jumpToDef.html", true);
+            await verifySrcJumpToDef({ line: 3, ch: 22 }, "jumpToDef.html", true);
+            await closeSession();
+        });
+
+    });
+});

--- a/src/extensions/default/HTMLCodeHints/main.js
+++ b/src/extensions/default/HTMLCodeHints/main.js
@@ -21,16 +21,18 @@
 
 define(function (require, exports, module) {
 
+    require("HTMLJumpToDef");
 
     // Load dependent modules
-    var AppInit             = brackets.getModule("utils/AppInit"),
+    const AppInit             = brackets.getModule("utils/AppInit"),
         CodeHintManager     = brackets.getModule("editor/CodeHintManager"),
         HTMLUtils           = brackets.getModule("language/HTMLUtils"),
         PreferencesManager  = brackets.getModule("preferences/PreferencesManager"),
         Strings             = brackets.getModule("strings"),
         HTMLTags            = require("text!HtmlTags.json"),
-        HTMLAttributes      = require("text!HtmlAttributes.json"),
-        tags,
+        HTMLAttributes      = require("text!HtmlAttributes.json");
+
+    let tags,
         attributes;
 
     PreferencesManager.definePreference("codehint.TagHints", "boolean", true, {

--- a/src/extensions/default/HTMLCodeHints/unittests.js
+++ b/src/extensions/default/HTMLCodeHints/unittests.js
@@ -25,9 +25,11 @@ define(function (require, exports, module) {
 
 
     // Modules from the SpecRunner window
-    var SpecRunnerUtils = brackets.getModule("spec/SpecRunnerUtils"),
+    const SpecRunnerUtils = brackets.getModule("spec/SpecRunnerUtils"),
         Editor          = brackets.getModule("editor/Editor").Editor,
         HTMLCodeHints   = require("main");
+
+    require("integ-tests");
 
     describe("unit: HTML Code Hinting", function () {
 

--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -718,10 +718,6 @@ define(function (require, exports, module) {
             installEditorListeners(current, previous);
         }
 
-        function setJumpPosition(curPos) {
-            EditorManager.getCurrentFullEditor().setCursorPos(curPos.line, curPos.ch, true);
-        }
-
         function JSJumpToDefProvider() {
         }
 

--- a/src/extensions/default/JavaScriptCodeHints/main.js
+++ b/src/extensions/default/JavaScriptCodeHints/main.js
@@ -725,8 +725,16 @@ define(function (require, exports, module) {
         function JSJumpToDefProvider() {
         }
 
-        JSJumpToDefProvider.prototype.canJumpToDef = function (editor, implicitChar) {
-            return true;
+        const jumpTokenTypes = ["variable", "variable-2", "variable-3", "property", "def", "string"];
+        // defs and strings not ignored for usage in imports
+
+        JSJumpToDefProvider.prototype.canJumpToDef = function (editor, optionalPosition) {
+            let pos = optionalPosition || editor.getCursorPos();
+            let token = editor.getToken(pos);
+            if(token && token.type && jumpTokenTypes.includes(token.type)){
+                return true;
+            }
+            return false;
         };
 
         /**

--- a/src/features/JumpToDefManager.js
+++ b/src/features/JumpToDefManager.js
@@ -91,16 +91,10 @@ define(function (require, exports, module) {
         return result.promise();
     }
 
-    /**
-     * variable that tracks is mark is already present in editor to improve redraw performance on mousemove
-     * @type {boolean}
-     */
-    let marksPresent = false;
-
     function _clearHoverMarkers(editor) {
-        if(marksPresent && editor){
+        if(editor && editor.hoverMarksPresent){
             editor.clearAllMarks(JUMP_TO_DEF_MARKER);
-            marksPresent = false;
+            editor.hoverMarksPresent = false;
         }
     }
 
@@ -110,7 +104,7 @@ define(function (require, exports, module) {
             let jumpToDefProvider = _getJumpToDefProvider(editor, pos);
             if(jumpToDefProvider){
                 editor.markToken(JUMP_TO_DEF_MARKER, pos, Editor.MARK_OPTION_HYPERLINK_TEXT);
-                marksPresent = true;
+                editor.hoverMarksPresent = true;
             }
         }
     }

--- a/src/features/JumpToDefManager.js
+++ b/src/features/JumpToDefManager.js
@@ -39,14 +39,15 @@ define(function (require, exports, module) {
         removeJumpToDefProvider = _providerRegistrationHandler.removeProvider.bind(_providerRegistrationHandler);
 
 
-    function _getJumpToDefProvider(editor) {
+    function _getJumpToDefProvider(editor, position = null) {
         let jumpToDefProvider = null;
         let language = editor.getLanguageForSelection(),
             enabledProviders = _providerRegistrationHandler.getProvidersForLanguageId(language.getId());
 
 
         enabledProviders.some(function (item, index) {
-            if (item.provider.canJumpToDef(editor)) {
+            // position is optional
+            if (item.provider.canJumpToDef(editor, position)) {
                 jumpToDefProvider = item.provider;
                 return true;
             }
@@ -103,15 +104,11 @@ define(function (require, exports, module) {
         }
     }
 
-    const tokenTypesToIgnore = ['keyword', "operator", 'meta', 'atom', 'number', 'comment'];
-    // defs and strings not ignored for usage in imports
-
     function _drawHoverMarkers(editor, pos) {
         if(editor){
             _clearHoverMarkers(editor);
-            let jumpToDefProvider = _getJumpToDefProvider(editor);
-            let token = editor.getToken(pos);
-            if(jumpToDefProvider && token.type && !tokenTypesToIgnore.includes(token.type)){
+            let jumpToDefProvider = _getJumpToDefProvider(editor, pos);
+            if(jumpToDefProvider){
                 editor.markToken(JUMP_TO_DEF_MARKER, pos, Editor.MARK_OPTION_HYPERLINK_TEXT);
                 marksPresent = true;
             }

--- a/test/spec/LiveDevelopment-MultiBrowser-test-files/jumpToDef.html
+++ b/test/spec/LiveDevelopment-MultiBrowser-test-files/jumpToDef.html
@@ -1,0 +1,17 @@
+<html>
+    <head>
+        <title>Test</title>
+        <link rel="stylesheet" href="sub/test.css" />
+    </head>
+    <body>
+        <div class="main">
+            <h1>Hello</h1>
+        </div>
+        <div class="sub">
+        </div>
+        <img href  =  "sub/icon_chevron.png" />
+        <img src=
+                     "blank.css" />
+        <img data-something  =  "sub/icon_chevron.png" />
+    </body>
+</html>


### PR DESCRIPTION
- feat: ctrl-click to jump to definition on html files. 
   - For tag/css class/id attribute, jump to def will initiate quick edit.
   - For src/href attribute, we will attempt to find and open the src file.
- test: integ tests for ctrl-click to jump to definition on html files
- chore: refactor jump to def provider hover highlights

![html jump to def](https://user-images.githubusercontent.com/5336369/206686190-0ecc9f5e-5b64-449f-9c44-8f3aec1ea5c2.gif)

![jump to def context](https://user-images.githubusercontent.com/5336369/206688421-52d690f0-ef6a-4776-a63d-8c461bce49a2.gif)
