### PR TITLE
 numeric quick view for live preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ src/phoenix/virtualfs.js.map
 /src/thirdparty/jszip.js
 /src/thirdparty/jshint.js
 /src/thirdparty/tinycolor.js
+/src/thirdparty/jquery.knob.min.js
 /src/thirdparty/underscore-min.js
 /src/thirdparty/bootstrap
 /src/thirdparty/highlight.js

--- a/docs/generatedApiDocs/features/QuickViewManager-API.md
+++ b/docs/generatedApiDocs/features/QuickViewManager-API.md
@@ -27,6 +27,8 @@ const QuickViewManager = brackets.getModule("features/QuickViewManager");
 // replace `all` with language ID(Eg. javascript) if you want to restrict the preview to js files only.
 QuickViewManager.registerQuickViewProvider(exports, ["all"]);
 
+// provide a helpful name for the QuickView. This will be useful if you have to debug the quick view
+exports.QUICK_VIEW_NAME = "extension.someName";
 // now implement the getQuickView function that will be invoked when ever user hovers over a text in the editor.
 exports.getQuickView = function(editor, pos, token, line) {
         return new Promise((resolve, reject)=>{

--- a/docs/generatedApiDocs/features/QuickViewManager-API.md
+++ b/docs/generatedApiDocs/features/QuickViewManager-API.md
@@ -44,8 +44,9 @@ exports.getQuickView = function(editor, pos, token, line) {
 When QuickViewManager determines that the user intents to see QuickView on hover, `getQuickView` function on all
 registered QuickView providers are invoked to get the quick view popup. `getQuickView` should return a promise
 that resolves to the popup contents if the provider has a quick view. Else just reject the promise. If multiple
-providers returns QuickView, all of them are displayed one by one. See detailed API docs for implementation
-details below:
+providers returns QuickView, all of them are displayed stacked one by one. Alternatively, you can return
+an `exclusive` flag from a provider to force only a particular popup to be displayed.
+See detailed API docs for implementation details below:
 
 ## API
 
@@ -96,7 +97,8 @@ provider.getQuickView = function(editor, pos, token, line) {
             resolve({
                 start: {line: pos.line, ch:token.start},
                 end: {line: pos.line, ch:token.end},
-                content: "<div>hello world</div>"
+                content: "<div>hello world</div>",
+                exclusive: false // this is optional. See details below:
             });
         });
     };
@@ -119,6 +121,8 @@ The promise returned should resolve to an object with the following contents:
 2.  `end` : Indicates the end cursor position to which the quick view is valid. These are generally used to highlight
     the hovered section of the text in the editor.
 3.  `content`: Either `HTML` as text, a `DOM Node` or a `Jquery Element`.
+4.  `exclusive`: Set to true if only this popup should be shown if multiple providers returns a valid popup.
+    If multiple providers return `exclusive` flag, the provider with the highest priority wins.
 
 #### Modifying the QuickView content after resolving `getQuickView` promise
 
@@ -134,7 +138,9 @@ performing any operations.
     handler takes time to resolve the QuickView, resolve a dummy quick once you are sure that a QuickView needs
     to be shown to the user. The div contents can be later updated as and when more details are available.
 2.  Note that the QuickView could be hidden/removed any time by the QuickViewManager.
-3.  If multiple providers returns a valid popup, all of them are displayed.
+3.  If multiple providers returns a valid popup, all of them are displayed except if the `exclusive` flag is
+    returned from one of the popups. If multiple providers return `exclusive` flag, the provider with the
+    highest priority wins.
 
 ## isQuickViewShown
 

--- a/docs/generatedApiDocs/features/QuickViewManager-API.md
+++ b/docs/generatedApiDocs/features/QuickViewManager-API.md
@@ -98,7 +98,8 @@ provider.getQuickView = function(editor, pos, token, line) {
                 start: {line: pos.line, ch:token.start},
                 end: {line: pos.line, ch:token.end},
                 content: "<div>hello world</div>",
-                exclusive: false // this is optional. See details below:
+                exclusive: false, // this is optional. See details below:
+                editsDoc: false // this is optional if the quick view edits the current doc
             });
         });
     };
@@ -121,8 +122,9 @@ The promise returned should resolve to an object with the following contents:
 2.  `end` : Indicates the end cursor position to which the quick view is valid. These are generally used to highlight
     the hovered section of the text in the editor.
 3.  `content`: Either `HTML` as text, a `DOM Node` or a `Jquery Element`.
-4.  `exclusive`: Set to true if only this popup should be shown if multiple providers returns a valid popup.
+4.  `exclusive`: Optional, set to true if only this popup should be shown if multiple providers returns a valid popup.
     If multiple providers return `exclusive` flag, the provider with the highest priority wins.
+5.  `editsDoc`: Optional, set to true if the quick view can edit the active document.
 
 #### Modifying the QuickView content after resolving `getQuickView` promise
 

--- a/docs/generatedApiDocs/features/SelectionViewManager-API.md
+++ b/docs/generatedApiDocs/features/SelectionViewManager-API.md
@@ -29,6 +29,8 @@ const SelectionViewManager = brackets.getModule("features/SelectionViewManager")
 // replace `all` with language ID(Eg. javascript) if you want to restrict the preview to js files only.
 SelectionViewManager.registerSelectionViewProvider(exports, ["all"]);
 
+// provide a helpful name for the SelectionView. This will be useful if you have to debug the selection view
+exports.SELECTION_VIEW_NAME = "extension.someName";
 // now implement the getSelectionView function that will be invoked when ever user selection changes in the editor.
 exports.getSelectionView = function(editor, selections) {
         return new Promise((resolve, reject)=>{

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1792,15 +1792,16 @@ define(function (require, exports, module) {
      * If there are multiple selections, this will return a mode only if all the selections are individually
      * consistent and resolve to the same mode.
      *
+     * @param {{start:{line:number, ch:number}, end:{line:number, ch:number}, reversed:boolean}} selection
      * @return {?(Object|string)} Name of syntax-highlighting mode, or object containing a "name" property
      *     naming the mode along with configuration options required by the mode.
      * @see {@link LanguageManager::#getLanguageForPath} and {@link LanguageManager::Language#getMode}.
      */
-    Editor.prototype.getModeForSelection = function () {
+    Editor.prototype.getModeForSelection = function (selection) {
         // Check for mixed mode info
         var self        = this,
-            sels        = this.getSelections(),
-            primarySel  = this.getSelection(),
+            sels        = selection ? [selection] : this.getSelections(),
+            primarySel  = selection || this.getSelection(),
             outerMode   = this._codeMirror.getMode(),
             startMode   = TokenUtils.getModeAt(this._codeMirror, primarySel.start),
             isMixed     = (outerMode.name !== startMode.name);
@@ -1856,6 +1857,17 @@ define(function (require, exports, module) {
      */
     Editor.prototype.getLanguageForSelection = function () {
         return this.document.getLanguage().getLanguageForMode(this.getModeForSelection());
+    };
+
+    /**
+     * gets the language for the selection. (Javascript selected from an HTML document or CSS selected from an HTML
+     * document, etc...)
+     * @return {!Language}
+     */
+    Editor.prototype.getLanguageForPosition = function (pos) {
+        let self = this;
+        pos = pos || self.getCursorPos();
+        return this.document.getLanguage().getLanguageForMode(self.getModeForSelection({start: pos, end: pos}));
     };
 
     /**

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -82,6 +82,7 @@ define(function (require, exports, module) {
         TokenUtils         = require("utils/TokenUtils"),
         HTMLUtils          = require("language/HTMLUtils"),
         MainViewManager    = require("view/MainViewManager"),
+        Metrics            = require("utils/Metrics"),
         _                  = require("thirdparty/lodash");
 
     /** Editor helpers */
@@ -307,6 +308,7 @@ define(function (require, exports, module) {
             if(event.ctrlKey || event.metaKey){
                 setTimeout(()=>{
                     CommandManager.execute(Commands.NAVIGATE_JUMPTO_DEFINITION);
+                    Metrics.countEvent(Metrics.EVENT_TYPE.EDITOR, "ctrlClick", _cm.getMode().name);
                 }, 100);
             }
             return {

--- a/src/extensions/default/QuickView/ImagePreviewProvider.js
+++ b/src/extensions/default/QuickView/ImagePreviewProvider.js
@@ -223,5 +223,6 @@ define(function (require, exports, module) {
     });
 
     exports.getQuickView = getQuickView;
+    exports.QUICK_VIEW_NAME = "ImagePreviewProvider";
 
 });

--- a/src/extensions/default/QuickView/ImagePreviewProvider.js
+++ b/src/extensions/default/QuickView/ImagePreviewProvider.js
@@ -33,6 +33,7 @@ define(function (require, exports, module) {
         PathUtils           = brackets.getModule("thirdparty/path-utils/path-utils"),
         AppInit             = brackets.getModule("utils/AppInit"),
         QuickView           = brackets.getModule("features/QuickViewManager"),
+        Metrics             = brackets.getModule("utils/Metrics"),
         FileViewController  = brackets.getModule("project/FileViewController");
 
     let enabled,                             // Only show preview if true
@@ -188,8 +189,10 @@ define(function (require, exports, module) {
                         $imgPreview.click(function () {
                             FileViewController.openAndSelectDocument(imageFile.fullPath,
                                 FileViewController.PROJECT_MANAGER);
+                            Metrics.countEvent(Metrics.EVENT_TYPE.QUICK_VIEW, "image", "click");
                         });
                         showHandlerWithImageURL(dataURL);
+                        Metrics.countEvent(Metrics.EVENT_TYPE.QUICK_VIEW, "image", "show");
                         resolve(previewPopup);
                     } else {
                         reject();

--- a/src/extensions/default/QuickView/colorGradientProvider.js
+++ b/src/extensions/default/QuickView/colorGradientProvider.js
@@ -31,6 +31,7 @@ define(function (require, exports, module) {
         AppInit             = brackets.getModule("utils/AppInit"),
         QuickView           = brackets.getModule("features/QuickViewManager"),
         Strings             = brackets.getModule("strings"),
+        Metrics             = brackets.getModule("utils/Metrics"),
         CommandManager      = brackets.getModule("command/CommandManager"),
         Commands            = brackets.getModule("command/Commands");
 
@@ -296,8 +297,10 @@ define(function (require, exports, module) {
                     }
                     editor.setCursorPos(startPos);
                     CommandManager.execute(Commands.TOGGLE_QUICK_EDIT);
+                    Metrics.countEvent(Metrics.EVENT_TYPE.QUICK_VIEW, "color", "click");
                 });
 
+                Metrics.countEvent(Metrics.EVENT_TYPE.QUICK_VIEW, "color", "show");
                 resolve({
                     start: startPos,
                     end: endPos,

--- a/src/extensions/default/QuickView/colorGradientProvider.js
+++ b/src/extensions/default/QuickView/colorGradientProvider.js
@@ -315,4 +315,5 @@ define(function (require, exports, module) {
     });
 
     exports.getQuickView = getQuickView;
+    exports.QUICK_VIEW_NAME = "colorGradientProvider";
 });

--- a/src/extensions/default/QuickView/main.js
+++ b/src/extensions/default/QuickView/main.js
@@ -25,6 +25,7 @@ define(function (require, exports, module) {
     const ExtensionUtils      = brackets.getModule("utils/ExtensionUtils");
     require("./colorGradientProvider");
     require("./ImagePreviewProvider");
+    require("./numberPreviewProvider");
 
     // Load our stylesheet
     ExtensionUtils.loadStyleSheet(module, "QuickView.less");

--- a/src/extensions/default/QuickView/numberPreviewProvider.js
+++ b/src/extensions/default/QuickView/numberPreviewProvider.js
@@ -43,9 +43,9 @@ define(function (require, exports, module) {
 
     function _splitNumber(numStr) {
         // https://stackoverflow.com/questions/2868947/split1px-into-1px-1-px-in-javascript
-        let split = numStr.match(/^-?(\d*\.?\d*)(.*)/); // "1px" -> ["1px", "1", "px"]
-        let number = split[1] || "";
-        let decimalPlaces = number.split(".")[1];
+        let split = numStr.match(/(^-?)(\d*\.?\d*)(.*)/); // "1px" -> ["1px", "1", "px"]
+        let number = split[1] + split[2] || "";
+        let decimalPlaces = number.split(".")[2];
         decimalPlaces = decimalPlaces && decimalPlaces.length || 0;
         let roundTo;
         switch (decimalPlaces) {
@@ -56,7 +56,7 @@ define(function (require, exports, module) {
         }
         return {
             number,
-            units: split[2] || "",
+            units: split[3] || "",
             decimalPlaces,
             roundTo
         };

--- a/src/extensions/default/QuickView/numberPreviewProvider.js
+++ b/src/extensions/default/QuickView/numberPreviewProvider.js
@@ -85,7 +85,7 @@ define(function (require, exports, module) {
                     return Math.round(value*split.roundTo)/split.roundTo + split.units;
                 },
                 change: function (value) {
-                    console.log(value);
+                    //console.log(value);
                 }
             });
             resolve({

--- a/src/extensions/default/QuickView/numberPreviewProvider.js
+++ b/src/extensions/default/QuickView/numberPreviewProvider.js
@@ -45,7 +45,7 @@ define(function (require, exports, module) {
         // https://stackoverflow.com/questions/2868947/split1px-into-1px-1-px-in-javascript
         let split = numStr.match(/(^-?)(\d*\.?\d*)(.*)/); // "1px" -> ["1px", "1", "px"]
         let number = split[1] + split[2] || "";
-        let decimalPlaces = number.split(".")[2];
+        let decimalPlaces = number.split(".")[1];
         decimalPlaces = decimalPlaces && decimalPlaces.length || 0;
         let roundTo;
         switch (decimalPlaces) {

--- a/src/extensions/default/QuickView/numberPreviewProvider.js
+++ b/src/extensions/default/QuickView/numberPreviewProvider.js
@@ -29,7 +29,8 @@ define(function (require, exports, module) {
     let PreferencesManager  = brackets.getModule("preferences/PreferencesManager"),
         Strings             = brackets.getModule("strings"),
         AppInit             = brackets.getModule("utils/AppInit"),
-        QuickView           = brackets.getModule("features/QuickViewManager");
+        QuickView           = brackets.getModule("features/QuickViewManager"),
+        colorGradientProvider = require("./colorGradientProvider");
 
     const PREF_ENABLED_KEY = "numberEditor";
 
@@ -111,6 +112,23 @@ define(function (require, exports, module) {
         });
     }
 
+    function filterQuickView(popovers){
+        // rgb(10 , 100, 20), hover over these kind of numbers should open color quick view if present over number view
+        let numberQuickView, colorQuickView;
+        for(let popover of popovers){
+            if(popover.providerInfo.provider.QUICK_VIEW_NAME === exports.QUICK_VIEW_NAME){
+                numberQuickView = popover;
+            } else if(popover.providerInfo.provider.QUICK_VIEW_NAME === colorGradientProvider.QUICK_VIEW_NAME){
+                colorQuickView = popover;
+            }
+        }
+        if(colorQuickView){
+            return [colorQuickView];
+        }
+
+        return [numberQuickView] || popovers;
+    }
+
     prefs.on("change", PREF_ENABLED_KEY, function () {
         enabled = prefs.get(PREF_ENABLED_KEY);
     });
@@ -121,6 +139,7 @@ define(function (require, exports, module) {
     });
 
     exports.getQuickView = getQuickView;
+    exports.filterQuickView = filterQuickView;
     exports.QUICK_VIEW_NAME = "numberPreviewProvider";
 
 });

--- a/src/extensions/default/QuickView/numberPreviewProvider.js
+++ b/src/extensions/default/QuickView/numberPreviewProvider.js
@@ -27,7 +27,6 @@ define(function (require, exports, module) {
 
     // Brackets modules
     let PreferencesManager  = brackets.getModule("preferences/PreferencesManager"),
-        LanguageManager     = brackets.getModule("language/LanguageManager"),
         Strings             = brackets.getModule("strings"),
         AppInit             = brackets.getModule("utils/AppInit"),
         QuickView           = brackets.getModule("features/QuickViewManager");
@@ -85,6 +84,11 @@ define(function (require, exports, module) {
                 fontSize: "1em",
                 format: function(value){
                     return Math.round(value*split.roundTo)/split.roundTo + split.units;
+                },
+                getValue: function(userInput){
+                    let changedSplit = _splitNumber(userInput);
+                    split.units = changedSplit.units;
+                    return changedSplit.number;
                 },
                 change: function (value) {
                     editor.document.batchOperation(function () {

--- a/src/extensions/default/QuickView/numberPreviewProvider.js
+++ b/src/extensions/default/QuickView/numberPreviewProvider.js
@@ -1,0 +1,111 @@
+/*
+ * GNU AGPL-3.0 License
+ *
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
+ * Original work Copyright (c) 2013 - 2021 Adobe Systems Incorporated. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
+ *
+ */
+
+/*jslint regexp: true */
+
+define(function (require, exports, module) {
+
+    require("./thirdparty/jquery.knob.modified");
+
+    // Brackets modules
+    let PreferencesManager  = brackets.getModule("preferences/PreferencesManager"),
+        LanguageManager     = brackets.getModule("language/LanguageManager"),
+        Strings             = brackets.getModule("strings"),
+        AppInit             = brackets.getModule("utils/AppInit"),
+        QuickView           = brackets.getModule("features/QuickViewManager");
+
+    const PREF_ENABLED_KEY = "numberEditor";
+
+    let prefs = PreferencesManager.getExtensionPrefs("quickview");
+    prefs.definePreference(PREF_ENABLED_KEY, "boolean", true, {
+        description: Strings.DESCRIPTION_NUMBER_QUICK_VIEW
+    });
+
+    let enabled;                             // Only show preview if true
+
+    function _splitNumber(numStr) {
+        // https://stackoverflow.com/questions/2868947/split1px-into-1px-1-px-in-javascript
+        let split = numStr.match(/^-?(\d*\.?\d*)(.*)/); // "1px" -> ["1px", "1", "px"]
+        let number = split[1] || "";
+        let decimalPlaces = number.split(".")[1];
+        decimalPlaces = decimalPlaces && decimalPlaces.length || 0;
+        let roundTo;
+        switch (decimalPlaces) {
+        case 0: roundTo = 1; break;
+        case 1: roundTo = 10; break;
+        case 2: roundTo = 100; break;
+        default: roundTo = 100; break;
+        }
+        return {
+            number,
+            units: split[2] || "",
+            decimalPlaces,
+            roundTo
+        };
+    }
+
+    function getQuickView(editor, pos, token, line) {
+
+        return new Promise((resolve, reject)=>{
+            if(token.type !== "number" || !enabled){
+                reject();
+                return;
+            }
+            let sPos = {line: pos.line, ch: token.start},
+                ePos = {line: pos.line, ch: token.end};
+            let $content = $(`<div><input type="text" value="${token.string}" class="dial"><div>`);
+            let split = _splitNumber(token.string);
+            $content.find(".dial").knob({
+                stopper: false,
+                step: 1/split.roundTo,
+                max: 100/split.roundTo,
+                width: 100,
+                height: 100,
+                fgColor: "#2893ef",
+                fontSize: "1em",
+                format: function(value){
+                    return Math.round(value*split.roundTo)/split.roundTo + split.units;
+                },
+                change: function (value) {
+                    console.log(value);
+                }
+            });
+            resolve({
+                start: sPos,
+                end: ePos,
+                content: $content,
+                exclusive: true
+            });
+        });
+    }
+
+    prefs.on("change", PREF_ENABLED_KEY, function () {
+        enabled = prefs.get(PREF_ENABLED_KEY);
+    });
+
+    AppInit.appReady(function () {
+        enabled = prefs.get(PREF_ENABLED_KEY);
+        QuickView.registerQuickViewProvider(exports, ["css", "html"]);
+    });
+
+    exports.getQuickView = getQuickView;
+
+});

--- a/src/extensions/default/QuickView/numberPreviewProvider.js
+++ b/src/extensions/default/QuickView/numberPreviewProvider.js
@@ -121,5 +121,6 @@ define(function (require, exports, module) {
     });
 
     exports.getQuickView = getQuickView;
+    exports.QUICK_VIEW_NAME = "numberPreviewProvider";
 
 });

--- a/src/extensions/default/QuickView/numberPreviewProvider.js
+++ b/src/extensions/default/QuickView/numberPreviewProvider.js
@@ -30,6 +30,7 @@ define(function (require, exports, module) {
         Strings             = brackets.getModule("strings"),
         AppInit             = brackets.getModule("utils/AppInit"),
         QuickView           = brackets.getModule("features/QuickViewManager"),
+        Metrics             = brackets.getModule("utils/Metrics"),
         colorGradientProvider = require("./colorGradientProvider");
 
     const PREF_ENABLED_KEY = "numberEditor";
@@ -75,6 +76,7 @@ define(function (require, exports, module) {
             let editOrigin = "+NumberQuickView_" + (lastOriginId++);
             let $content = $(`<div><input type="text" value="${token.string}" class="dial"><div>`);
             let split = _splitNumber(token.string);
+            let changedMetricSent = false;
             $content.find(".dial").knob({
                 stopper: false,
                 step: 1/split.roundTo,
@@ -100,6 +102,10 @@ define(function (require, exports, module) {
                         ePos = {line: sPos.line, ch: sPos.ch + replaceStr.length};
                         editor.setSelection(sPos, ePos);
                     });
+                    if(!changedMetricSent){
+                        Metrics.countEvent(Metrics.EVENT_TYPE.QUICK_VIEW, "num", "changed");
+                        changedMetricSent = true;
+                    }
                 }
             });
             resolve({
@@ -109,6 +115,7 @@ define(function (require, exports, module) {
                 exclusive: true,
                 editsDoc: true
             });
+            Metrics.countEvent(Metrics.EVENT_TYPE.QUICK_VIEW, "num", "show");
         });
     }
 

--- a/src/extensions/default/QuickView/thirdparty/jquery.knob.modified.js
+++ b/src/extensions/default/QuickView/thirdparty/jquery.knob.modified.js
@@ -699,8 +699,9 @@
                             if ($.inArray(kc,[38,40, 13]) > -1) {
                                 e.preventDefault();
 
-                                let value = s.o.getValue(s.$.val());
+                                let value = (s.o.getValue && s.o.getValue(s.$.val())) || s.$.val();
                                 var v = s.o.parse(value);
+                                console.log(v, kv);
                                 if(kc !== 13){
                                     v = v + kv[kc] * m;
                                 }

--- a/src/extensions/default/QuickView/thirdparty/jquery.knob.modified.js
+++ b/src/extensions/default/QuickView/thirdparty/jquery.knob.modified.js
@@ -693,10 +693,10 @@
                             && kc !== 189                   // -
                             && (kc !== 190
                                 || s.$.val().match(/\./))   // . allowed once
-                            && e.preventDefault();
+                            ;
 
                             // arrows
-                            if ($.inArray(kc,[37,38,39,40]) > -1) {
+                            if ($.inArray(kc,[38,40]) > -1) {
                                 e.preventDefault();
 
                                 var v = s.o.parse(s.$.val()) + kv[kc] * m;
@@ -725,8 +725,8 @@
                             }
                         } else {
                             // kval postcond
-                            (s.$.val() > s.o.max && s.$.val(s.o.max))
-                            || (s.$.val() < s.o.min && s.$.val(s.o.min));
+                            (s.o.stopper && s.$.val() > s.o.max && s.$.val(s.o.max))
+                            || (s.o.stopper && s.$.val() < s.o.min && s.$.val(s.o.min));
                         }
                     }
                 );

--- a/src/extensions/default/QuickView/thirdparty/jquery.knob.modified.js
+++ b/src/extensions/default/QuickView/thirdparty/jquery.knob.modified.js
@@ -318,7 +318,43 @@
 
                 if (v == s.cv) return;
 
-                s.change(s._validate(v));
+                let period = s.o.max-s.o.min;
+                let cv = s.cv;
+                if(cv > s.o.max){
+                    cv =cv % period;
+                } else if(cv < s.o.min){
+                    cv = period + cv % period;
+                }
+                let oldAngle = s.angle(cv), newAngle = s.angle(v);
+                let direction = "", PI2= 2*Math.PI, driftAngle;
+                if(newAngle > oldAngle){
+                    let distance = newAngle - oldAngle,
+                        complimentaryDistance = PI2 - distance;
+                    if(distance<complimentaryDistance){
+                        driftAngle = distance;
+                        direction = "forward";
+                    } else {
+                        direction = "reverse";
+                        driftAngle = complimentaryDistance;
+                    }
+                } else {
+                    let distance = oldAngle - newAngle,
+                        complimentaryDistance = PI2 - distance;
+                    if(distance<complimentaryDistance){
+                        driftAngle = distance;
+                        direction = "reverse";
+                    } else {
+                        driftAngle = complimentaryDistance;
+                        direction = "forward";
+                    }
+                }
+                let displacement = period * driftAngle/PI2, value;
+                if(direction === "forward"){
+                    value = s.cv + displacement;
+                } else {
+                    value = s.cv - displacement;
+                }
+                s.change(s._validate(value));
                 s._draw();
             };
 
@@ -347,8 +383,43 @@
                 var v = s.xy2val(e.pageX, e.pageY);
 
                 if (v == s.cv) return;
-
-                s.change(s._validate(v));
+                let period = s.o.max-s.o.min;
+                let cv = s.cv;
+                if(cv > s.o.max){
+                    cv =cv % period;
+                } else if(cv < s.o.min){
+                    cv = period + cv % period;
+                }
+                let oldAngle = s.angle(cv), newAngle = s.angle(v);
+                let direction = "", PI2= 2*Math.PI, driftAngle;
+                if(newAngle > oldAngle){
+                    let distance = newAngle - oldAngle,
+                        complimentaryDistance = PI2 - distance;
+                    if(distance<complimentaryDistance){
+                        driftAngle = distance;
+                        direction = "forward";
+                    } else {
+                        direction = "reverse";
+                        driftAngle = complimentaryDistance;
+                    }
+                } else {
+                    let distance = oldAngle - newAngle,
+                        complimentaryDistance = PI2 - distance;
+                    if(distance<complimentaryDistance){
+                        driftAngle = distance;
+                        direction = "reverse";
+                    } else {
+                        driftAngle = complimentaryDistance;
+                        direction = "forward";
+                    }
+                }
+                let displacement = period * driftAngle/PI2, value;
+                if(direction === "forward"){
+                    value = s.cv + displacement;
+                } else {
+                    value = s.cv - displacement;
+                }
+                s.change(s._validate(value));
                 s._draw();
             };
 

--- a/src/extensions/default/QuickView/thirdparty/jquery.knob.modified.js
+++ b/src/extensions/default/QuickView/thirdparty/jquery.knob.modified.js
@@ -695,11 +695,15 @@
                                 || s.$.val().match(/\./))   // . allowed once
                             ;
 
-                            // arrows
-                            if ($.inArray(kc,[38,40]) > -1) {
+                            // arrows, enter
+                            if ($.inArray(kc,[38,40, 13]) > -1) {
                                 e.preventDefault();
 
-                                var v = s.o.parse(s.$.val()) + kv[kc] * m;
+                                let value = s.o.getValue(s.$.val());
+                                var v = s.o.parse(value);
+                                if(kc !== 13){
+                                    v = v + kv[kc] * m;
+                                }
                                 s.o.stopper && (v = max(min(v, s.o.max), s.o.min));
 
                                 s.change(s._validate(v));

--- a/src/extensions/default/QuickView/thirdparty/jquery.knob.modified.js
+++ b/src/extensions/default/QuickView/thirdparty/jquery.knob.modified.js
@@ -1,0 +1,799 @@
+/*!jQuery Knob*/
+/**
+ * modified version of jquery knobs
+ * Downward compatible, touchable dial
+ *
+ * Version: 1.2.12
+ * Requires: jQuery v1.7+
+ *
+ * Copyright (c) 2012 Anthony Terrien
+ * Under MIT License (http://www.opensource.org/licenses/mit-license.php)
+ *
+ * Thanks to vor, eskimoblood, spiffistan, FabrizioC
+ */
+
+/*globals jQuery*/
+
+(function (factory) {
+    // only works with global jquery object
+    factory(jQuery);
+}(function ($) {
+
+    /**
+     * Kontrol library
+     */
+    "use strict";
+
+    /**
+     * Definition of globals and core
+     */
+    var k = {}, // kontrol
+        max = Math.max,
+        min = Math.min;
+
+    k.c = {};
+    k.c.d = $(document);
+    k.c.t = function (e) {
+        return e.originalEvent.touches.length - 1;
+    };
+
+    /**
+     * Kontrol Object
+     *
+     * Definition of an abstract UI control
+     *
+     * Each concrete component must call this one.
+     * <code>
+     * k.o.call(this);
+     * </code>
+     */
+    k.o = function () {
+        var s = this;
+
+        this.o = null; // array of options
+        this.$ = null; // jQuery wrapped element
+        this.i = null; // mixed HTMLInputElement or array of HTMLInputElement
+        this.g = null; // deprecated 2D graphics context for 'pre-rendering'
+        this.v = null; // value ; mixed array or integer
+        this.cv = null; // change value ; not commited value
+        this.x = 0; // canvas x position
+        this.y = 0; // canvas y position
+        this.w = 0; // canvas width
+        this.h = 0; // canvas height
+        this.$c = null; // jQuery canvas element
+        this.c = null; // rendered canvas context
+        this.t = 0; // touches index
+        this.isInit = false;
+        this.fgColor = null; // main color
+        this.pColor = null; // previous color
+        this.dH = null; // draw hook
+        this.cH = null; // change hook
+        this.eH = null; // cancel hook
+        this.rH = null; // release hook
+        this.scale = 1; // scale factor
+        this.relative = false;
+        this.relativeWidth = false;
+        this.relativeHeight = false;
+        this.$div = null; // component div
+
+        this.run = function () {
+            var cf = function (e, conf) {
+                var k;
+                for (k in conf) {
+                    s.o[k] = conf[k];
+                }
+                s._carve().init();
+                s._configure()
+                 ._draw();
+            };
+
+            if (this.$.data('kontroled')) return;
+            this.$.data('kontroled', true);
+
+            this.extend();
+            this.o = $.extend({
+                    // Config
+                    min: this.$.data('min') !== undefined ? this.$.data('min') : 0,
+                    max: this.$.data('max') !== undefined ? this.$.data('max') : 100,
+                    stopper: true,
+                    readOnly: this.$.data('readonly') || (this.$.attr('readonly') === 'readonly'),
+
+                    // UI
+                    cursor: this.$.data('cursor') === true && 30
+                            || this.$.data('cursor') || 0,
+                    thickness: this.$.data('thickness')
+                               && Math.max(Math.min(this.$.data('thickness'), 1), 0.01)
+                               || 0.35,
+                    lineCap: this.$.data('linecap') || 'butt',
+                    width: this.$.data('width') || 200,
+                    height: this.$.data('height') || 200,
+                    displayInput: this.$.data('displayinput') == null || this.$.data('displayinput'),
+                    displayPrevious: this.$.data('displayprevious'),
+                    fgColor: this.$.data('fgcolor') || '#87CEEB',
+                    inputColor: this.$.data('inputcolor'),
+                    font: this.$.data('font') || 'Arial',
+                    fontWeight: this.$.data('font-weight') || 'bold',
+                    inline: false,
+                    step: this.$.data('step') || 1,
+                    rotation: this.$.data('rotation'),
+
+                    // Hooks
+                    draw: null, // function () {}
+                    change: null, // function (value) {}
+                    cancel: null, // function () {}
+                    release: null, // function (value) {}
+
+                    // Output formatting, allows to add unit: %, ms ...
+                    format: function(v) {
+                        return v;
+                    },
+                    parse: function (v) {
+                        return parseFloat(v);
+                    }
+                }, this.o
+            );
+
+            // finalize options
+            this.o.flip = this.o.rotation === 'anticlockwise' || this.o.rotation === 'acw';
+            if (!this.o.inputColor) {
+                this.o.inputColor = this.o.fgColor;
+            }
+
+            // routing value
+            if (this.$.is('fieldset')) {
+
+                // fieldset = array of integer
+                this.v = {};
+                this.i = this.$.find('input');
+                this.i.each(function(k) {
+                    var $this = $(this);
+                    s.i[k] = $this;
+                    s.v[k] = s.o.parse($this.val());
+
+                    $this.bind(
+                        'change blur',
+                        function () {
+                            var val = {};
+                            val[k] = $this.val();
+                            s.val(s._validate(val));
+                        }
+                    );
+                });
+                this.$.find('legend').remove();
+            } else {
+
+                // input = integer
+                this.i = this.$;
+                this.v = this.o.parse(this.$.val());
+                this.v === '' && (this.v = this.o.min);
+                this.$.bind(
+                    'change blur',
+                    function () {
+                        s.val(s._validate(s.o.parse(s.$.val())));
+                    }
+                );
+
+            }
+
+            !this.o.displayInput && this.$.hide();
+
+            // adds needed DOM elements (canvas, div)
+            this.$c = $(document.createElement('canvas')).attr({
+                width: this.o.width,
+                height: this.o.height
+            });
+
+            // wraps all elements in a div
+            // add to DOM before Canvas init is triggered
+            this.$div = $('<div style="'
+                + (this.o.inline ? 'display:inline;' : '')
+                + 'width:' + this.o.width + 'px;height:' + this.o.height + 'px;'
+                + '"></div>');
+
+            this.$.wrap(this.$div).before(this.$c);
+            this.$div = this.$.parent();
+
+            if (typeof G_vmlCanvasManager !== 'undefined') {
+                G_vmlCanvasManager.initElement(this.$c[0]);
+            }
+
+            this.c = this.$c[0].getContext ? this.$c[0].getContext('2d') : null;
+
+            if (!this.c) {
+                throw {
+                    name:        "CanvasNotSupportedException",
+                    message:     "Canvas not supported. Please use excanvas on IE8.0.",
+                    toString:    function(){return this.name + ": " + this.message}
+                }
+            }
+
+            // hdpi support
+            this.scale = (window.devicePixelRatio || 1) / (
+                            this.c.webkitBackingStorePixelRatio ||
+                            this.c.mozBackingStorePixelRatio ||
+                            this.c.msBackingStorePixelRatio ||
+                            this.c.oBackingStorePixelRatio ||
+                            this.c.backingStorePixelRatio || 1
+                         );
+
+            // detects relative width / height
+            this.relativeWidth =  this.o.width % 1 !== 0
+                                  && this.o.width.indexOf('%');
+            this.relativeHeight = this.o.height % 1 !== 0
+                                  && this.o.height.indexOf('%');
+            this.relative = this.relativeWidth || this.relativeHeight;
+
+            // computes size and carves the component
+            this._carve();
+
+            // prepares props for transaction
+            if (this.v instanceof Object) {
+                this.cv = {};
+                this.copy(this.v, this.cv);
+            } else {
+                this.cv = this.v;
+            }
+
+            // binds configure event
+            this.$
+                .bind("configure", cf)
+                .parent()
+                .bind("configure", cf);
+
+            // finalize init
+            this._listen()
+                ._configure()
+                ._xy()
+                .init();
+
+            this.isInit = true;
+
+            this.$.val(this.o.format(this.v));
+            this._draw();
+
+            return this;
+        };
+
+        this._carve = function() {
+            if (this.relative) {
+                var w = this.relativeWidth ?
+                        this.$div.parent().width() *
+                        parseInt(this.o.width) / 100
+                        : this.$div.parent().width(),
+                    h = this.relativeHeight ?
+                        this.$div.parent().height() *
+                        parseInt(this.o.height) / 100
+                        : this.$div.parent().height();
+
+                // apply relative
+                this.w = this.h = Math.min(w, h);
+            } else {
+                this.w = this.o.width;
+                this.h = this.o.height;
+            }
+
+            // finalize div
+            this.$div.css({
+                'width': this.w + 'px',
+                'height': this.h + 'px'
+            });
+
+            // finalize canvas with computed width
+            this.$c.attr({
+                width: this.w,
+                height: this.h
+            });
+
+            // scaling
+            if (this.scale !== 1) {
+                this.$c[0].width = this.$c[0].width * this.scale;
+                this.$c[0].height = this.$c[0].height * this.scale;
+                this.$c.width(this.w);
+                this.$c.height(this.h);
+            }
+
+            return this;
+        };
+
+        this._draw = function () {
+
+            // canvas pre-rendering
+            var d = true;
+
+            s.g = s.c;
+
+            s.clear();
+
+            s.dH && (d = s.dH());
+
+            d !== false && s.draw();
+        };
+
+        this._touch = function (e) {
+            var touchMove = function (e) {
+                var v = s.xy2val(
+                            e.originalEvent.touches[s.t].pageX,
+                            e.originalEvent.touches[s.t].pageY
+                        );
+
+                if (v == s.cv) return;
+
+                s.change(s._validate(v));
+                s._draw();
+            };
+
+            // get touches index
+            this.t = k.c.t(e);
+
+            // First touch
+            touchMove(e);
+
+            // Touch events listeners
+            k.c.d
+                .bind("touchmove.k", touchMove)
+                .bind(
+                    "touchend.k",
+                    function () {
+                        k.c.d.unbind('touchmove.k touchend.k');
+                        s.val(s.cv);
+                    }
+                );
+
+            return this;
+        };
+
+        this._mouse = function (e) {
+            var mouseMove = function (e) {
+                var v = s.xy2val(e.pageX, e.pageY);
+
+                if (v == s.cv) return;
+
+                s.change(s._validate(v));
+                s._draw();
+            };
+
+            // First click
+            mouseMove(e);
+
+            // Mouse events listeners
+            k.c.d
+                .bind("mousemove.k", mouseMove)
+                .bind(
+                    // Escape key cancel current change
+                    "keyup.k",
+                    function (e) {
+                        if (e.keyCode === 27) {
+                            k.c.d.unbind("mouseup.k mousemove.k keyup.k");
+
+                            if (s.eH && s.eH() === false)
+                                return;
+
+                            s.cancel();
+                        }
+                    }
+                )
+                .bind(
+                    "mouseup.k",
+                    function (e) {
+                        k.c.d.unbind('mousemove.k mouseup.k keyup.k');
+                        s.val(s.cv);
+                    }
+                );
+
+            return this;
+        };
+
+        this._xy = function () {
+            var o = this.$c.offset();
+            this.x = o.left;
+            this.y = o.top;
+
+            return this;
+        };
+
+        this._listen = function () {
+            if (!this.o.readOnly) {
+                this.$c
+                    .bind(
+                        "mousedown",
+                        function (e) {
+                            e.preventDefault();
+                            s._xy()._mouse(e);
+                        }
+                    )
+                    .bind(
+                        "touchstart",
+                        function (e) {
+                            e.preventDefault();
+                            s._xy()._touch(e);
+                        }
+                    );
+
+                this.listen();
+            } else {
+                this.$.attr('readonly', 'readonly');
+            }
+
+            if (this.relative) {
+                $(window).resize(function() {
+                    s._carve().init();
+                    s._draw();
+                });
+            }
+
+            return this;
+        };
+
+        this._configure = function () {
+
+            // Hooks
+            if (this.o.draw) this.dH = this.o.draw;
+            if (this.o.change) this.cH = this.o.change;
+            if (this.o.cancel) this.eH = this.o.cancel;
+            if (this.o.release) this.rH = this.o.release;
+
+            if (this.o.displayPrevious) {
+                this.pColor = this.h2rgba(this.o.fgColor, "0.4");
+                this.fgColor = this.h2rgba(this.o.fgColor, "0.6");
+            } else {
+                this.fgColor = this.o.fgColor;
+            }
+
+            return this;
+        };
+
+        this._clear = function () {
+            this.$c[0].width = this.$c[0].width;
+        };
+
+        this._validate = function (v) {
+            return Math.round(v * 100) / 100;
+        };
+
+        // Abstract methods
+        this.listen = function () {}; // on start, one time
+        this.extend = function () {}; // each time configure triggered
+        this.init = function () {}; // each time configure triggered
+        this.change = function (v) {}; // on change
+        this.val = function (v) {}; // on release
+        this.xy2val = function (x, y) {}; //
+        this.draw = function () {}; // on change / on release
+        this.clear = function () { this._clear(); };
+
+        // Utils
+        this.h2rgba = function (h, a) {
+            var rgb;
+            h = h.substring(1,7);
+            rgb = [
+                parseInt(h.substring(0,2), 16),
+                parseInt(h.substring(2,4), 16),
+                parseInt(h.substring(4,6), 16)
+            ];
+
+            return "rgba(" + rgb[0] + "," + rgb[1] + "," + rgb[2] + "," + a + ")";
+        };
+
+        this.copy = function (f, t) {
+            for (var i in f) {
+                t[i] = f[i];
+            }
+        };
+    };
+
+
+    /**
+     * k.Dial
+     */
+    k.Dial = function () {
+        k.o.call(this);
+
+        this.startAngle = null;
+        this.xy = null;
+        this.radius = null;
+        this.lineWidth = null;
+        this.cursorExt = null;
+        this.w2 = null;
+        this.PI2 = 2*Math.PI;
+
+        this.extend = function () {
+            this.o = $.extend({
+                bgColor: this.$.data('bgcolor') || '#EEEEEE',
+                angleOffset: this.$.data('angleoffset') || 0,
+                angleArc: this.$.data('anglearc') || 360,
+                inline: true
+            }, this.o);
+        };
+
+        this.val = function (v, triggerRelease) {
+            if (null != v) {
+
+                // reverse format
+                v = this.o.parse(v);
+
+                if (triggerRelease !== false
+                    && v != this.v
+                    && this.rH
+                    && this.rH(v) === false) { return; }
+
+                this.cv = this.o.stopper ? max(min(v, this.o.max), this.o.min) : v;
+                this.v = this.cv;
+                this.$.val(this.o.format(this.v));
+                this._draw();
+            } else {
+                return this.v;
+            }
+        };
+
+        this.xy2val = function (x, y) {
+            var a, ret;
+
+            a = Math.atan2(
+                        x - (this.x + this.w2),
+                        - (y - this.y - this.w2)
+                    ) - this.angleOffset;
+
+            if (this.o.flip) {
+                a = this.angleArc - a - this.PI2;
+            }
+
+            if (this.angleArc != this.PI2 && (a < 0) && (a > -0.5)) {
+
+                // if isset angleArc option, set to min if .5 under min
+                a = 0;
+            } else if (a < 0) {
+                a += this.PI2;
+            }
+
+            ret = (a * (this.o.max - this.o.min) / this.angleArc) + this.o.min;
+
+            this.o.stopper && (ret = max(min(ret, this.o.max), this.o.min));
+
+            return ret;
+        };
+
+        this.listen = function () {
+
+            // bind MouseWheel
+            var s = this, mwTimerStop,
+                mwTimerRelease,
+                mw = function (e) {
+                    e.preventDefault();
+
+                    var ori = e.originalEvent,
+                        deltaX = ori.detail || ori.wheelDeltaX,
+                        deltaY = ori.detail || ori.wheelDeltaY,
+                        v = s._validate(s.o.parse(s.$.val()))
+                            + (
+                                deltaX > 0 || deltaY > 0
+                                ? s.o.step
+                                : deltaX < 0 || deltaY < 0 ? -s.o.step : 0
+                              );
+
+                    s.o.stopper && (v = max(min(v, s.o.max), s.o.min));
+
+                    if (s.cH && s.cH(v) === false) return;
+                    s.val(v, false);
+
+                    if (s.rH) {
+                        // Handle mousewheel stop
+                        clearTimeout(mwTimerStop);
+                        mwTimerStop = setTimeout(function () {
+                            s.rH(v);
+                            mwTimerStop = null;
+                        }, 100);
+
+                        // Handle mousewheel releases
+                        if (!mwTimerRelease) {
+                            mwTimerRelease = setTimeout(function () {
+                                if (mwTimerStop)
+                                    s.rH(v);
+                                mwTimerRelease = null;
+                            }, 200);
+                        }
+                    }
+                },
+                kval,
+                to,
+                m = 1,
+                kv = {
+                    37: -s.o.step,
+                    38: s.o.step,
+                    39: s.o.step,
+                    40: -s.o.step
+                };
+
+            this.$
+                .bind(
+                    "keydown",
+                    function (e) {
+                        var kc = e.keyCode;
+
+                        // numpad support
+                        if (kc >= 96 && kc <= 105) {
+                            kc = e.keyCode = kc - 48;
+                        }
+
+                        kval = parseInt(String.fromCharCode(kc));
+
+                        if (isNaN(kval)) {
+                            (kc !== 13)                     // enter
+                            && kc !== 8                     // bs
+                            && kc !== 9                     // tab
+                            && kc !== 189                   // -
+                            && (kc !== 190
+                                || s.$.val().match(/\./))   // . allowed once
+                            && e.preventDefault();
+
+                            // arrows
+                            if ($.inArray(kc,[37,38,39,40]) > -1) {
+                                e.preventDefault();
+
+                                var v = s.o.parse(s.$.val()) + kv[kc] * m;
+                                s.o.stopper && (v = max(min(v, s.o.max), s.o.min));
+
+                                s.change(s._validate(v));
+                                s._draw();
+
+                                // long time keydown speed-up
+                                to = window.setTimeout(function () {
+                                    m = 2;
+                                }, 30);
+                            }
+                        }
+                    }
+                )
+                .bind(
+                    "keyup",
+                    function (e) {
+                        if (isNaN(kval)) {
+                            if (to) {
+                                window.clearTimeout(to);
+                                to = null;
+                                m = 1;
+                                s.val(s.$.val());
+                            }
+                        } else {
+                            // kval postcond
+                            (s.$.val() > s.o.max && s.$.val(s.o.max))
+                            || (s.$.val() < s.o.min && s.$.val(s.o.min));
+                        }
+                    }
+                );
+
+            this.$c.bind("mousewheel DOMMouseScroll", mw);
+            this.$.bind("mousewheel DOMMouseScroll", mw);
+        };
+
+        this.init = function () {
+            if (this.o.stopper && (this.v < this.o.min
+                || this.v > this.o.max)) { this.v = this.o.min; }
+
+            this.$.val(this.v);
+            this.w2 = this.w / 2;
+            this.cursorExt = this.o.cursor / 100;
+            this.xy = this.w2 * this.scale;
+            this.lineWidth = this.xy * this.o.thickness;
+            this.lineCap = this.o.lineCap;
+            this.radius = this.xy - this.lineWidth / 2;
+
+            this.o.angleOffset
+            && (this.o.angleOffset = isNaN(this.o.angleOffset) ? 0 : this.o.angleOffset);
+
+            this.o.angleArc
+            && (this.o.angleArc = isNaN(this.o.angleArc) ? this.PI2 : this.o.angleArc);
+
+            // deg to rad
+            this.angleOffset = this.o.angleOffset * Math.PI / 180;
+            this.angleArc = this.o.angleArc * Math.PI / 180;
+
+            // compute start and end angles
+            this.startAngle = 1.5 * Math.PI + this.angleOffset;
+            this.endAngle = 1.5 * Math.PI + this.angleOffset + this.angleArc;
+
+            var s = max(
+                String(Math.abs(this.o.max)).length,
+                String(Math.abs(this.o.min)).length,
+                2
+            ) + 2;
+            let fontSize = this.o.fontSize || (((this.w / s) >> 0) + 'px');
+
+            this.o.displayInput
+                && this.i.css({
+                        'width' : ((this.w / 2 + 4) >> 0) + 'px',
+                        'height' : ((this.w / 3) >> 0) + 'px',
+                        'position' : 'absolute',
+                        'vertical-align' : 'middle',
+                        'margin-top' : ((this.w / 3) >> 0) + 'px',
+                        'margin-left' : '-' + ((this.w * 3 / 4 + 2) >> 0) + 'px',
+                        'border' : 0,
+                        'background' : 'none',
+                        'font' : this.o.fontWeight + ' ' + fontSize + ' ' + this.o.font,
+                        'text-align' : 'center',
+                        'color' : this.o.inputColor || this.o.fgColor,
+                        'padding' : '0px',
+                        '-webkit-appearance': 'none'
+                        }) || this.i.css({
+                            'width': '0px',
+                            'visibility': 'hidden'
+                        });
+        };
+
+        this.change = function (v) {
+            if (this.cH && this.cH(v) === false) return;
+            this.cv = v;
+            this.$.val(this.o.format(v));
+        };
+
+        this.angle = function (v) {
+            return (v - this.o.min) * this.angleArc / (this.o.max - this.o.min);
+        };
+
+        this.arc = function (v) {
+          var sa, ea;
+          v = this.angle(v);
+          if (this.o.flip) {
+              sa = this.endAngle + 0.00001;
+              ea = sa - v - 0.00001;
+          } else {
+              sa = this.startAngle - 0.00001;
+              ea = sa + v + 0.00001;
+          }
+          this.o.cursor
+              && (sa = ea - this.cursorExt)
+              && (ea = ea + this.cursorExt);
+
+          return {
+              s: sa,
+              e: ea,
+              d: this.o.flip && !this.o.cursor
+          };
+        };
+
+        this.draw = function () {
+            var c = this.g,                 // context
+                a = this.arc(this.cv),      // Arc
+                pa,                         // Previous arc
+                r = 1;
+
+            c.lineWidth = this.lineWidth;
+            c.lineCap = this.lineCap;
+
+            if (this.o.bgColor !== "none") {
+                c.beginPath();
+                    c.strokeStyle = this.o.bgColor;
+                    c.arc(this.xy, this.xy, this.radius, this.endAngle - 0.00001, this.startAngle + 0.00001, true);
+                c.stroke();
+            }
+
+            if (this.o.displayPrevious) {
+                pa = this.arc(this.v);
+                c.beginPath();
+                c.strokeStyle = this.pColor;
+                c.arc(this.xy, this.xy, this.radius, pa.s, pa.e, pa.d);
+                c.stroke();
+                r = this.cv == this.v;
+            }
+
+            c.beginPath();
+            c.strokeStyle = r ? this.o.fgColor : this.fgColor ;
+            c.arc(this.xy, this.xy, this.radius, a.s, a.e, a.d);
+            c.stroke();
+        };
+
+        this.cancel = function () {
+            this.val(this.v);
+        };
+    };
+
+    $.fn.dial = $.fn.knob = function (o) {
+        return this.each(
+            function () {
+                var d = new k.Dial();
+                d.o = o;
+                d.$ = $(this);
+                d.run();
+            }
+        ).parent();
+    };
+
+}));

--- a/src/extensions/default/QuickView/unittests.js
+++ b/src/extensions/default/QuickView/unittests.js
@@ -160,9 +160,9 @@ define(function (require, exports, module) {
             });
 
             it("should NOT show preview of unsupported hsl/hsla colors",async function () {
-                await expectNoPreviewAtPos(38, 25);    // cursor on hsla(90, 100%, 50%, 2)
-                await expectNoPreviewAtPos(39, 24);    // cursor on hsla(0, 200%, 50%, 0.5)
-                await expectNoPreviewAtPos(40, 25);    // cursor on hsla(0.0, 100%, 50%, .5)
+                await expectNoPreviewAtPos(38, 14);    // cursor on hsla(90, 100%, 50%, 2)
+                await expectNoPreviewAtPos(39, 14);    // cursor on hsla(0, 200%, 50%, 0.5)
+                await expectNoPreviewAtPos(40, 14);    // cursor on hsla(0.0, 100%, 50%, .5)
             });
 
             it("should show preview of colors with valid names", async function () {

--- a/src/features/PriorityBasedRegistration.js
+++ b/src/features/PriorityBasedRegistration.js
@@ -65,26 +65,13 @@ define(function (require, exports, module) {
             },
             self = this;
 
-        if (languageIds.indexOf("all") !== -1) {
-            // Ignore anything else in languageIds and just register for every language. This includes
-            // the special "all" language since its key is in the hintProviders map from the beginning.
-            var languageId;
-            for (languageId in self._providers) {
-                if (self._providers.hasOwnProperty(languageId)) {
-                    self._providers[languageId].push(providerObj);
-                    self._providers[languageId].sort(_providerSort);
-                }
+        languageIds.forEach(function (languageId) {
+            if (!self._providers[languageId]) {
+                self._providers[languageId] = [];
             }
-        } else {
-            languageIds.forEach(function (languageId) {
-                if (!self._providers[languageId]) {
-                    // Initialize provider list with any existing all-language providers
-                    self._providers[languageId] = Array.prototype.concat(self._providers.all);
-                }
-                self._providers[languageId].push(providerObj);
-                self._providers[languageId].sort(_providerSort);
-            });
-        }
+            self._providers[languageId].push(providerObj);
+            self._providers[languageId].sort(_providerSort);
+        });
     };
 
     /**
@@ -122,7 +109,8 @@ define(function (require, exports, module) {
 
 
     RegistrationHandler.prototype.getProvidersForLanguageId = function (languageId) {
-        var providers = this._providers[languageId] || this._providers.all;
+        var providers = (this._providers[languageId] || []).concat(this._providers.all || [])
+            .sort(_providerSort);
 
         // Exclude providers that are explicitly disabled in the preferences.
         // All providers that do not have their constructor

--- a/src/features/QuickViewManager.js
+++ b/src/features/QuickViewManager.js
@@ -172,9 +172,9 @@ define(function (require, exports, module) {
         registerQuickViewProvider = _providerRegistrationHandler.registerProvider.bind(_providerRegistrationHandler),
         removeQuickViewProvider = _providerRegistrationHandler.removeProvider.bind(_providerRegistrationHandler);
 
-    function _getQuickViewProviders(editor) {
+    function _getQuickViewProviders(editor, pos) {
         let quickViewProviders = [];
-        let language = editor.getLanguageForSelection(),
+        let language = editor.getLanguageForPosition(pos),
             enabledProviders = _providerRegistrationHandler.getProvidersForLanguageId(language.getId());
 
         for(let item of enabledProviders){
@@ -384,7 +384,7 @@ define(function (require, exports, module) {
      */
     async function queryPreviewProviders(editor, pos, token) {
         let line = editor.document.getLine(pos.line);
-        let providerInfos = _getQuickViewProviders(editor);
+        let providerInfos = _getQuickViewProviders(editor, pos);
         let providerPromises = [], resultPriorities = [];
         for(let providerInfo of providerInfos){
             let provider = providerInfo.provider;

--- a/src/features/QuickViewManager.js
+++ b/src/features/QuickViewManager.js
@@ -107,7 +107,8 @@
  *                 start: {line: pos.line, ch:token.start},
  *                 end: {line: pos.line, ch:token.end},
  *                 content: "<div>hello world</div>",
- *                 exclusive: false // this is optional. See details below:
+ *                 exclusive: false, // this is optional. See details below:
+ *                 editsDoc: false // this is optional if the quick view edits the current doc
  *             });
  *         });
  *     };
@@ -126,8 +127,9 @@
  * 1. `end` : Indicates the end cursor position to which the quick view is valid. These are generally used to highlight
  *    the hovered section of the text in the editor.
  * 1. `content`: Either `HTML` as text, a `DOM Node` or a `Jquery Element`.
- * 1. `exclusive`: Set to true if only this popup should be shown if multiple providers returns a valid popup.
+ * 1. `exclusive`: Optional, set to true if only this popup should be shown if multiple providers returns a valid popup.
  *     If multiple providers return `exclusive` flag, the provider with the highest priority wins.
+ * 1. `editsDoc`: Optional, set to true if the quick view can edit the active document.
  *
  * #### Modifying the QuickView content after resolving `getQuickView` promise
  * Some advanced/interactive extensions may need to do dom operations on the quick view content.
@@ -328,6 +330,9 @@ define(function (require, exports, module) {
                 }
                 if(_isResultAfterPopoverEnd(editor, popover, result)){
                     popover.end = result.end;
+                }
+                if(result.editsDoc){
+                    popover.editsDoc = true;
                 }
                 popover.content.append(result.content);
             }
@@ -557,16 +562,22 @@ define(function (require, exports, module) {
         }
     }
 
+    function docChanged() {
+        if(popoverState && !popoverState.editsDoc){
+            hidePreview();
+        }
+    }
+
     function onActiveEditorChange(event, current, previous) {
         // Hide preview when editor changes
         hidePreview();
 
         if (previous && previous.document) {
-            previous.document.off("change", hidePreview);
+            previous.document.off("change", docChanged);
         }
 
         if (current && current.document) {
-            current.document.on("change", hidePreview);
+            current.document.on("change", docChanged);
         }
     }
 

--- a/src/features/QuickViewManager.js
+++ b/src/features/QuickViewManager.js
@@ -45,6 +45,8 @@
  * // replace `all` with language ID(Eg. javascript) if you want to restrict the preview to js files only.
  * QuickViewManager.registerQuickViewProvider(exports, ["all"]);
  *
+ * // provide a helpful name for the QuickView. This will be useful if you have to debug the quick view
+ * exports.QUICK_VIEW_NAME = "extension.someName";
  * // now implement the getQuickView function that will be invoked when ever user hovers over a text in the editor.
  * exports.getQuickView = function(editor, pos, token, line) {
  *         return new Promise((resolve, reject)=>{

--- a/src/features/SelectionViewManager.js
+++ b/src/features/SelectionViewManager.js
@@ -46,6 +46,8 @@
  * // replace `all` with language ID(Eg. javascript) if you want to restrict the preview to js files only.
  * SelectionViewManager.registerSelectionViewProvider(exports, ["all"]);
  *
+ * // provide a helpful name for the SelectionView. This will be useful if you have to debug the selection view
+ * exports.SELECTION_VIEW_NAME = "extension.someName";
  * // now implement the getSelectionView function that will be invoked when ever user selection changes in the editor.
  * exports.getSelectionView = function(editor, selections) {
  *         return new Promise((resolve, reject)=>{

--- a/src/language/CodeInspection.js
+++ b/src/language/CodeInspection.js
@@ -928,7 +928,8 @@ define(function (require, exports, module) {
         toggleCollapsed(prefs.get(PREF_COLLAPSED), true);
 
         QuickViewManager.registerQuickViewProvider({
-            getQuickView
+            getQuickView,
+            QUICK_VIEW_NAME: "CodeInspection"
         }, ["all"]);
     });
 

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -832,6 +832,7 @@ define({
     "DESCRIPTION_QUICK_VIEW_ENABLED": "true to enable Quick View",
     "DESCRIPTION_SELECTION_VIEW_ENABLED": "true to enable Selection View",
     "DESCRIPTION_EXTENSION_LESS_IMAGE_PREVIEW": "true to show image previews for URLs missing extensions",
+    "DESCRIPTION_NUMBER_QUICK_VIEW": "true to show Quick View on hover over numbers in editor",
     "DESCRIPTION_THEME": "Select a {APP_NAME} theme",
     "DESCRIPTION_USE_THEME_SCROLLBARS": "true to allow custom scroll bars",
     "DESCRIPTION_LINTING_COLLAPSED": "true to collapse linting panel",

--- a/src/thirdparty/licences/jquery-knob.markdown
+++ b/src/thirdparty/licences/jquery-knob.markdown
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2013 Anthony Terrien
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/utils/Metrics.js
+++ b/src/utils/Metrics.js
@@ -73,6 +73,7 @@ define(function (require, exports, module) {
         KEYBOARD: "keyboard",
         CODE_HINTS: "code-hints",
         EDITOR: "editor",
+        QUICK_VIEW: "quickView",
         SEARCH: "search",
         SHARING: "sharing",
         PERFORMANCE: "performance",

--- a/test/spec/QuickViewManager-test.js
+++ b/test/spec/QuickViewManager-test.js
@@ -206,8 +206,9 @@ define(function (require, exports, module) {
         describe("Quick view register provider", function (){
             let pos, token, line;
 
-            function getProvider(html, noPreview, exclusive = false) {
+            function getProvider(html, {noPreview, exclusive, name}) {
                 return {
+                    QUICK_VIEW_NAME: name,
                     getQuickView: function(editor, posx, tokenx, linex) {
                         expect(editor).toBeDefined();
                         pos = posx; token = tokenx; line = linex;
@@ -227,11 +228,16 @@ define(function (require, exports, module) {
                 };
             }
 
-            let provider = getProvider("<div id='blinker-fluid'>hello world</div>");
-            let provider2 = getProvider("<div id='blinker-fluid2'>hello world</div>");
-            let providerNoPreview = getProvider("<div id='blinker-fluid3'>hello world</div>", true);
-            let exclusiveProvider1 = getProvider("<div id='blinker-fluid4'>hello world</div>", false, true);
-            let exclusiveProvider2 = getProvider("<div id='blinker-fluid5'>hello world</div>", false, true);
+            let provider = getProvider("<div id='blinker-fluid'>hello world</div>",
+                {name: "provider"});
+            let provider2 = getProvider("<div id='blinker-fluid2'>hello world</div>",
+                {name: "provider2"});
+            let providerNoPreview = getProvider("<div id='blinker-fluid3'>hello world</div>",
+                {noPreview:true, name: "providerNoPreview"});
+            let exclusiveProvider1 = getProvider("<div id='blinker-fluid4'>hello world</div>",
+                {exclusive:true, name: "exclusiveProvider1"});
+            let exclusiveProvider2 = getProvider("<div id='blinker-fluid5'>hello world</div>",
+                {exclusive:true, name: "exclusiveProvider2"});
 
             beforeEach(async function () {
                 await awaitsForDone(SpecRunnerUtils.openProjectFiles([testFile]), "open test file: " + testFile);


### PR DESCRIPTION
- chore: add quick view exclusive flag to show only one quick view instead of all for a location
- feat: numeric quick view for live preview
- feat: knob with infinite scroll and  works with negative values touch plus mouse
- feat: knob edit left and right arrow working inside text edit
- feat: quickview language mode detection change on hover
- feat: quickview doesnt dismiss on document change
- fix: quickview number filed update on keyboard edit
- docs: update quickviewManager
- fix: number quick view negative number up and down
![number quick view](https://user-images.githubusercontent.com/5336369/207240516-cf4ecc53-3c58-4bf4-8c33-039fe9598ca5.gif)

## pending
* unit and integ tests
* number editor in inline html styles