### PR TITLE
tauri shell adpater and window size and positioning logic

### DIFF
--- a/src/phoenix/shell.js
+++ b/src/phoenix/shell.js
@@ -28,6 +28,7 @@
 import init from "./init_vfs.js";
 import ERR_CODES from "./errno.js";
 import getBrowserDetails from "./browserDetails.js";
+import initTauriShell from "./tauriShell.js";
 
 function _getBaseURL() {
     // strip query string
@@ -76,4 +77,9 @@ Phoenix.app = {
 
 if(!window.appshell){
     window.appshell = Phoenix;
+}
+
+if(window.__TAURI__) {
+    // the __TAURI__ object will be present if we are in a tauri window
+    initTauriShell();
 }

--- a/src/phoenix/tauriShell.js
+++ b/src/phoenix/tauriShell.js
@@ -1,0 +1,68 @@
+/*
+ * GNU AGPL-3.0 License
+ *
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
+ *
+ */
+
+// jshint ignore: start
+/*globals __TAURI__*/
+
+const TAURI_KEYS = {
+    LAST_WINDOW_WIDTH: "tauri.LAST_WINDOW_WIDTH",
+    LAST_WINDOW_HEIGHT: "tauri.LAST_WINDOW_HEIGHT"
+};
+
+const appWindow = __TAURI__.window.appWindow;
+
+function _setupWindowResizeListeners() {
+    appWindow.onResized(async ({ payload: size }) => {
+        const maximized = await appWindow.isMaximized();
+        if(!maximized) {
+            localStorage.setItem(TAURI_KEYS.LAST_WINDOW_HEIGHT, size.height);
+            localStorage.setItem(TAURI_KEYS.LAST_WINDOW_WIDTH, size.width);
+        }
+    });
+}
+
+async function positionWindow() {
+    const phoenixAspectRatio = 1.6,  // phoenix looks good in aspect ratio 1.6w:1h
+        minWidth = 800,
+        minHeight = 600;
+    let monitorSize = (await __TAURI__.window.currentMonitor()).size,
+        targetWindowHeight = monitorSize.height * 2/3,
+        targetWindowWidth = targetWindowHeight * phoenixAspectRatio;
+    let targetHeight = parseInt(localStorage.getItem(TAURI_KEYS.LAST_WINDOW_HEIGHT) || `${targetWindowHeight}`),
+        targetWidth =  parseInt(localStorage.getItem(TAURI_KEYS.LAST_WINDOW_WIDTH) || `${targetWindowWidth}`);
+    if(targetHeight.height > monitorSize.height || targetWidth.width > monitorSize.width){
+        // our window is larger than the monitor, so just maximise to fit to monitor
+        appWindow.maximize();
+        _setupWindowResizeListeners();
+        return;
+    }
+    if(targetHeight < minHeight){
+        targetHeight = minHeight;
+    }
+    if(targetWidth < minWidth){
+        targetWidth = minWidth;
+    }
+    await appWindow.setSize(new __TAURI__.window.PhysicalSize(targetWidth, targetHeight));
+    _setupWindowResizeListeners();
+}
+
+function initTauriShell() {
+    positionWindow();
+}
+
+export default initTauriShell;

--- a/src/phoenix/tauriShell.js
+++ b/src/phoenix/tauriShell.js
@@ -17,14 +17,15 @@
  */
 
 // jshint ignore: start
-/*globals __TAURI__*/
+/*globals*/
+const TAURI = window.__TAURI__;
 
 const TAURI_KEYS = {
     LAST_WINDOW_WIDTH: "tauri.LAST_WINDOW_WIDTH",
     LAST_WINDOW_HEIGHT: "tauri.LAST_WINDOW_HEIGHT"
 };
 
-const appWindow = __TAURI__.window.appWindow;
+const appWindow = TAURI && TAURI.window.appWindow;
 
 function _setupWindowResizeListeners() {
     appWindow.onResized(async ({ payload: size }) => {
@@ -40,7 +41,7 @@ async function positionWindow() {
     const phoenixAspectRatio = 1.6,  // phoenix looks good in aspect ratio 1.6w:1h
         minWidth = 800,
         minHeight = 600;
-    let monitorSize = (await __TAURI__.window.currentMonitor()).size,
+    let monitorSize = (await TAURI.window.currentMonitor()).size,
         targetWindowHeight = monitorSize.height * 2/3,
         targetWindowWidth = targetWindowHeight * phoenixAspectRatio;
     let targetHeight = parseInt(localStorage.getItem(TAURI_KEYS.LAST_WINDOW_HEIGHT) || `${targetWindowHeight}`),
@@ -57,7 +58,7 @@ async function positionWindow() {
     if(targetWidth < minWidth){
         targetWidth = minWidth;
     }
-    await appWindow.setSize(new __TAURI__.window.PhysicalSize(targetWidth, targetHeight));
+    await appWindow.setSize(new TAURI.window.PhysicalSize(targetWidth, targetHeight));
     _setupWindowResizeListeners();
 }
 


### PR DESCRIPTION
- feat: Tauri shell adapter and window size and positioning logic
- fix: browser load fail after Tauri shell adapter init

## window initial positioning logic
* Phoenix will remember the last window's size and resize the window on launch.
* Edge case check like min window size is 800x600, max size should not be larger than monitor size.