### PR TITLE
fix: showing mobile device is not supported message instead of browser not supported

### DIFF
--- a/src/extensions/default/Phoenix/main.js
+++ b/src/extensions/default/Phoenix/main.js
@@ -33,6 +33,7 @@ define(function (require, exports, module) {
         Strings      = brackets.getModule("strings"),
         Dialogs      = brackets.getModule("widgets/Dialogs"),
         Mustache     = brackets.getModule("thirdparty/mustache/mustache"),
+        DefaultDialogs = brackets.getModule("widgets/DefaultDialogs"),
         unSupportedBrowserTemplate     = require("text!html/unsupported-browser.html");
 
     const PERSIST_STORAGE_DIALOG_DELAY_SECS = 60000;
@@ -57,6 +58,14 @@ define(function (require, exports, module) {
             return;
         }
         unsupportedBrowserDialogShown = true;
+        if(Phoenix.browser.isMobile || Phoenix.browser.isTablet){
+            Dialogs.showModalDialog(
+                DefaultDialogs.DIALOG_ID_ERROR,
+                Strings.UNSUPPORTED_BROWSER,
+                Strings.UNSUPPORTED_BROWSER_MOBILE
+            );
+            return;
+        }
         let templateVars = {
             Strings: Strings,
             surveyURL: "https://s.surveyplanet.com/6208d1eccd51c561fc8e59ca"

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -922,9 +922,10 @@ define({
 
     // Phoenix extension
     "UNSUPPORTED_BROWSER": "Browser Is Not Supported",
+    "UNSUPPORTED_BROWSER_MOBILE": "Mobile and Tablet devices are currently not fully supported. You may close this dialogue, but some features in Phoenix will not work in this browser.",
     "UNSUPPORTED_BROWSER_OPEN_FOLDER": "Browser does not support Open folder. Please use Chrome, Edge or Opera to open local folders.",
     "UNSUPPORTED_BROWSER_MESSAGE_LINE1": "Please use one of the supported browsers below.",
-    "UNSUPPORTED_BROWSER_MESSAGE_LINE2": " We are working hard to make Phoenix available in more browsers. You may close this dialogue, but some features in Phoenix won't work in this browser.",
+    "UNSUPPORTED_BROWSER_MESSAGE_LINE2": " We are working hard to make Phoenix available in more browsers. You may close this dialogue, but some features in Phoenix will not work in this browser.",
     "CANNOT_PUBLISH_LARGE_PROJECT": "Cannot Publish Large Project",
     "CANNOT_PUBLISH_LARGE_PROJECT_MESSAGE": "Phoenix is still in experimental alpha. We have not yet enabled sync of projects with greater than 500 files.",
     "SHARE_WEBSITE": "Publish and Share Website?",


### PR DESCRIPTION
mitigates https://github.com/phcode-dev/phoenix/issues/703
better error messaging specific to mobile devices not supported

![image](https://user-images.githubusercontent.com/5336369/210152454-6ea99715-71e0-4dd1-953a-ab77b84dc554.png)
