### PR TITLE
feat: gating development sites behind devEnable flag

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,29 +1,36 @@
-<!--
-Update "[ ]" to "[x]" to check a box
--->
-
 ### What kind of change does this PR introduce?
-<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->
+<!-- Delete ones that doesnt apply-->
 
-- [ ] Bugfix
-- [ ] Feature
-- [ ] Docs
-- [ ] New Binding issue #___
-- [ ] Code style update
-- [ ] Refactor
-- [ ] Build-related changes
-- [ ] Other, please describe:
+- Bugfix - fixes issues- give issue github url/details here.
+- Feature
+- Docs
+- Code style update
+- Refactor
+- Build-related changes
+- Other, please describe:
+
+### Screenshots or Gifs of the change
+1. Any visual or workflow changes must come with a gif or screenshot.
+2. Gif screen recordings help more if present. You can use one of the below free screen recorders:
+   1. windows gif recorder- https://www.screentogif.com/
+   2. mac gif recorder- https://apps.apple.com/au/app/giphy-capture-the-gif-maker/id668208984?mt=12
+   3. linux gif recorder-  https://github.com/phw/peek
 
 ### Does this PR introduce a breaking change?
 <!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->
 
-- [ ] Yes, and the changes were approved in issue #___
-- [ ] No
+- Yes, and the changes were approved in issue #___
+- No
+
+### Tests done
+- Describe unit tests done
+- Describe integration tests done
+- Describe manual tests done
 
 ### Checklist
-- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
-- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
-- [ ] I have added a convincing reason for adding this feature, if necessary
+- [ ] When resolving issues, reference those issue URLs in description.
+- [ ] Propose a changelog if this pull request has any customer facing impact.
+- [ ] I have added a convincing reason for adding this feature, if necessary.
 
 ### Other information
 
@@ -32,3 +39,4 @@ Update "[ ]" to "[x]" to check a box
 * It's OK to have multiple small commits as you work on the PR - we will let GitHub automatically squash it before merging.
 * If adding new feature:, Provide convincing reason to add this feature. Ideally you should open a suggestion issue first and have it greenlighted before working on it.
 * If fixing a bug:Provide detailed description of the bug in the PR, or link to an issue that does.
+* Provide screenshots or gifs of the changes whenever possible.

--- a/src/devEnable.html
+++ b/src/devEnable.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>Enable Phoenix development site</title>
+        <link rel="stylesheet" href="styles.css" />
+        <script>
+            function showEnabledStatus() {
+                let enabled = localStorage.getItem("devDomainsEnabled") === "true",
+                    statusMessage = `Dev site at ${location.hostname} is currently disabled`,
+                    btnMessage = `Enable ${location.hostname}`,
+                    color = "red";
+                if(enabled){
+                    statusMessage = `Dev site at ${location.hostname} is currently Enabled`;
+                    btnMessage = `Disable ${location.hostname}`;
+                    color = "green";
+                }
+                document.getElementById("heading").textContent = `Enable or Disable Phoenix Development site at: ${location.hostname}`;
+                document.getElementById("enableStatus").textContent = statusMessage;
+                document.getElementById('enableStatus').style.color = color;
+                document.getElementById("enableBtn").textContent = btnMessage;
+            }
+            function buttonClicked() {
+                let enabled = localStorage.getItem("devDomainsEnabled") === "true";
+                enabled = "" + (!enabled);
+                localStorage.setItem("devDomainsEnabled", enabled);
+                showEnabledStatus();
+            }
+        </script>
+    </head>
+    <body onload="showEnabledStatus()">
+        <h1 id="heading">Enable or Disable Phoenix Dev site.</h1>
+        <div id="enableStatus">Checking if dev site is enabled...</div>
+        <br />
+        <button id="enableBtn" onclick="buttonClicked()">Click me</button>
+    </body>
+</html>

--- a/src/index.html
+++ b/src/index.html
@@ -45,6 +45,14 @@
 
     <!-- JavaScript -->
     <script type="text/javascript">
+        if(["dev.phcode.dev", "staging.phcode.dev"].includes(location.hostname)
+            && localStorage.getItem("devDomainsEnabled") !== "true"){
+            alert("Hello explorer, you have reached a development version of phcode.dev that is not for general use and could be very unstable." +
+                `\n\nIf you know what you are doing and what to visit the dev site, please go to https://${location.hostname}/devEnable.html to enable dev site and visit again.` +
+                "\n\nYou will now be redirected to phcode.dev.");
+            window.location = "https://phcode.dev";
+        }
+
         // logger setup
         function swallowLogs() {
             // Do nothing


### PR DESCRIPTION
addresses https://github.com/phcode-dev/phoenix/issues/804

Visitors to `dev.phcode.dev` and `staging.phcode.dev` will be redirected to `phcode.dev` unless they go to `dev.phcode.dev/devEnable.html` and `staging.phcode.dev/devEnable.html` to enable dev site access

![image](https://user-images.githubusercontent.com/5336369/210176928-dfa70099-b229-4197-9fc1-d8743c9d7f68.png)
![image](https://user-images.githubusercontent.com/5336369/210176943-c3e8d17d-e3e0-45c0-98bb-89e4d4123eb4.png)
