### PR TITLE
fix: cancelling file>new on escape key caused new file creation to not work again

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -759,10 +759,13 @@ define(function (require, exports, module) {
         // of validating file name, creating the new file and selecting.
         function createWithSuggestedName(suggestedName) {
             return ProjectManager.createNewItem(baseDirEntry, suggestedName, false, isFolder)
-                .done(function (file) {
-                    DocumentManager.getDocumentForPath(file.fullPath)
+                .done(function (fileOrStatus) {
+                    if(!(typeof fileOrStatus === 'object' && fileOrStatus.fullPath)){
+                        return;
+                    }
+                    DocumentManager.getDocumentForPath(fileOrStatus.fullPath)
                         .done(doc =>{
-                            NewFileContentManager.getInitialContentForFile(file.fullPath).then(content =>{
+                            NewFileContentManager.getInitialContentForFile(fileOrStatus.fullPath).then(content =>{
                                 doc.setText(content);
                             });
                         })


### PR DESCRIPTION
## fix for the below issue
* right on file tree and > click new file
* press escape to cancel new file creation
* The new file gets created as untitled - bug 1
* right on file tree and > click new file : nothing happens - bug 2
