### PR TITLE
feat: transparent updates and delay cache refresh till after app loads

### DIFF
--- a/src/phoenix/virtual-server-loader.js
+++ b/src/phoenix/virtual-server-loader.js
@@ -113,7 +113,7 @@ if (_isServiceWorkerLoaderPage() && 'serviceWorker' in navigator) {
                 console.log(`Service worker loader: clear cache updatedFilesCount: `, updatedFilesCount);
                 window.Phoenix.cache.updatePendingReloadReason = "clearCache";
                 window.Phoenix.cache.showUpdateDialogue = true;
-                window.Phoenix.cache.updatedFilesCount = updatedFilesCount;
+                window.Phoenix.cache.updatedFilesCount = updatedFilesCount || 0;
                 localStorage.setItem(cacheKey, newCacheVersion);
                 doneCB();
             }).catch(err=>{
@@ -142,7 +142,7 @@ if (_isServiceWorkerLoaderPage() && 'serviceWorker' in navigator) {
         }).then(({updatedFilesCount})=>{
             console.log(`Service worker loader: refresh cache updatedFilesCount: `, updatedFilesCount);
             window.Phoenix.cache.updatePendingReloadReason = "refreshCache";
-            window.Phoenix.cache.updatedFilesCount = updatedFilesCount;
+            window.Phoenix.cache.updatedFilesCount = updatedFilesCount || 0;
             doneCB();
         }).catch(err=>{
             console.error("Service worker loader: Error while triggering refresh cache", err);

--- a/src/virtual-server-main.js
+++ b/src/virtual-server-main.js
@@ -143,12 +143,13 @@ workbox.routing.registerRoute(
 );
 
 // cache and offline access route
-function _clearCache() {
+function _clearCache(event) {
     caches.open(CACHE_NAME_EVERYTHING).then((cache) => {
         cache.keys().then((keys) => {
             keys.forEach((request, index, array) => {
                 cache.delete(request);
             });
+            event.ports[0].postMessage({updatedFilesCount: keys.length});
         });
     });
 }
@@ -281,7 +282,7 @@ addEventListener('message', (event) => {
             self._debugSWLivePreviewLogs = event.data.logLivePreview;
             self.__WB_DISABLE_DEV_LOGS = Config.debug && _debugSWCacheLogs;
             event.ports[0].postMessage({baseURL}); break;
-        case 'CLEAR_CACHE': _clearCache(); break;
+        case 'CLEAR_CACHE': _clearCache(event); break;
         case 'REFRESH_CACHE': _refreshCache(event); break;
         case 'setInstrumentedURLs': self.Serve.setInstrumentedURLs(event); return true;
         default:


### PR DESCRIPTION
Addresses more of https://github.com/phcode-dev/phoenix/issues/802

Transparent updates mostly without showing an update dialogue to the user.

* change made to cache refresh infra so that cache is only refreshed after phoenix is loaded to prevent inconsistent loads from cached and non-cached js files.
* The update dialogue will now only be shown now if an explicit cache version bump is made in virtual-server-loader.js::_forceClearCacheIfNeeded
* Added metrics for cache stats and errors