### PR TITLE
fix: prevent inconsistant browser cache reset and updates

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -34,9 +34,64 @@
     <meta name="msapplication-TileColor" content="#47484B">
     <title>Phoenix</title>
 
-    <!-- CSS/LESS -->
+    <!-- Bootstrap cache check. since index.html is always loaded network first, the cache reset code will always
+    be guaranteed to be hit on app update.
+    Note that this cannot be moved to a separate file and should be in index.html due to above reason.
+    -->
+    <script type="module">
+        // this is a nuke cache option. Though mostly safe, Use it wisely to prevent slow startup when resetting.
+        const CACHE_NAME_EVERYTHING = "everything";
+        function _resetCacheIfNeeded() {
+            window.cacheClearError;
+            const cacheKey = "browserCacheVersionKey";
+            const newCacheVersion = "V3"; // just increment this number to V2, v3 etc. to force clear the cached content.
+            const lastClearedVersion = window.localStorage.getItem(cacheKey);
+            if(lastClearedVersion === null){
+                // First load, no cache, return.
+                localStorage.setItem(cacheKey, newCacheVersion);
+                return;
+            }
+            if(!window.caches){
+                console.error("CacheStorage Reset: API not supported by browser.");
+            }
+            if(lastClearedVersion !== newCacheVersion) {
+                window.cacheRefreshInProgress = true;
+                let openedCache;
+                console.log("CacheStorage Reset: Reset cache in progress..");
+                caches.open(CACHE_NAME_EVERYTHING)
+                    .then(cache => {
+                        openedCache = cache;
+                        return cache.keys();
+                    })
+                    .then(keys => {
+                        let promises = []
+                        for(let key of keys){
+                            promises.push(openedCache.delete(key));
+                        }
+                        console.log(`CacheStorage Reset: Deleting ${promises.length} cache entries from ${CACHE_NAME_EVERYTHING}`);
+                        return Promise.all(promises);
+                    }).then(() => {
+                        console.log("CacheStorage Reset: Cache successfully reset");
+                        localStorage.setItem(cacheKey, newCacheVersion);
+                        location.reload();
+                    }).catch( e => {
+                        console.error("Error while resetting cache", e);
+                        window.cacheClearError = e;
+                        window.cacheRefreshInProgress = false;
+                        // try our luck loading phoenix as cache reset failed
+                        if(window._loadPhoenixAfterSplashScreen) {
+                            window._loadPhoenixAfterSplashScreen();
+                        }
+                        // throw again so that bugsnag can report if initialised. else bugsnag
+                        // will report the error when it comes online via window.cacheClearError
+                        throw e;
+                    });
+            }
+        }
+        _resetCacheIfNeeded();
+    </script>
 
-    <!-- NOTE: All scripts must be external for Chrome App support: http://developer.chrome.com/apps/app_csp.html -->
+    <!-- CSS/LESS -->
 
     <link rel="stylesheet" type="text/css" href="thirdparty/fontawesome/css/all.min.css">
     <link rel="stylesheet" type="text/css" href="thirdparty/devicon/devicon.min.css">
@@ -104,12 +159,17 @@
 
         function _loadPhoenixAfterSplashScreen() {
             _removeSplashScreenIfNeeded();
+            if(window.cacheRefreshInProgress){
+                // We should not load anything while the cache is inconsistent.
+                // A page reload will be scheduled on successful clear.
+                return;
+            }
             var loadJS = function(url, implementationCode, location, dataMainValue){
                 //url is URL of external file, implementationCode is the code
                 //to be called from the file, location is the location to
                 //insert the <script> element
 
-                var scriptTag = document.createElement('script');
+                const scriptTag = document.createElement('script');
                 if(dataMainValue){
                     scriptTag.setAttribute('data-main', dataMainValue);
                 }

--- a/src/logger.js
+++ b/src/logger.js
@@ -165,6 +165,9 @@ if(isBugsnagEnabled) {
         maxBreadcrumbs: 50,
         onError
     });
+    if(window.cacheClearError){
+        logger.reportError(window.cacheClearError);
+    }
 } else {
     console.warn("Logging to Bugsnag is disabled as current environment is localhost.");
 }

--- a/src/virtual-server-main.js
+++ b/src/virtual-server-main.js
@@ -38,7 +38,7 @@ const StaleWhileRevalidate = workbox.strategies.StaleWhileRevalidate;
 const ExpirationPlugin = workbox.expiration.ExpirationPlugin;
 const CacheExpiration = workbox.expiration.CacheExpiration;
 const DAYS_30_IN_SEC = 60 * 60 * 24 * 30;
-const CACHE_NAME_EVERYTHING = "everything";
+const CACHE_NAME_EVERYTHING = "everything"; // This is referenced in index.html as well if you are changing te name.
 const CACHE_NAME_CORE_SCRIPTS = "coreScripts";
 const CACHE_NAME_EXTERNAL = "external";
 const ExpirationManager ={
@@ -141,18 +141,6 @@ workbox.routing.registerRoute(
     },
     'GET'
 );
-
-// cache and offline access route
-function _clearCache(event) {
-    caches.open(CACHE_NAME_EVERYTHING).then((cache) => {
-        cache.keys().then((keys) => {
-            keys.forEach((request, index, array) => {
-                cache.delete(request);
-            });
-            event.ports[0].postMessage({updatedFilesCount: keys.length});
-        });
-    });
-}
 
 function _updateTTL(cacheName, urls) {
     // this is needed for workbox to purge cache by ttl. purge behaviour is not part of w3c spec, but done by workbox.
@@ -282,7 +270,6 @@ addEventListener('message', (event) => {
             self._debugSWLivePreviewLogs = event.data.logLivePreview;
             self.__WB_DISABLE_DEV_LOGS = Config.debug && _debugSWCacheLogs;
             event.ports[0].postMessage({baseURL}); break;
-        case 'CLEAR_CACHE': _clearCache(event); break;
         case 'REFRESH_CACHE': _refreshCache(event); break;
         case 'setInstrumentedURLs': self.Serve.setInstrumentedURLs(event); return true;
         default:


### PR DESCRIPTION
Earlier cache reset was spear across the service worker, the loader script and it brought in too many inconsistent cache management issues as there were too many moving parts and each at varying state of cache.

* Moved all cache reset management to `index.html` . Since it is loaded in a cache first policy, it is guaranteed to be refreshed on second load, and then the main index itself force cleans the cache. This brings in much more cache predictability.
  * Phoenix will not load while a reset is in progress and, If the reset succeeded, Phoenix is reloaded again
  * Else on cache rest failure, we try to load phoenix as is hoping for the best.
* Cache refresh will be directed by phoenix and will be done after app start. While this can be a problem if we load any files after the app start, this will resolve itself on the next load. We should consider optimizing this in the future.