### PR TITLE
Remove google fonts in favor of brackets UI font source-sans pro for better UI consistency, 

### DIFF
--- a/src/assets/new-project/assets/css/style.css
+++ b/src/assets/new-project/assets/css/style.css
@@ -1,9 +1,22 @@
+:root {
+    --sansFontFamily: 'SourceSansPro', Helvetica, Arial, "Meiryo UI", "ＭＳ Ｐゴシック", "MS PGothic", sans-serif;
+}
+
+/* SourceSansPro Regular */
+@font-face {
+    font-family: 'SourceSansPro';
+    src: url('../../../../styles/fonts/SourceSansPro/SourceSansPro-Regular.ttf');
+    font-weight: normal;
+    font-style: normal;
+}
+
+
 html {
     height: 100%;
 }
 
 body {
-    font-family: 'Urbanist', sans-serif;
+    font-family: var(--sansFontFamily);
     overflow: hidden;
     background-color: #fff;
     height: 100%;

--- a/src/assets/new-project/code-editor.html
+++ b/src/assets/new-project/code-editor.html
@@ -9,10 +9,6 @@
     <link rel="stylesheet" href="assets/css/style.css"/>
     <link rel="stylesheet" href="assets/css/responsive.css">
     <link rel="stylesheet" href="../../thirdparty/fontawesome/css/all.min.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Urbanist:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap"
-          rel="stylesheet">
     <script src="assets/js/phoenix.js"></script>
     <script src="assets/js/code-editor.js"></script>
     <script src="../../thirdparty/floating-ui.core.umd.min.js"></script>

--- a/src/assets/new-project/new-project-from-url.html
+++ b/src/assets/new-project/new-project-from-url.html
@@ -10,10 +10,6 @@
     <link rel="stylesheet" href="assets/css/responsive.css">
     <link rel="stylesheet" href="assets/css/lity.css">
     <link rel="stylesheet" href="../../thirdparty/fontawesome/css/all.min.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Urbanist:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap"
-          rel="stylesheet">
     <script src="assets/js/phoenix.js"></script>
     <script src="assets/js/new-project-from-url.js"></script>
     <!-- Javascript -->

--- a/src/assets/new-project/new-project-github.html
+++ b/src/assets/new-project/new-project-github.html
@@ -9,10 +9,6 @@
     <link rel="stylesheet" href="assets/css/style.css"/>
     <link rel="stylesheet" href="assets/css/responsive.css">
     <link rel="stylesheet" href="../../thirdparty/fontawesome/css/all.min.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Urbanist:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap"
-          rel="stylesheet">
     <script src="assets/js/phoenix.js"></script>
     <script src="assets/js/new-github-project.js"></script>
 </head>

--- a/src/assets/new-project/new-project-more.html
+++ b/src/assets/new-project/new-project-more.html
@@ -9,10 +9,6 @@
     <link href="assets/css/style.css" rel="stylesheet"/>
     <link href="assets/css/responsive.css" rel="stylesheet">
     <link rel="stylesheet" href="../../thirdparty/fontawesome/css/all.min.css">
-    <link href="https://fonts.googleapis.com" rel="preconnect">
-    <link crossorigin href="https://fonts.gstatic.com" rel="preconnect">
-    <link href="https://fonts.googleapis.com/css2?family=Urbanist:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap"
-          rel="stylesheet">
     <script src="assets/js/phoenix.js"></script>
     <script src="assets/js/new-project-more.js"></script>
 </head>

--- a/src/assets/new-project/new-project-website.html
+++ b/src/assets/new-project/new-project-website.html
@@ -10,10 +10,6 @@
     <link rel="stylesheet" href="assets/css/responsive.css">
     <link rel="stylesheet" href="assets/css/lity.css">
     <link rel="stylesheet" href="../../thirdparty/fontawesome/css/all.min.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Urbanist:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap"
-          rel="stylesheet">
     <script type="text/javascript">
         function urlInputKeyUp() {
             let currentUrl = document.getElementById("bigFrame").src;

--- a/src/assets/phoenix-splash/index.html
+++ b/src/assets/phoenix-splash/index.html
@@ -3,7 +3,6 @@
     <head>
         <title>Phoenix editor</title>
         <link rel="stylesheet" href="styles.css">
-        <link href='https://fonts.googleapis.com/css?family=Montserrat:100,200,300,500,600,800' rel='stylesheet'>
     </head>
 
     <body>
@@ -12,7 +11,8 @@
             <img id="logo"  src="images/phoenix-logo.svg"/>
             <div id="MainText">
                 <h1>Phoenix</h1>
-                <span >Modern, Open-source, IDE For The Web <br></span><br>
+                <span>Modern, Open-source, IDE For The Web</span>
+                <br><br>
                 <button id="load-status-display-btn" class="primary-button">Loading Editor...</button>
                 <p style= "color: white; font-size:13px;" id="load-status-display-text"  >...</p>
             </div>

--- a/src/assets/phoenix-splash/safari.html
+++ b/src/assets/phoenix-splash/safari.html
@@ -3,8 +3,6 @@
     <head>
         <title>Phoenix editor</title>
         <link rel="stylesheet" href="styles.css">
-        <link href='https://fonts.googleapis.com/css?family=Montserrat:100,200,300,500,600,800' rel='stylesheet'>
-
     </head>
 
     <body>

--- a/src/assets/phoenix-splash/styles.css
+++ b/src/assets/phoenix-splash/styles.css
@@ -1,3 +1,18 @@
+/* Brackets Fonts */
+
+/* Alternative weights */
+
+:root {
+    --sansFontFamily: 'SourceSansPro', Helvetica, Arial, "Meiryo UI", "ＭＳ Ｐゴシック", "MS PGothic", sans-serif;
+}
+
+/* SourceSansPro Regular */
+@font-face {
+    font-family: 'SourceSansPro';
+    src: url('../../styles/fonts/SourceSansPro/SourceSansPro-Regular.ttf');
+    font-weight: normal;
+    font-style: normal;
+}
 
 body {
     background: #000A2E;
@@ -5,7 +20,7 @@ body {
     display: flex;
     justify-content: center;
     align-items: center;
-    font-family: 'Montserrat';
+    font-family: var(--sansFontFamily) ;
     font-size: 22px;
 }
 
@@ -72,6 +87,7 @@ h1 {
     width: 200px;
     height: 45px;
     background: linear-gradient(90deg, #FAAA47 0%, #FA1801 100%);
+    font-family: var(--sansFontFamily) ;
     background-size: 200% 200%;
     border-radius: 5px;
     border: none;

--- a/src/main.js
+++ b/src/main.js
@@ -115,8 +115,11 @@ const callback = function(mutationsList) {
             trackedScriptCount++;
             let scriptAddedSplit = mutation.addedNodes[0].src.split("/");
             if(scriptAddedSplit.length > 0){
-                _setSplashScreenStatusUpdate(
-                    `Loading (${trackedScriptCount})` , `${scriptAddedSplit[scriptAddedSplit.length-1]}`);
+                let message = `Loading (${trackedScriptCount})`;
+                if(window.Phoenix.firstBoot) {
+                    message = `Installing (${trackedScriptCount})`;
+                }
+                _setSplashScreenStatusUpdate(message, `${scriptAddedSplit[scriptAddedSplit.length-1]}`);
             }
         }
     }


### PR DESCRIPTION
Remove google fonts in favor of brackets UI font source-sans pro for better UI consistency, improved load speed from cache, better offline support
- chore: remove google fonts from the splash screen in favor of brackets fonts
- chore: remove google fonts from all new project dialogues

## fixes part of
- https://github.com/phcode-dev/phoenix/issues/827