### PR TITLE
chore: only metrics for extensions errors no bugsnag

### DIFF
--- a/src/phoenix/init_vfs.js
+++ b/src/phoenix/init_vfs.js
@@ -31,12 +31,16 @@
  * This module should be functionally as light weight as possible with minimal deps as it is a shell component.
  * **/
 
+const EXTENSION_DIR = '/fs/app/extensions/';
+
 function _setupVFS(fsLib, pathLib){
     Phoenix.VFS = {
         getRootDir: () => '/fs/',
         getMountDir: () => '/mnt/',
         getAppSupportDir: () => '/fs/app/',
-        getExtensionDir: () => '/fs/app/extensions/',
+        getExtensionDir: () => EXTENSION_DIR,
+        getUserExtensionDir: () => `${EXTENSION_DIR}user`,
+        getDevExtensionDir: () => `${EXTENSION_DIR}dev`,
         getLocalDir: () => '/fs/local/',
         getTempDir: () => '/temp/',
         getTrashDir: () => '/fs/trash/',

--- a/src/phoenix/shell.js
+++ b/src/phoenix/shell.js
@@ -68,7 +68,6 @@ Phoenix.app = {
         window.open(url);
     },
     getApplicationSupportDirectory: Phoenix.VFS.getAppSupportDir,
-    getExtensionDirectory: Phoenix.VFS.getExtensionDir,
     getUserDocumentsDirectory: Phoenix.VFS.getUserDocumentsDirectory,
     ERR_CODES: ERR_CODES,
     getElapsedMilliseconds: function () {

--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -94,14 +94,14 @@ define(function (require, exports, module) {
      * Returns the full path to the development extensions directory.
      */
     function _getExtensionPath() {
-        return pathLib.normalize(brackets.app.getExtensionDirectory());
+        return pathLib.normalize(Phoenix.VFS.getExtensionDir());
     }
 
     /**
      * Returns the full path to the development extensions directory.
      */
     function getDevExtensionPath() {
-        return _getExtensionPath() + "/dev";
+        return pathLib.normalize(Phoenix.VFS.getDevExtensionDir());
     }
 
     /**
@@ -111,11 +111,7 @@ define(function (require, exports, module) {
      * C:\Users\<user>\AppData\Roaming\Brackets\extensions\user on windows.
      */
     function getUserExtensionPath() {
-        if (brackets.app.getApplicationSupportDirectory) {
-            return _getExtensionPath()+ "/user";
-        }
-
-        return null;
+        return pathLib.normalize(Phoenix.VFS.getUserExtensionDir());
     }
 
     /**


### PR DESCRIPTION
* As we enable Extensions, there is a risk that the extension errors will be high and reduce the visibility of core errors. So now, we raise metrics only if we find an extension in the crash stack.
* Extensions are from random sources, and we cannot Quality Control the error stability of extensions.