### PR TITLE
chore: guided tour ux improvement and show actions based on context

### DIFF
--- a/src/command/CommandManager.js
+++ b/src/command/CommandManager.js
@@ -30,21 +30,23 @@
 define(function (require, exports, module) {
 
 
-    var EventDispatcher = require("utils/EventDispatcher");
+    const EventDispatcher = require("utils/EventDispatcher");
+
+    const EVENT_BEFORE_EXECUTE_COMMAND = "beforeExecuteCommand";
 
 
     /**
      * Map of all registered global commands
      * @type {Object.<commandID: string, Command>}
      */
-    var _commands = {};
+    let _commands = {};
 
     /**
      * Temporary copy of commands map for restoring after testing
      * TODO (issue #1039): implement separate require contexts for unit tests
      * @type {Object.<commandID: string, Command>}
      */
-    var _commandsOriginal = {};
+    let _commandsOriginal = {};
 
     /**
      * Events:
@@ -277,7 +279,7 @@ define(function (require, exports, module) {
 
         if (command) {
             try {
-                exports.trigger("beforeExecuteCommand", id);
+                exports.trigger(EVENT_BEFORE_EXECUTE_COMMAND, id);
             } catch (err) {
                 console.error(err);
             }
@@ -298,4 +300,5 @@ define(function (require, exports, module) {
     exports.getAll              = getAll;
     exports._testReset          = _testReset;
     exports._testRestore        = _testRestore;
+    exports.EVENT_BEFORE_EXECUTE_COMMAND = EVENT_BEFORE_EXECUTE_COMMAND;
 });

--- a/src/view/MainViewManager.js
+++ b/src/view/MainViewManager.js
@@ -95,6 +95,8 @@ define(function (require, exports, module) {
         Pane                = require("view/Pane").Pane,
         KeyBindingManager   = brackets.getModule("command/KeyBindingManager");
 
+    const EVENT_CURRENT_FILE_CHANGE = "currentFileChange";
+
     /**
      * Preference setting name for the MainView Saved State
      * @const
@@ -392,7 +394,7 @@ define(function (require, exports, module) {
             _activePaneId = newPaneId;
 
             exports.trigger("activePaneChange", newPaneId, oldPaneId);
-            exports.trigger("currentFileChange", _getPane(ACTIVE_PANE).getCurrentlyViewedFile(),
+            exports.trigger(EVENT_CURRENT_FILE_CHANGE, _getPane(ACTIVE_PANE).getCurrentlyViewedFile(),
                                                             newPaneId,
                                                             oldPane.getCurrentlyViewedFile(),
                                                             oldPaneId);
@@ -1131,7 +1133,7 @@ define(function (require, exports, module) {
             newPane.on("currentViewChange.mainview", function (e, newView, oldView) {
                 _updatePaneHeaders();
                 if (_activePaneId === newPane.id) {
-                    exports.trigger("currentFileChange",
+                    exports.trigger(EVENT_CURRENT_FILE_CHANGE,
                                                newView && newView.getFile(),
                                                newPane.id, oldView && oldView.getFile(),
                                                newPane.id);
@@ -1649,7 +1651,7 @@ define(function (require, exports, module) {
         //  to the event before we've been initialized
         WorkspaceManager.on("workspaceUpdateLayout", _updateLayout);
 
-        exports.on("currentFileChange", _scheduleViewStateSave);
+        exports.on(EVENT_CURRENT_FILE_CHANGE, _scheduleViewStateSave);
         exports.on("paneLayoutChange", _scheduleViewStateSave);
 
         // Listen to key Alt-W to toggle between panes
@@ -1715,7 +1717,7 @@ define(function (require, exports, module) {
 
     EventDispatcher.makeEventDispatcher(exports);
     // currentFileChange has a large number of listeners. so we raise warning threshold to 25
-    EventDispatcher.setLeakThresholdForEvent("currentFileChange", 25);
+    EventDispatcher.setLeakThresholdForEvent(EVENT_CURRENT_FILE_CHANGE, 25);
 
     // Unit Test Helpers
     exports._initialize                   = _initialize;
@@ -1785,4 +1787,5 @@ define(function (require, exports, module) {
     exports.ACTIVE_PANE                   = ACTIVE_PANE;
     exports.FIRST_PANE                    = FIRST_PANE;
     exports.SECOND_PANE                   = SECOND_PANE;
+    exports.EVENT_CURRENT_FILE_CHANGE     = EVENT_CURRENT_FILE_CHANGE;
 });


### PR DESCRIPTION
Right now, there are too many distracting popups on first boot. reduce the,:
### Order of things in the first boot now:
1. First, we show the popup in the new project window to select the default project - see the HTML in assets folder
2. After the user opens the default project, we show "edit code for live preview popup."
3. When the user changes a file by clicking on the files panel, we show "click here to open new project window"
    this will continue showing every session until the user clicks on the new project icon
4. After about 3 minutes, the health popup will show up.
5. When the user clicks on live preview, we show "click here to pop out live preview"

![tour](https://user-images.githubusercontent.com/5336369/212321888-d1960232-1f33-4b6d-9e1f-97e0d23ae3ae.gif)
