### PR TITLE
chore: deferred load scripts and cache refresh on require load fail

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -189,16 +189,16 @@
             math: 'always'
         };
     </script>
-    <script src="thirdparty/less.min.js"></script>
-    <script src="thirdparty/jquery-2.1.3.min.js"></script>
-    <script src="thirdparty/underscore-min.js"></script>
-    <script src="thirdparty/floating-ui.core.umd.min.js"></script>
-    <script src="thirdparty/floating-ui.dom.umd.min.js"></script>
-    <script type="text/javascript" src="thirdparty/jszip.js"></script>
-    <script type="text/javascript" src="thirdparty/jszip-utils-phoenix.js"></script>
+    <script src="thirdparty/less.min.js" defer></script>
+    <script src="thirdparty/jquery-2.1.3.min.js" defer></script>
+    <script src="thirdparty/underscore-min.js" defer></script>
+    <script src="thirdparty/floating-ui.core.umd.min.js" defer></script>
+    <script src="thirdparty/floating-ui.dom.umd.min.js" defer></script>
+    <script type="text/javascript" src="thirdparty/jszip.js" defer></script>
+    <script type="text/javascript" src="thirdparty/jszip-utils-phoenix.js" defer></script>
 
     <!-- Warn about failed cross origin requests in Chrome -->
-    <script type="application/javascript" src="xorigin.js"></script>
+    <script type="application/javascript" src="xorigin.js" defer></script>
 
 </head>
 <body onload="_loadPhoenixAfterSplashScreen()">

--- a/src/main.js
+++ b/src/main.js
@@ -143,6 +143,8 @@ define(function (require) {
         try{
             require(["brackets"]);
         } catch (err) {
+            // try a cache refresh (not a full reset). this will happen in the service worker in the background
+            window.refreshServiceWorkerCache && window.refreshServiceWorkerCache();
             // metrics api might not be available here as we were seeing no metrics raised. Only bugsnag there.
             window.logger && window.logger.reportError(err,
                 'Critical error when loading brackets. Trying to reload again.');


### PR DESCRIPTION
* We are seeing higher startup times on the first boot. so reverting in favor of faster first boot times. 
* reload times might be slower by .5 secs.
* Also try to refresh cache if require load failed.