### PR TITLE
fix: z-indexes of core ui

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -198,6 +198,7 @@ a, img {
         padding: 0;
         left: @sidebar-width;  // changed dynamically via Resizer
         right: @main-toolbar-width;
+        z-index: @z-index-brackets-main-content;
     }
 
     .force-right-zero {

--- a/src/styles/brackets_variables.less
+++ b/src/styles/brackets_variables.less
@@ -54,10 +54,11 @@
 @z-index-brackets-max: @z-index-brackets-toolbar;
 @z-index-brackets-modalbar: (@z-index-brackets-toolbar - 1);
 @z-index-brackets-main-toolbar: (@z-index-brackets-toolbar + 1);
+@z-index-brackets-main-content: (@z-index-brackets-main-toolbar + 1);
 
-@z-index-brackets-sidebar-resizer: (@z-index-brackets-ui + 2);
+@z-index-brackets-sidebar-resizer: (@z-index-brackets-main-content + 3);
 @z-index-brackets-resizer-div: (@z-index-brackets-sidebar-resizer + 1);
-@z-index-brackets-panel-resizer: (@z-index-brackets-ui + 2);
+@z-index-brackets-panel-resizer: (@z-index-brackets-resizer-div + 2);
 
 @z-index-brackets-drag-ghost:            999;
 @z-index-brackets-context-menu-base:    1000;


### PR DESCRIPTION
* Panels hid main menus. Fixed it.
![image](https://user-images.githubusercontent.com/5336369/212537375-07710fa0-2a7c-48a7-b7ac-09f151d6b9f4.png)
![image](https://user-images.githubusercontent.com/5336369/212537383-aabfd504-c0b0-4d44-bd0a-e834a813bf5f.png)

## testing
* resize panels, sidebar, plugin and bottom panels work as expected.
