### PR TITLE
fix: project-content-right overflow on 720p screens.

### DIFF
--- a/src/assets/new-project/assets/css/responsive.css
+++ b/src/assets/new-project/assets/css/responsive.css
@@ -92,6 +92,8 @@
         width: 242px;
         height: 42px;
     }
+    #noProjectContainer #YTVideoFrame {
+        width: 267px;
 }
 
 @media (max-width: 650px) {

--- a/src/assets/new-project/assets/css/responsive.css
+++ b/src/assets/new-project/assets/css/responsive.css
@@ -79,10 +79,12 @@
 @media (max-width: 720px) {
     .project-content-left {
         margin-left:0px;
+        width:300px;
     }
   
     .project-content-right {
         margin-left:15px;
+        width:300px;
 
     }
     


### PR DESCRIPTION
### What kind of change does this PR introduce?
<!-- Delete ones that doesnt apply-->

- Bugfix - currently the newly added "no project video" causes overflow to the right on 720p screens .



### Screenshots or Gifs of the change

Currently the newly added "no project video" causes overflow to the right 720p screens .
![Screenshot from 2023-01-16 01-11-47](https://user-images.githubusercontent.com/78793827/212565971-026c2358-2ab2-4e99-9e7e-1de810c17590.png)

with this change.
![Screenshot from 2023-01-16 01-58-30](https://user-images.githubusercontent.com/78793827/212565949-b2220fff-aa85-409b-ac90-8a206ea6ebc9.png)
### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->
~This will remove the extra padding on both sides of the video.~

### Tests done
- Describe unit tests done -->none
- Describe integration tests done -->none
- Describe manual tests done -->visual inspection
