### PR TITLE
fix: project-content-right overflow on 720p screens. 

### DIFF
--- a/src/assets/new-project/assets/css/responsive.css
+++ b/src/assets/new-project/assets/css/responsive.css
@@ -78,11 +78,13 @@
 
 @media (max-width: 720px) {
     .project-content-left {
-        margin-left:0px;
+        margin-left: 0px;
+        width: 300px;
     }
   
     .project-content-right {
-        margin-left:15px;
+        margin-left: 15px;
+        width: 300px;
 
     }
     
@@ -90,6 +92,11 @@
         width: 242px;
         height: 42px;
     }
+    
+    #noProjectIframe {
+        width: 267px;
+    }
+    
 }
 
 @media (max-width: 650px) {

--- a/src/assets/new-project/assets/js/code-editor.js
+++ b/src/assets/new-project/assets/js/code-editor.js
@@ -91,7 +91,7 @@ function _updateProjectCards() {
     if(!showRecentProjects){
         $("#recentProjectsContainer").addClass("forced-hidden");
         $("#noProjectContainer").removeClass("forced-hidden");
-        let videoHtml = `<iframe style="align-items: center" src="https://www.youtube.com/embed/Nqukd9oU060" title="YouTube video player"
+        let videoHtml = `<iframe id="noProjectIframe" style="align-items: center" src="https://www.youtube.com/embed/Nqukd9oU060" title="YouTube video player"
                 frameBorder="0"
                 allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
                 allowFullScreen></iframe>`;


### PR DESCRIPTION
### What kind of change does this PR introduce?
<!-- Delete ones that doesnt apply-->

- Bugfix - currently the newly added "no project video" causes overflow to the right on 720p screens .



### Screenshots or Gifs of the change

- Currently the newly added "no project video" causes overflow to the right 720p screens .

![Screenshot from 2023-01-16 01-11-47](https://user-images.githubusercontent.com/78793827/212565971-026c2358-2ab2-4e99-9e7e-1de810c17590.png)

- with this change.

![image](https://user-images.githubusercontent.com/78793827/212570390-2beebbb0-eda9-45d1-95a7-e6053f7271d7.png)
### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->
~This will remove the extra padding on both sides of the video.~

### Tests done
- Describe unit tests done -->none
- Describe integration tests done -->none
- Describe manual tests done -->visual inspection
