### PR TITLE
defaultExtension.json loading, metrics for repeat users, error logs

### DIFF
--- a/src/extensions/default/DefaultExtensions.json
+++ b/src/extensions/default/DefaultExtensions.json
@@ -35,5 +35,11 @@
   "Phoenix-extension-store",
   "Phoenix-live-preview",
   "icons",
-  "StaticServer"
+  "StaticServer",
+  {
+    "description": "list extension ids here that you want to show this warning in extension store: 'You may not need this extension. Phoenix comes built in with this support.'",
+    "extensionStoreExtensionIDs": [
+
+    ]
+  }
 ]

--- a/src/extensions/default/Phoenix/main.js
+++ b/src/extensions/default/Phoenix/main.js
@@ -53,7 +53,7 @@ define(function (require, exports, module) {
         });
     }
     function _showUnSupportedBrowserDialogue() {
-        if(unsupportedBrowserDialogShown){
+        if(unsupportedBrowserDialogShown || Phoenix.isTestWindow){
             return;
         }
         unsupportedBrowserDialogShown = true;

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -1172,7 +1172,7 @@ a[href^="http"] {
             width: 720px;
         }
         .table {
-            margin-top: 48px;
+            margin-top: 65px;
         }
     }
 
@@ -1183,7 +1183,7 @@ a[href^="http"] {
             width: 720px;
         }
         .table {
-            margin-top: 48px;
+            margin-top: 65px;
         }
     }
 

--- a/src/utils/Metrics.js
+++ b/src/utils/Metrics.js
@@ -264,11 +264,11 @@ define(function (require, exports, module) {
         }
     }
 
-    function _decorateRepeatUserEvent(eventType) {
-        if(isFirstUseDay || window.Phoenix.isTestWindow){
-            return eventType;
-        }
-        return `R.${eventType}`;
+    function _countEvent(eventType, eventCategory, eventSubCategory, count= 1) {
+        _logEventForAudit(eventType, eventCategory, eventSubCategory, count, AUDIT_TYPE_COUNT);
+        _sendToGoogleAnalytics(eventType, eventCategory, eventSubCategory, count);
+        _sendToMixPanel(eventType, eventCategory, eventSubCategory, count);
+        _sendToCoreAnalytics(eventType, eventCategory, eventSubCategory, count);
     }
 
     /**
@@ -287,11 +287,18 @@ define(function (require, exports, module) {
      * @type {function}
      */
     function countEvent(eventType, eventCategory, eventSubCategory, count= 1) {
-        eventType= _decorateRepeatUserEvent(eventType);
-        _logEventForAudit(eventType, eventCategory, eventSubCategory, count, AUDIT_TYPE_COUNT);
-        _sendToGoogleAnalytics(eventType, eventCategory, eventSubCategory, count);
-        _sendToMixPanel(eventType, eventCategory, eventSubCategory, count);
-        _sendToCoreAnalytics(eventType, eventCategory, eventSubCategory, count);
+        if(!isFirstUseDay){
+            // emit repeat user metrics too
+            _countEvent(`R-${eventType}`, eventCategory, eventSubCategory, count);
+        }
+        _countEvent(eventType, eventCategory, eventSubCategory, count);
+    }
+
+    function _valueEvent(eventType, eventCategory, eventSubCategory, value) {
+        _logEventForAudit(eventType, eventCategory, eventSubCategory, value, AUDIT_TYPE_VALUE);
+        _sendToGoogleAnalytics(eventType, eventCategory, eventSubCategory, value);
+        _sendToMixPanel(eventType, eventCategory, eventSubCategory, 1, value);
+        _sendToCoreAnalytics(eventType, eventCategory, eventSubCategory, 1, value);
     }
 
     /**
@@ -309,11 +316,11 @@ define(function (require, exports, module) {
      * @type {function}
      */
     function valueEvent(eventType, eventCategory, eventSubCategory, value) {
-        eventType= _decorateRepeatUserEvent(eventType);
-        _logEventForAudit(eventType, eventCategory, eventSubCategory, value, AUDIT_TYPE_VALUE);
-        _sendToGoogleAnalytics(eventType, eventCategory, eventSubCategory, value);
-        _sendToMixPanel(eventType, eventCategory, eventSubCategory, 1, value);
-        _sendToCoreAnalytics(eventType, eventCategory, eventSubCategory, 1, value);
+        if(!isFirstUseDay){
+            // emit repeat user metrics too
+            _valueEvent(`R-${eventType}`, eventCategory, eventSubCategory, value);
+        }
+        _valueEvent(eventType, eventCategory, eventSubCategory, value);
     }
 
     function setDisabled(shouldDisable) {

--- a/src/view/ThemeManager.js
+++ b/src/view/ThemeManager.js
@@ -353,7 +353,7 @@ define(function (require, exports, module) {
                             deferred.resolve(theme);
                         });
                 }).fail(function (error) {
-                    console.error(error);
+                    console.error("Error writing " + themePath, error);
                     deferred.reject();
                 });
             });


### PR DESCRIPTION
- refactor: defaultExtension.json loading, metrics for repeat users, error logs
- Extension tests now start loading up in firefox, though most integ tests fail, likely due to some firefox related test infrastructure misconfig.
- fix: removed browser not supported warning showing up in firefox test windows