### PR TITLE
feat: increase load speed by showing ui just after first theme load, also reduces boot time flicker

### DIFF
--- a/src/extensibility/ExtensionManager.js
+++ b/src/extensibility/ExtensionManager.js
@@ -968,9 +968,9 @@ define(function (require, exports, module) {
 
     // Listen to extension load and loadFailed events
     ExtensionLoader
-        .on("load", _handleExtensionLoad)
-        .on("loadFailed", _handleExtensionLoad)
-        .on("disabled", _handleExtensionLoad);
+        .on(ExtensionLoader.EVENT_EXTENSION_LOADED, _handleExtensionLoad)
+        .on(ExtensionLoader.EVENT_EXTENSION_LOAD_FAILED, _handleExtensionLoad)
+        .on(ExtensionLoader.EVENT_EXTENSION_DISABLED, _handleExtensionLoad);
 
 
     EventDispatcher.makeEventDispatcher(exports);

--- a/src/extensions/default/DefaultExtensions.json
+++ b/src/extensions/default/DefaultExtensions.json
@@ -1,5 +1,7 @@
 {
   "defaultExtensionsList": [
+    "DarkTheme",
+    "LightTheme",
     "CloseOthers",
     "CodeFolding",
     "NoDistractions",
@@ -30,8 +32,6 @@
     "RemoteFileAdapter",
     "SVGCodeHints",
     "UrlCodeHints",
-    "DarkTheme",
-    "LightTheme",
     "HealthData",
     "Phoenix-extension-store",
     "Phoenix-live-preview",

--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -54,7 +54,10 @@ define(function (require, exports, module) {
 
     // default async initExtension timeout
     var EXTENSION_LOAD_TIMOUT_SECONDS = 60,
-        INIT_EXTENSION_TIMEOUT = EXTENSION_LOAD_TIMOUT_SECONDS * 1000;
+        INIT_EXTENSION_TIMEOUT = EXTENSION_LOAD_TIMOUT_SECONDS * 1000,
+        EVENT_EXTENSION_LOADED = "load",
+        EVENT_EXTENSION_DISABLED = "disabled",
+        EVENT_EXTENSION_LOAD_FAILED = "loadFailed";
 
     var _init       = false,
         _extensions = {},
@@ -321,12 +324,12 @@ define(function (require, exports, module) {
 
             })
             .then(function () {
-                exports.trigger("load", config.baseUrl);
+                exports.trigger(EVENT_EXTENSION_LOADED, config.baseUrl);
             }, function (err) {
                 if (err === "disabled") {
-                    exports.trigger("disabled", config.baseUrl);
+                    exports.trigger(EVENT_EXTENSION_DISABLED, config.baseUrl);
                 } else {
-                    exports.trigger("loadFailed", config.baseUrl);
+                    exports.trigger(EVENT_EXTENSION_LOAD_FAILED, config.baseUrl);
                 }
             });
     }
@@ -606,9 +609,9 @@ define(function (require, exports, module) {
 
             if (params.get("reloadWithoutUserExts") !== "true") {
                 paths = [
+                    "default",
                     getUserExtensionPath(),
-                    getDevExtensionPath(),
-                    "default"
+                    getDevExtensionPath()
                 ];
             } else {
                 paths = [];
@@ -664,4 +667,7 @@ define(function (require, exports, module) {
     exports.loadAllExtensionsInNativeDirectory = loadAllExtensionsInNativeDirectory;
     exports.testAllExtensionsInNativeDirectory = testAllExtensionsInNativeDirectory;
     exports.testAllDefaultExtensions = testAllDefaultExtensions;
+    exports.EVENT_EXTENSION_LOADED = EVENT_EXTENSION_LOADED;
+    exports.EVENT_EXTENSION_DISABLED = EVENT_EXTENSION_DISABLED;
+    exports.EVENT_EXTENSION_LOAD_FAILED = EVENT_EXTENSION_LOAD_FAILED;
 });

--- a/src/view/ThemeManager.js
+++ b/src/view/ThemeManager.js
@@ -45,7 +45,8 @@ define(function (require, exports, module) {
         scrollbarsRegex = /((?:[^}|,]*)::-webkit-scrollbar(?:[^{]*)[{](?:[^}]*?)[}])/mgi,
         stylesPath      = FileUtils.getNativeBracketsDirectoryPath() + "/styles/";
 
-    const EVENT_THEME_CHANGE = "themeChange";
+    const EVENT_THEME_CHANGE = "themeChange",
+        EVENT_THEME_APPLIED = "themeApplied";
 
     /**
      * @private
@@ -242,6 +243,7 @@ define(function (require, exports, module) {
             .then(function (cssContent) {
                 $("body").toggleClass("dark", theme.dark);
                 styleNode.text(cssContent);
+                exports.trigger(EVENT_THEME_APPLIED, theme);
                 return theme;
             });
 
@@ -511,6 +513,7 @@ define(function (require, exports, module) {
     exports.isOSInDarkTheme = isOSInDarkTheme;
     exports.setCurrentTheme = setCurrentTheme;
     exports.EVENT_THEME_CHANGE = EVENT_THEME_CHANGE;
+    exports.EVENT_THEME_APPLIED = EVENT_THEME_APPLIED;
 
     // Exposed for testing purposes
     exports._toDisplayName     = toDisplayName;


### PR DESCRIPTION
* we will show the ui as soon as the first theme is loaded instead of waiting for full UI to render. This will significantly boost first-paint times. 
* Also the UI will not flicker from light to dark theme on first boot with this change.
* changed default extension load order to first load light and dark themes.
* Tested in chrome, firefox and edge.