### PR TITLE
fix FireFox tests

### DIFF
--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -542,7 +542,7 @@ define(function (require, exports, module) {
                     console.log("Loading Extension Test from virtual fs: ", extConfig);
                     _testExtensionByURL(extensionName, extConfig, 'unittests').always(function () {
                         // Always resolve the promise even if some extensions had errors
-                        console.log("lc", extensionName);
+                        console.log("tested", extensionName);
                         loadResult.resolve();
                     });
                     return loadResult.promise();
@@ -571,9 +571,9 @@ define(function (require, exports, module) {
         const srcBaseUrl = new URL(baseUrl + '/../src').href;
         var result = new $.Deferred();
 
-        for (let extensionEntry of DefaultExtensionsList){
-            console.log("Testing default extension: ", extensionEntry);
-            var extConfig = {
+        Async.doInParallel(DefaultExtensionsList, function (extensionEntry) {
+            const loadResult = new $.Deferred();
+            const extConfig = {
                 basePath: 'extensions/default',
                 baseUrl: new URL(srcBaseUrl + DEFAULT_EXTENSIONS_PATH_BASE + "/" + extensionEntry).href,
                 paths: {
@@ -581,9 +581,17 @@ define(function (require, exports, module) {
                     "spec": bracketsPath + "/spec"
                 }
             };
-            _testExtensionByURL(extensionEntry, extConfig, 'unittests');
-        }
-        result.resolve();
+            console.log("Testing default extension: ", extensionEntry);
+            _testExtensionByURL(extensionEntry, extConfig, 'unittests').always(function () {
+                // Always resolve the promise even if some extensions had errors
+                console.log("load complete", extensionEntry);
+                loadResult.resolve();
+            });
+            return loadResult.promise();
+        }).always(function () {
+            // Always resolve the promise even if some extensions had errors
+            result.resolve();
+        });
 
         return result.promise();
     }

--- a/src/worker/WorkerComm.js
+++ b/src/worker/WorkerComm.js
@@ -293,7 +293,9 @@
                     }
                 }
             } catch (err) {
-                response.err = err.stack || err.toString();
+                response.err = err.message || err.stack ?
+                    {message: err.message, stack: err.stack}
+                    : err.toString();
             }
             postTarget.postMessage(JSON.stringify(response));
         }

--- a/test/spec/WorkerComm-test.js
+++ b/test/spec/WorkerComm-test.js
@@ -48,7 +48,7 @@ define(function (require, exports, module) {
         });
 
         afterAll(function () {
-            //_myWorker.terminate();
+            _myWorker.terminate();
         });
 
         describe("execPeer API tests", function () {
@@ -69,7 +69,7 @@ define(function (require, exports, module) {
                 } catch (e) {
                     thrown = e;
                 }
-                expect(thrown.startsWith("Error: oops")).toBeTrue();
+                expect(thrown.message).toBe("oops");
             });
 
             it("Should throw if promise rejected in worker", async function () {
@@ -95,7 +95,7 @@ define(function (require, exports, module) {
                     throw new Error("throw_me");
                 });
                 let result = await exports.execPeer("execAndRejectInMainThread");
-                expect(result.startsWith("Error: throw_me")).toBeTrue();
+                expect(result.message).toBe("throw_me");
             });
         });
 


### PR DESCRIPTION
- fix: firefox ut failures in worker comm
- fix: flakey firefox extension tests

## testing
* Edge/chrome:- full test suite run, works same as before. sanity tests: beautify, find in files, jshint working
* Firefox- 1 unit test breaking of 2259 tests that doesn't break in chrome. integration, tests also have few issues. Other tests mostly inline with chrome.