### PR TITLE
ci: separate out build and pull request verify action

### DIFF
--- a/.github/workflows/pull_request_verify.yml
+++ b/.github/workflows/pull_request_verify.yml
@@ -1,7 +1,7 @@
 name: Phoenix build verification
 
 on:
-  push:
+  pull_request:
     branches: [ main ]
 
 jobs:


### PR DESCRIPTION
- Improve future security posture as push action has secret access but not pull requests. I gave a message so that someone in the future doesn't work around this security restriction for pull request secrets. 
- also the build verify badge in readme will only track main branch stability instead fo pull request stability which is the actual intended requirement.