### PR TITLE
Allow live preview to go full-screen on  devices with smaller screen-…

### DIFF
--- a/src/extensions/default/Phoenix-live-preview/main.js
+++ b/src/extensions/default/Phoenix-live-preview/main.js
@@ -221,8 +221,11 @@ define(function (require, exports, module) {
             clickToPopout: Strings.LIVE_DEV_CLICK_POPOUT,
             clickToPinUnpin: Strings.LIVE_DEV_CLICK_TO_PIN_UNPIN
         };
-        const PANEL_MIN_SIZE = 50;
-        const INITIAL_PANEL_SIZE = document.body.clientWidth/2.5;
+        
+        let PANEL_MIN_SIZE = 50;
+        let INITIAL_PANEL_SIZE = document.body.clientWidth;
+        if (INITIAL_PANEL_SIZE > 600)  INITIAL_PANEL_SIZE = INITIAL_PANEL_SIZE/2.5;
+        
         $icon = $("#toolbar-go-live");
         $icon.click(_toggleVisibilityOnClick);
         $panel = $(Mustache.render(panelHTML, templateVars));

--- a/src/extensions/default/Phoenix-live-preview/main.js
+++ b/src/extensions/default/Phoenix-live-preview/main.js
@@ -224,7 +224,9 @@ define(function (require, exports, module) {
         
         let PANEL_MIN_SIZE = 50;
         let INITIAL_PANEL_SIZE = document.body.clientWidth;
-        if (INITIAL_PANEL_SIZE > 600)  INITIAL_PANEL_SIZE = INITIAL_PANEL_SIZE/2.5;
+        if (INITIAL_PANEL_SIZE > 600) {
+            INITIAL_PANEL_SIZE = INITIAL_PANEL_SIZE/2.5;
+        };
         
         $icon = $("#toolbar-go-live");
         $icon.click(_toggleVisibilityOnClick);


### PR DESCRIPTION

### What kind of change does this PR introduce?
<!-- Delete ones that doesnt apply-->


- Feature


### Screenshots or Gifs of the change

- without this change  live preview's width is too small.
<img src="https://user-images.githubusercontent.com/78793827/220342342-5c0ca52e-07a2-48b2-bd51-8e1df8d1cb57.jpeg"  width="300" height="750">

- with this change live preview can go fullscreen

<img src="https://user-images.githubusercontent.com/78793827/220342379-3e84df65-44fd-4721-850a-3dba983e1f1d.jpeg"  width="300" height="750">


### Does this PR introduce a breaking change?

- No


### Other information

