### PR TITLE
popout live preview button will now hide the live preview panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "phoenix",
-    "version": "3.1.15-0",
+    "version": "3.1.17-0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "phoenix",
-            "version": "3.1.15-0",
+            "version": "3.1.17-0",
             "dependencies": {
                 "@bugsnag/js": "^7.18.0",
                 "@floating-ui/dom": "^0.5.4",

--- a/src/extensions/default/Phoenix-live-preview/main.js
+++ b/src/extensions/default/Phoenix-live-preview/main.js
@@ -199,6 +199,7 @@ define(function (require, exports, module) {
         open(openURL, "livePreview", "noopener,noreferrer");
         Metrics.countEvent(Metrics.EVENT_TYPE.LIVE_PREVIEW, "popoutBtn", "click");
         _loadPreview(true);
+        panel && panel.hide();
     }
 
     function _setTitle(fileName) {

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -956,7 +956,7 @@ define({
     "CANNOT_PUBLISH_LARGE_PROJECT_MESSAGE": "Phoenix is still in experimental alpha. We have not yet enabled sync of projects with greater than 500 files.",
     "SHARE_WEBSITE": "Publish and Share Website?",
     "PUBLISH": "Publish",
-    "PUBLISH_CONSENT_MESSAGE": "Quickly preview changes and share your website with others. Phoenix can publish this website for you at {0}. The published links will be valid for a period of 7 days. </br>Do you wish to publish and share your website?",
+    "PUBLISH_CONSENT_MESSAGE": "Quickly preview changes and share your website with others. Phoenix can publish this website for you at {0}. The published links will be valid for a period of 30 days. </br>Do you wish to publish and share your website?",
     "PUBLISH_SYNC_IN_PROGRESS": "Sync in progress for preview...",
     "PUBLISH_PAGE": "Click to publish and share this site",
     "PUBLISH_VIEW_PAGE": "Click to view published page",


### PR DESCRIPTION
Based on user feedback, the following changes were made:
- chore: published sites validity raised to 30 days from 7 based on user feedback
- chore: popout live preview button will now hide the live preview panel
