### PR TITLE
feat: revert to browser native zoom. brackets zoom changed to ctrl-shift-+ or -

### DIFF
--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -219,6 +219,21 @@
             "platform": "mac"
         }
     ],
+    "view.zoomIn":  [
+        {
+            "key": "Ctrl-=",
+            "displayKey": "Ctrl-+"
+        },
+        {
+            "key": "Ctrl-+"
+        }
+    ],
+    "view.zoomOut":  [
+        {
+            "key": "Ctrl--",
+            "displayKey": "Ctrl-−"
+        }
+    ],
     "view.increaseFontSize":  [
         {
             "key": "Ctrl-Shift-=",
@@ -235,7 +250,7 @@
         }
     ],
     "view.restoreFontSize":  [
-        "Ctrl-Shift-0"
+        "Ctrl-Shift-9"
     ],
     "view.scrollLineUp":  [
         {

--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -221,21 +221,21 @@
     ],
     "view.increaseFontSize":  [
         {
-            "key": "Ctrl-=",
-            "displayKey": "Ctrl-+"
+            "key": "Ctrl-Shift-=",
+            "displayKey": "Ctrl-Shift-+"
         },
         {
-            "key": "Ctrl-+"
+            "key": "Ctrl-Shift-+"
         }
     ],
     "view.decreaseFontSize":  [
         {
-            "key": "Ctrl--",
-            "displayKey": "Ctrl-−"
+            "key": "Ctrl-Shift--",
+            "displayKey": "Ctrl-Shift-−"
         }
     ],
     "view.restoreFontSize":  [
-        "Ctrl-0"
+        "Ctrl-Shift-0"
     ],
     "view.scrollLineUp":  [
         {

--- a/src/command/CommandManager.js
+++ b/src/command/CommandManager.js
@@ -94,8 +94,17 @@ define(function (require, exports, module) {
         if (!this._enabled) {
             return (new $.Deferred()).reject().promise();
         }
-
-        var result = this._commandFn.apply(this, arguments);
+        let args = arguments;
+        if(this._options.eventSource) {
+            // This command has been registered with the optional source details set we have to ensure the event
+            // argument is inserted first. The event source may be already injected by the executor,
+            // if not we have to do it now.
+            if(!args.length || !(typeof args[0] === 'object' && args[0].source)) {
+                const event = {source: SOURCE_OTHER}; // default we don't know the source
+                args = [event].concat(args);
+            }
+        }
+        let result = this._commandFn.apply(this, args);
         if (!result) {
             // If command does not return a promise, assume that it handled the
             // command and return a resolved promise

--- a/src/command/CommandManager.js
+++ b/src/command/CommandManager.js
@@ -99,8 +99,8 @@ define(function (require, exports, module) {
             // This command has been registered with the optional source details set we have to ensure the event
             // argument is inserted first. The event source may be already injected by the executor,
             // if not we have to do it now.
-            if(!args.length || !(typeof args[0] === 'object' && args[0].source)) {
-                const event = {source: SOURCE_OTHER}; // default we don't know the source
+            if(!args.length || !(typeof args[0] === 'object' && args[0].eventSource)) {
+                const event = {eventSource: SOURCE_OTHER}; // default we don't know the source
                 args = [event].concat(args);
             }
         }
@@ -200,7 +200,7 @@ define(function (require, exports, module) {
      *     CommandManager will assume it is synchronous, and return a promise that is already resolved.
      * @param {Object} [options]
      * @param {boolean} options.eventSource If set to true, the commandFn will be called with the first argument `event`
-     * with details about the source(invoker) as event.source(one of the `CommandManager.SOURCE_*`) and
+     * with details about the source(invoker) as event.eventSource(one of the `CommandManager.SOURCE_*`) and
      * event.sourceType(Eg. Ctrl-K) parameter.
      * @return {?Command}
      */
@@ -306,8 +306,8 @@ define(function (require, exports, module) {
                 // This command has been registered with the optional source details set we have to ensure the event
                 // argument is inserted first. The event source may be already injected by the executor,
                 // if not we have to do it now.
-                if(!args.length || !(typeof args[0] === 'object' && args[0].source)) {
-                    const event = {source: SOURCE_OTHER}; // default we don't know the source
+                if(!args.length || !(typeof args[0] === 'object' && args[0].eventSource)) {
+                    const event = {eventSource: SOURCE_OTHER}; // default we don't know the source
                     args = [event].concat(args);
                 }
             }

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -112,6 +112,8 @@ define(function (require, exports, module) {
     // VIEW
     exports.CMD_THEMES_OPEN_SETTINGS    = "view.themesOpenSetting";     // MenuCommands.js              Settings.open()
     exports.VIEW_HIDE_SIDEBAR           = "view.toggleSidebar";         // SidebarView.js               toggle()
+    exports.VIEW_ZOOM_IN                = "view.zoomIn";                // ViewCommandHandlers.js       _handleZoomIn()
+    exports.VIEW_ZOOM_OUT               = "view.zoomOut";                // ViewCommandHandlers.js       _handleZoomOut()
     exports.VIEW_INCREASE_FONT_SIZE     = "view.increaseFontSize";      // ViewCommandHandlers.js       _handleIncreaseFontSize()
     exports.VIEW_DECREASE_FONT_SIZE     = "view.decreaseFontSize";      // ViewCommandHandlers.js       _handleDecreaseFontSize()
     exports.VIEW_RESTORE_FONT_SIZE      = "view.restoreFontSize";       // ViewCommandHandlers.js       _handleRestoreFontSize()

--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -149,9 +149,12 @@ define(function (require, exports, module) {
         menu.addMenuItem(Commands.VIEW_HIDE_SIDEBAR);
         menu.addMenuItem(Commands.TOGGLE_SEARCH_AUTOHIDE);
         menu.addMenuDivider();
-        menu.addMenuItem(Commands.VIEW_INCREASE_FONT_SIZE);
-        menu.addMenuItem(Commands.VIEW_DECREASE_FONT_SIZE);
-        menu.addMenuItem(Commands.VIEW_RESTORE_FONT_SIZE);
+        let subMenu = menu.addSubMenu(Strings.CMD_ZOOM_UI, "zoom-view-submenu");
+        subMenu.addMenuItem(Commands.VIEW_ZOOM_IN);
+        subMenu.addMenuItem(Commands.VIEW_ZOOM_OUT);
+        subMenu.addMenuItem(Commands.VIEW_INCREASE_FONT_SIZE);
+        subMenu.addMenuItem(Commands.VIEW_DECREASE_FONT_SIZE);
+        subMenu.addMenuItem(Commands.VIEW_RESTORE_FONT_SIZE);
         menu.addMenuDivider();
         menu.addMenuItem(Commands.TOGGLE_ACTIVE_LINE);
         menu.addMenuItem(Commands.TOGGLE_LINE_NUMBERS);

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -101,8 +101,8 @@ define(function (require, exports, module) {
 
     let _specialCommands      = [Commands.EDIT_UNDO, Commands.EDIT_REDO, Commands.EDIT_SELECT_ALL,
             Commands.EDIT_CUT, Commands.EDIT_COPY, Commands.EDIT_PASTE],
-        _reservedShortcuts    = ["Ctrl-Z", "Ctrl-Y", "Ctrl-A", "Ctrl-X", "Ctrl-C", "Ctrl-V"],
-        _macReservedShortcuts = ["Cmd-,", "Cmd-H", "Cmd-Alt-H", "Cmd-M", "Cmd-Shift-Z", "Cmd-Q"],
+        _reservedShortcuts    = ["Ctrl-Z", "Ctrl-Y", "Ctrl-A", "Ctrl-X", "Ctrl-C", "Ctrl-V", "Ctrl-=", "Ctrl--"],
+        _macReservedShortcuts = ["Cmd-,", "Cmd-H", "Cmd-Alt-H", "Cmd-M", "Cmd-Shift-Z", "Cmd-Q", "Cmd-=", "Cmd--"],
         _keyNames             = ["Up", "Down", "Left", "Right", "Backspace", "Enter", "Space", "Tab",
             "PageUp", "PageDown", "Home", "End", "Insert", "Delete"];
 
@@ -437,6 +437,7 @@ define(function (require, exports, module) {
     function _mapKeycodeToKey(event) {
         // key code mapping https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_code_values
         const code = event.code;
+        console.log(code);
         let codes = {
             "Tab": "Tab",
             "Space": "Space",
@@ -825,7 +826,15 @@ define(function (require, exports, module) {
             // we always mark the event as processed and return true.
             // We don't want multiple behavior tied to the same key event. For Instance, in browser, if `ctrl-k`
             // is not handled by quick edit, it will open browser url bar if we return false here(which is bad ux).
-            let promise = CommandManager.execute(_keyMap[key].commandID);
+            let command = CommandManager.get(_keyMap[key].commandID);
+            let eventDetails = undefined;
+            if(command._options.eventSource){
+                eventDetails = {
+                    source: CommandManager.SOURCE_KEYBOARD_SHORTCUT,
+                    sourceType: key
+                };
+            }
+            let promise = CommandManager.execute(_keyMap[key].commandID, eventDetails);
             if(UN_SWALLOWED_EVENTS[_keyMap[key].commandID] || _isUnSwallowedKeys(key)){
                 // The execute() function returns a promise because some commands are async.
                 // Generally, commands decide whether they can run or not synchronously,
@@ -1000,6 +1009,7 @@ define(function (require, exports, module) {
             }
         }
         _detectAltGrKeyDown(event);
+        console.log(event);
         if (!handled && _handleKey(_translateKeyboardEvent(event))) {
             event.stopPropagation();
             event.preventDefault();

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -829,7 +829,7 @@ define(function (require, exports, module) {
             let eventDetails = undefined;
             if(command._options.eventSource){
                 eventDetails = {
-                    source: CommandManager.SOURCE_KEYBOARD_SHORTCUT,
+                    eventSource: CommandManager.SOURCE_KEYBOARD_SHORTCUT,
                     sourceType: key
                 };
             }

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -437,7 +437,6 @@ define(function (require, exports, module) {
     function _mapKeycodeToKey(event) {
         // key code mapping https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_code_values
         const code = event.code;
-        console.log(code);
         let codes = {
             "Tab": "Tab",
             "Space": "Space",
@@ -1009,7 +1008,6 @@ define(function (require, exports, module) {
             }
         }
         _detectAltGrKeyDown(event);
-        console.log(event);
         if (!handled && _handleKey(_translateKeyboardEvent(event))) {
             event.stopPropagation();
             event.preventDefault();

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -541,6 +541,7 @@ define(function (require, exports, module) {
      * @return {MenuItem} the newly created MenuItem
      */
     Menu.prototype.addMenuItem = function (command, keyBindings, position, relativeID, options = {}) {
+        const self = this;
         let id,
             $menuItem,
             menuItem,
@@ -571,7 +572,7 @@ define(function (require, exports, module) {
         }
 
         // Internal id is the a composite of the parent menu id and the command id.
-        id = this._getMenuItemId(commandID);
+        id = self._getMenuItemId(commandID);
 
         if (menuItemMap[id]) {
             console.log("MenuItem added with same id of existing MenuItem: " + id);
@@ -594,7 +595,14 @@ define(function (require, exports, module) {
             $menuItem.on("click", function () {
                 Metrics.countEvent(Metrics.EVENT_TYPE.UI_MENU, "click", menuItem._command.getID());
                 logger.leaveTrail("UI Menu Click: " + menuItem._command.getID());
-                menuItem._command.execute();
+                if(menuItem._command._options.eventSource){
+                    menuItem._command.execute({
+                        source: CommandManager.SOURCE_UI_MENU_CLICK,
+                        sourceType: self.id
+                    });
+                } else {
+                    menuItem._command.execute();
+                }
             });
 
             let self = this;

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -597,7 +597,7 @@ define(function (require, exports, module) {
                 logger.leaveTrail("UI Menu Click: " + menuItem._command.getID());
                 if(menuItem._command._options.eventSource){
                     menuItem._command.execute({
-                        source: CommandManager.SOURCE_UI_MENU_CLICK,
+                        eventSource: CommandManager.SOURCE_UI_MENU_CLICK,
                         sourceType: self.id
                     });
                 } else {

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -60,6 +60,10 @@ define({
     "REQUEST_NATIVE_FILE_SYSTEM_ERROR": "An error occurred when trying to load the directory <span class='dialog-filename'>{0}</span>. (error {1})",
     "READ_DIRECTORY_ENTRIES_ERROR": "An error occurred when reading the contents of the directory <span class='dialog-filename'>{0}</span>. (error {1})",
 
+    // FirefoxZoom Dialogue
+    "ZOOM_WITH_SHORTCUTS": "Use Keyboard Shortcuts to Zoom",
+    "ZOOM_WITH_SHORTCUTS_DETAILS": "Please use keyboard shortcuts <code><i>{0}</i></code> to Zoom In and <code><i>{1}</i></code> to Zoom Out.",
+
     // File open/save error string
     "ERROR_OPENING_FILE_TITLE": "Error Opening File",
     "ERROR_OPENING_FILE": "An error occurred when trying to open the file <span class='dialog-filename'>{0}</span>. {1}",
@@ -433,6 +437,9 @@ define({
     "CMD_TOGGLE_SIDEBAR": "Toggle Sidebar",
     "CMD_TOGGLE_PANELS": "Toggle Panels",
     "CMD_TOGGLE_PURE_CODE": "No Distractions",
+    "CMD_ZOOM_UI": "Zoom UI and Fonts",
+    "CMD_ZOOM_IN": "Zoom In",
+    "CMD_ZOOM_OUT": "Zoom Out",
     "CMD_INCREASE_FONT_SIZE": "Increase Font Size",
     "CMD_DECREASE_FONT_SIZE": "Decrease Font Size",
     "CMD_RESTORE_FONT_SIZE": "Restore Font Size",

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -363,7 +363,7 @@ define(function (require, exports, module) {
         // ui with in phcode will not be affected by zoom resulting in widely inconsistent ux on zoom.
         // Further, in Firefox, we cannot programmatically zoom, but user can zoom with Ctrl-+ or - shortcut. So
         // if user click on ui menu, all we can do is to show a dialogue asking them to press ctrl + / minus
-        if(event.source === CommandManager.SOURCE_KEYBOARD_SHORTCUT){
+        if(event.eventSource === CommandManager.SOURCE_KEYBOARD_SHORTCUT){
             // for keyboard shortcuts, we immediately reject so that the browser zoom kicks in that is the
             // most reliable zoom for now.
             return new $.Deferred().reject("use browser zoom");

--- a/test/spec/CommandManager-test.js
+++ b/test/spec/CommandManager-test.js
@@ -108,7 +108,7 @@ define(function (require, exports, module) {
             expect(command.getName()).toBe("newName");
         });
         it("execute a command with optional source event", function () {
-            let event = {source: "hello"};
+            let event = {eventSource: "hello"};
             let receivedEvent;
             let command = CommandManager.register("test command", commandID, (event)=>{
                 receivedEvent = event;
@@ -121,7 +121,7 @@ define(function (require, exports, module) {
             expect(receivedEvent).toBe(event);
         });
         it("execute a command with optional source event and additional exec args", function () {
-            let event = {source: "hello"};
+            let event = {eventSource: "hello"};
             let receivedEvent, receiveArg1, receiveArg2;
             let command = CommandManager.register("test command", commandID, (event, arg1, arg2)=>{
                 receivedEvent = event;
@@ -145,11 +145,11 @@ define(function (require, exports, module) {
                 receivedEvent = event;
             }, {eventSource: true});
             command.execute();
-            expect(receivedEvent).toEql({ source: 'otherExecAction' });
+            expect(receivedEvent).toEql({ eventSource: 'otherExecAction' });
             // now do with command manager exec
             receivedEvent = null;
             CommandManager.execute(commandID);
-            expect(receivedEvent).toEql({ source: 'otherExecAction' });
+            expect(receivedEvent).toEql({ eventSource: 'otherExecAction' });
         });
         it("execute a command will not get eventSource if eventSource option set to false", function () {
             let receivedEvent;

--- a/test/spec/CommandManager-test.js
+++ b/test/spec/CommandManager-test.js
@@ -107,5 +107,71 @@ define(function (require, exports, module) {
             expect(eventTriggered).toBeTruthy();
             expect(command.getName()).toBe("newName");
         });
+        it("execute a command with optional source event", function () {
+            let event = {source: "hello"};
+            let receivedEvent;
+            let command = CommandManager.register("test command", commandID, (event)=>{
+                receivedEvent = event;
+            }, {eventSource: true});
+            command.execute(event);
+            expect(receivedEvent).toBe(event);
+            // now do with command manager exec
+            receivedEvent = null;
+            CommandManager.execute(commandID, event);
+            expect(receivedEvent).toBe(event);
+        });
+        it("execute a command with optional source event and additional exec args", function () {
+            let event = {source: "hello"};
+            let receivedEvent, receiveArg1, receiveArg2;
+            let command = CommandManager.register("test command", commandID, (event, arg1, arg2)=>{
+                receivedEvent = event;
+                receiveArg1 = arg1;
+                receiveArg2 = arg2;
+            }, {eventSource: true});
+            command.execute(event, 42, "arg2");
+            expect(receivedEvent).toBe(event);
+            expect(receiveArg1).toBe(42);
+            expect(receiveArg2).toBe("arg2");
+            // now do with command manager exec
+            receivedEvent = null;
+            CommandManager.execute(commandID, event, 55, "argx");
+            expect(receivedEvent).toBe(event);
+            expect(receiveArg1).toBe(55);
+            expect(receiveArg2).toBe("argx");
+        });
+        it("execute a command registered with eventSource should get event even if execute misses the source", function () {
+            let receivedEvent;
+            let command = CommandManager.register("test command", commandID, (event)=>{
+                receivedEvent = event;
+            }, {eventSource: true});
+            command.execute();
+            expect(receivedEvent).toEql({ source: 'otherExecAction' });
+            // now do with command manager exec
+            receivedEvent = null;
+            CommandManager.execute(commandID);
+            expect(receivedEvent).toEql({ source: 'otherExecAction' });
+        });
+        it("execute a command will not get eventSource if eventSource option set to false", function () {
+            let receivedEvent;
+            let command = CommandManager.register("test command", commandID, (event)=>{
+                receivedEvent = event;
+            }, {eventSource: false});
+            command.execute();
+            expect(receivedEvent).not.toBeDefined();
+            // now do with command manager exec
+            receivedEvent = null;
+            CommandManager.execute(commandID);
+            expect(receivedEvent).not.toBeDefined();
+        });
+        it("execute a command will not get eventSource if eventSource option not given", function () {
+            let receivedEvent;
+            let command = CommandManager.register("test command", commandID, (event)=>{receivedEvent = event;});
+            command.execute();
+            expect(receivedEvent).not.toBeDefined();
+            // now do with command manager exec
+            receivedEvent = null;
+            CommandManager.execute(commandID);
+            expect(receivedEvent).not.toBeDefined();
+        });
     });
 });


### PR DESCRIPTION
More natural browser native zoom.

We could have set the zoom programmatically if we do set document.body.style=zoom = 1,5 ,
But then the new project window or generally any iframes based ui with in phcode will not be affected by zoom resulting in widely inconsistent ux on zoom.

Further, in Firefox, we cannot programmatically zoom, but user can zoom with Ctrl-+ or - shortcut. So if user click on ui menu, all we can do is to show a dialogue asking them to press ctrl + / minus.

VSCode gets away with this as they just have chromium to deal with and not filefox/safari/mobile in native builds. In web based vscode.dev, they don't show the zoom option altogether. We could do similar things in Tauri.

![zoom](https://user-images.githubusercontent.com/5336369/229292019-49de2546-8c20-4dae-8a6a-51a575371426.gif)

## new zoom UI and fonts sub menu
![image](https://user-images.githubusercontent.com/5336369/229274740-7bf9de56-bc82-441b-991c-8ab0ddd219e3.png)

## zoom-in and out Ui menu click dialogue
If someone clicks on zoom-in or out menu from the view zoom submenu, we show the dialogue below to zoom using the shortcut. This is because we cant reliably programmatically zoom.
![image](https://user-images.githubusercontent.com/5336369/229274787-b06d7a0a-533b-4247-b71e-5302233d6b23.png)
