### PR TITLE
fix: view > collapse all not working as expected

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "phoenix",
-    "version": "3.1.17-0",
+    "version": "3.1.21-0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "phoenix",
-            "version": "3.1.17-0",
+            "version": "3.1.21-0",
             "dependencies": {
                 "@bugsnag/js": "^7.18.0",
                 "@floating-ui/dom": "^0.5.4",

--- a/src/extensions/default/CodeFolding/main.js
+++ b/src/extensions/default/CodeFolding/main.js
@@ -252,7 +252,7 @@ define(function (require, exports, module) {
         var editor = EditorManager.getFocusedEditor();
         if (editor) {
             var cm = editor._codeMirror;
-            CodeMirror.commands.foldToLevel(cm);
+            CodeMirror.commands.foldAll(cm);
         }
     }
 


### PR DESCRIPTION
Fix for: Collapse All does not seem to do what you would want. It collapses all the way to the top indent, usually the tag, which is great. But when you start expanding sub-elements, not all of them are collapsed as well, meaning Collapse All did not really do anything useful. It would be great if Collapse All would collapse all of the elements, as the name implies.

part of https://github.com/phcode-dev/phoenix/issues/1034