### PR TITLE
Safari Support for live preview and extensions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "phoenix",
-    "version": "3.1.21-0",
+    "version": "3.1.22-0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "phoenix",
-            "version": "3.1.21-0",
+            "version": "3.1.22-0",
             "dependencies": {
                 "@bugsnag/js": "^7.18.0",
                 "@floating-ui/dom": "^0.5.4",

--- a/src/phoenix/virtualServer/config.js
+++ b/src/phoenix/virtualServer/config.js
@@ -33,7 +33,6 @@ if(!self.Config){
      *
      * `debug`: if present (i.e., `Boolean`), enable workbox debug logging
      */
-    const url = new URL(location);
 
     /**
      * Given a route string, make sure it follows the pattern we expect:
@@ -47,7 +46,7 @@ if(!self.Config){
      * @param {String} route
      */
     function getNormalizeRoute() {
-        let route = url.searchParams.get('route') || 'fs';
+        let route = (new URL(location)).searchParams.get('route') || 'fs';
 
         // Only a single / at the front of the route
         route = route.replace(/^\/*/, '');
@@ -59,7 +58,7 @@ if(!self.Config){
 
     self.Config = {
         route: getNormalizeRoute(),
-        disableIndexes: url.searchParams.get('disableIndexes') !== null,
+        disableIndexes: (new URL(location)).searchParams.get('disableIndexes') !== null,
         debug: false // this is set via sw messages from phoenix
     };
 }

--- a/src/phoenix/virtualServer/content-type.js
+++ b/src/phoenix/virtualServer/content-type.js
@@ -17,46 +17,48 @@
  *
  */
 
-/* global lookup, importScripts*/
+/* global mime, importScripts*/
 
 importScripts('phoenix/virtualServer/mime-types.js');
 
 if(!self.ContentType){
-    function getMimeType(path) {
-        return lookup(path) || 'application/octet-stream';
-    }
-
-    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#Audio_and_video_types
-    function isMedia(path) {
-        let mimeType = lookup(path);
-        if (!mimeType) {
-            return false;
+    (function () {
+        function getMimeType(path) {
+            return mime.lookup(path) || 'application/octet-stream';
         }
 
-        mimeType = mimeType.toLowerCase();
+        // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#Audio_and_video_types
+        function isMedia(path) {
+            let mimeType = mime.lookup(path);
+            if (!mimeType) {
+                return false;
+            }
 
-        // Deal with OGG special case
-        if (mimeType === 'application/ogg') {
-            return true;
+            mimeType = mimeType.toLowerCase();
+
+            // Deal with OGG special case
+            if (mimeType === 'application/ogg') {
+                return true;
+            }
+
+            // Anything else with `audio/*` or `video/*` is "media"
+            return mimeType.startsWith('audio/') || mimeType.startsWith('video/');
         }
 
-        // Anything else with `audio/*` or `video/*` is "media"
-        return mimeType.startsWith('audio/') || mimeType.startsWith('video/');
-    }
+        // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#Image_types
+        function isImage(path) {
+            const mimeType = mime.lookup(path);
+            if (!mimeType) {
+                return false;
+            }
 
-    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#Image_types
-    function isImage(path) {
-        const mimeType = lookup(path);
-        if (!mimeType) {
-            return false;
+            return mimeType.toLowerCase().startsWith('image/');
         }
 
-        return mimeType.toLowerCase().startsWith('image/');
-    }
-
-    self.ContentType = {
-        isMedia,
-        isImage,
-        getMimeType
-    };
+        self.ContentType = {
+            isMedia,
+            isImage,
+            getMimeType
+        };
+    }());
 }

--- a/src/phoenix/virtualServer/html-formatter.js
+++ b/src/phoenix/virtualServer/html-formatter.js
@@ -23,44 +23,45 @@ importScripts('phoenix/virtualServer/content-type.js');
 importScripts('phoenix/virtualServer/icons.js');
 
 if(!self.HtmlFormatter){
-// 20-Apr-2004 17:14
-    const formatDate = d => {
-        const day = d.getDate();
-        const month = d.toLocaleString('en-us', {month: 'short'});
-        const year = d.getFullYear();
-        const hours = d.getHours();
-        const mins = d.getMinutes();
-        return `${day}-${month}-${year} ${hours}:${mins}`;
-    };
+    (function () {
+        // 20-Apr-2004 17:14
+        const formatDate = d => {
+            const day = d.getDate();
+            const month = d.toLocaleString('en-us', {month: 'short'});
+            const year = d.getFullYear();
+            const hours = d.getHours();
+            const mins = d.getMinutes();
+            return `${day}-${month}-${year} ${hours}:${mins}`;
+        };
 
-    const formatSize = s => {
-        const units = ['', 'K', 'M'];
-        if (!s) {
-            return '-';
-        }
-        const i = Math.floor(Math.log(s) / Math.log(1024));
-        return Math.round(s / Math.pow(1024, i), 2) + units[i];
-    };
+        const formatSize = s => {
+            const units = ['', 'K', 'M'];
+            if (!s) {
+                return '-';
+            }
+            const i = Math.floor(Math.log(s) / Math.log(1024));
+            return Math.round(s / Math.pow(1024, i), 2) + units[i];
+        };
 
-    const formatRow = (
-        icon,
-        alt = '[   ]',
-        href,
-        name,
-        modified,
-        size
-    ) => `<tr><td valign='top'><img src='${icon || icons.unknown}' alt='${alt}'></td><td>
+        const formatRow = (
+            icon,
+            alt = '[   ]',
+            href,
+            name,
+            modified,
+            size
+        ) => `<tr><td valign='top'><img src='${icon || icons.unknown}' alt='${alt}'></td><td>
       <a href='${href}'>${name}</a></td>
       <td align='right'>${formatDate(new Date(modified))}</td>
       <td align='right'>${formatSize(size)}</td><td>&nbsp;</td></tr>`;
 
-    const footerClose = '<address>nohost (Web Browser Server)</address></body></html>';
+        const footerClose = '<address>nohost (Web Browser Server)</address></body></html>';
 
-    /**
-     * Send an Apache-style 404
-     */
-    function format404(url) {
-        const body = `
+        /**
+         * Send an Apache-style 404
+         */
+        function format404(url) {
+            const body = `
     <!DOCTYPE html>
     <html><head>
     <title>404 Not Found</title>
@@ -69,21 +70,21 @@ if(!self.HtmlFormatter){
     <p>The requested URL ${url} was not found on this server.</p>
     <hr>${footerClose}`;
 
-        return {
-            body,
-            config: {
-                status: 404,
-                statusText: 'Not Found',
-                headers: {'Content-Type': 'text/html'}
-            }
-        };
-    }
+            return {
+                body,
+                config: {
+                    status: 404,
+                    statusText: 'Not Found',
+                    headers: {'Content-Type': 'text/html'}
+                }
+            };
+        }
 
-    /**
-     * Send an Apache-style 500
-     */
-    function format500(path, err) {
-        const body = `
+        /**
+         * Send an Apache-style 500
+         */
+        function format500(path, err) {
+            const body = `
     <!DOCTYPE html>
     <html><head>
     <title>500 Internal Server Error</title>
@@ -93,24 +94,24 @@ if(!self.HtmlFormatter){
     <p>The error was: ${err.message}.</p>
     <hr>${footerClose}`;
 
-        return {
-            body,
-            config: {
-                status: 500,
-                statusText: 'Internal Error',
-                headers: {'Content-Type': 'text/html'}
-            }
-        };
-    }
+            return {
+                body,
+                config: {
+                    status: 500,
+                    statusText: 'Internal Error',
+                    headers: {'Content-Type': 'text/html'}
+                }
+            };
+        }
 
-    /**
-     * Send an Apache-style directory listing
-     */
-    function formatDir(route, dirPath, entries) {
-        const parent = self.path.dirname(dirPath) || '/';
-        // Maintain path sep, but deal with things like spaces in filenames
-        const url = encodeURI(route + parent);
-        const header = `
+        /**
+         * Send an Apache-style directory listing
+         */
+        function formatDir(route, dirPath, entries) {
+            const parent = self.path.dirname(dirPath) || '/';
+            // Maintain path sep, but deal with things like spaces in filenames
+            const url = encodeURI(route + parent);
+            const header = `
     <!DOCTYPE html>
     <html><head><title>Index of ${dirPath}</title></head>
     <body><h1>Index of ${dirPath}</h1>
@@ -121,59 +122,60 @@ if(!self.HtmlFormatter){
     <tr><td valign='top'><img src='${icons.back}' alt='[DIR]'></td>
     <td><a href='${url}'>Parent Directory</a></td><td>&nbsp;</td>
     <td align='right'>  - </td><td>&nbsp;</td></tr>`;
-        const footer = `<tr><th colspan='5'><hr></th></tr></table>${footerClose}`;
+            const footer = `<tr><th colspan='5'><hr></th></tr></table>${footerClose}`;
 
-        const rows = entries.map(entry => {
-            let entryName = entry.name || entry;
-            const ext = self.path.extname(entryName);
-            // Maintain path sep, but deal with things like spaces in filenames
-            const href = encodeURI(`${route}${self.path.join(dirPath, entryName)}`);
-            let icon;
-            let alt;
+            const rows = entries.map(entry => {
+                let entryName = entry.name || entry;
+                const ext = self.path.extname(entryName);
+                // Maintain path sep, but deal with things like spaces in filenames
+                const href = encodeURI(`${route}${self.path.join(dirPath, entryName)}`);
+                let icon;
+                let alt;
 
-            // TODO: switch this to entry.isDirectory() if possible
-            if (ContentType.isImage(ext)) {
-                icon = icons.image2;
-                alt = '[IMG]';
-            } else if (ContentType.isMedia(ext)) {
-                icon = icons.movie;
-                alt = '[MOV]';
-            } else if (!ext) {
-                icon = icons.folder;
-                alt = '[DIR]';
-            } else {
-                icon = icons.text;
-                alt = '[TXT]';
-            }
+                // TODO: switch this to entry.isDirectory() if possible
+                if (ContentType.isImage(ext)) {
+                    icon = icons.image2;
+                    alt = '[IMG]';
+                } else if (ContentType.isMedia(ext)) {
+                    icon = icons.movie;
+                    alt = '[MOV]';
+                } else if (!ext) {
+                    icon = icons.folder;
+                    alt = '[DIR]';
+                } else {
+                    icon = icons.text;
+                    alt = '[TXT]';
+                }
 
-            return formatRow(icon, alt, href, entryName, entry.mtime, entry.size);
-        }).join('\n');
+                return formatRow(icon, alt, href, entryName, entry.mtime, entry.size);
+            }).join('\n');
 
-        return {
-            body: header + rows + footer,
-            config: {
-                status: 200,
-                statusText: 'OK',
-                headers: {'Content-Type': 'text/html'}
-            }
+            return {
+                body: header + rows + footer,
+                config: {
+                    status: 200,
+                    statusText: 'OK',
+                    headers: {'Content-Type': 'text/html'}
+                }
+            };
+        }
+
+        function formatFile(path, content) {
+            return {
+                body: content,
+                config: {
+                    status: 200,
+                    statusText: 'OK',
+                    headers: {'Content-Type': ContentType.getMimeType(path)}
+                }
+            };
+        }
+
+        self.HtmlFormatter = {
+            format404,
+            format500,
+            formatDir,
+            formatFile
         };
-    }
-
-    function formatFile(path, content) {
-        return {
-            body: content,
-            config: {
-                status: 200,
-                statusText: 'OK',
-                headers: {'Content-Type': ContentType.getMimeType(path)}
-            }
-        };
-    }
-
-    self.HtmlFormatter = {
-        format404,
-        format500,
-        formatDir,
-        formatFile
-    };
+    }());
 }

--- a/src/phoenix/virtualServer/mime-types.js
+++ b/src/phoenix/virtualServer/mime-types.js
@@ -19,7 +19,7 @@
  *
  */
 
-/*globals path, MIME_TYPE_DATABASE_REFERENCE*/
+/*globals MIME_TYPE_DATABASE_REFERENCE*/
 importScripts('phoenix/virtualServer/mime-db.js');
 
 /**
@@ -27,191 +27,192 @@ importScripts('phoenix/virtualServer/mime-db.js');
  * based on  mime-types lib https://github.com/jshttp/mime-types
  */
 if(!self.mime){
-    self.mime ={};
-    let db = MIME_TYPE_DATABASE_REFERENCE;
+    (function() {
+        self.mime ={};
+        let db = MIME_TYPE_DATABASE_REFERENCE;
 
-    if (!self.path) {
-        console.error("Phoenix fs lib should be loaded before mime type.");
-    }
-    let extname = path.extname;
-    /**
-     * Module variables.
-     * @private
-     */
+        if (!self.path) {
+            console.error("Phoenix fs lib should be loaded before mime type.");
+        }
+        /**
+         * Module variables.
+         * @private
+         */
 
-    var EXTRACT_TYPE_REGEXP = /^\s*([^;\s]*)(?:;|\s|$)/;
-    var TEXT_TYPE_REGEXP = /^text\//i;
+        var EXTRACT_TYPE_REGEXP = /^\s*([^;\s]*)(?:;|\s|$)/;
+        var TEXT_TYPE_REGEXP = /^text\//i;
 
-    /**
-     * Module exports.
-     * @public
-     */
+        /**
+         * Module exports.
+         * @public
+         */
 
-    self.mime.charset = charset;
-    self.mime.charsets = {lookup: charset};
-    self.mime.contentType = contentType;
-    self.mime.extension = extension;
-    self.mime.extensions = {
-        "text/html": [
-            "html",
-            "htm",
-            "shtml"
-        ]
-    };
-    self.mime.lookup = lookup;
-    self.mime.types = {
-        htm: "text/html",
-        html: "text/html",
-        shtml: "text/html"
-    };
+        self.mime.charset = charset;
+        self.mime.charsets = {lookup: charset};
+        self.mime.contentType = contentType;
+        self.mime.extension = extension;
+        self.mime.extensions = {
+            "text/html": [
+                "html",
+                "htm",
+                "shtml"
+            ]
+        };
+        self.mime.lookup = lookup;
+        self.mime.types = {
+            htm: "text/html",
+            html: "text/html",
+            shtml: "text/html"
+        };
 
-    /**
-     * Get the default charset for a MIME type.
-     *
-     * @param {string} type
-     * @return {boolean|string}
-     */
+        /**
+         * Get the default charset for a MIME type.
+         *
+         * @param {string} type
+         * @return {boolean|string}
+         */
 
-    function charset(type) {
-        if (!type || typeof type !== 'string') {
+        function charset(type) {
+            if (!type || typeof type !== 'string') {
+                return false;
+            }
+
+            // TODO: use media-typer
+            var match = EXTRACT_TYPE_REGEXP.exec(type);
+            var mime = match && db[match[1].toLowerCase()];
+
+            if (mime && mime.charset) {
+                return mime.charset;
+            }
+
+            // default text/* to utf-8
+            if (match && TEXT_TYPE_REGEXP.test(match[1])) {
+                return 'UTF-8';
+            }
+
             return false;
         }
 
-        // TODO: use media-typer
-        var match = EXTRACT_TYPE_REGEXP.exec(type);
-        var mime = match && db[match[1].toLowerCase()];
+        /**
+         * Create a full Content-Type header given a MIME type or extension.
+         *
+         * @param {string} str
+         * @return {boolean|string}
+         */
 
-        if (mime && mime.charset) {
-            return mime.charset;
+        function contentType(str) {
+            // TODO: should this even be in this module?
+            if (!str || typeof str !== 'string') {
+                return false;
+            }
+
+            var mime = str.indexOf('/') === -1
+                ? self.mime.lookup(str)
+                : str;
+
+            if (!mime) {
+                return false;
+            }
+
+            // TODO: use content-type or other module
+            if (mime.indexOf('charset') === -1) {
+                var charset = self.mime.charset(mime);
+                if (charset) { mime += '; charset=' + charset.toLowerCase(); }
+            }
+
+            return mime;
         }
 
-        // default text/* to utf-8
-        if (match && TEXT_TYPE_REGEXP.test(match[1])) {
-            return 'UTF-8';
-        }
+        /**
+         * Get the default extension for a MIME type.
+         *
+         * @param {string} type
+         * @return {boolean|string}
+         */
 
-        return false;
-    }
+        function extension(type) {
+            if (!type || typeof type !== 'string') {
+                return false;
+            }
 
-    /**
-     * Create a full Content-Type header given a MIME type or extension.
-     *
-     * @param {string} str
-     * @return {boolean|string}
-     */
+            // TODO: use media-typer
+            var match = EXTRACT_TYPE_REGEXP.exec(type);
 
-    function contentType(str) {
-        // TODO: should this even be in this module?
-        if (!str || typeof str !== 'string') {
-            return false;
-        }
-
-        var mime = str.indexOf('/') === -1
-            ? self.mime.lookup(str)
-            : str;
-
-        if (!mime) {
-            return false;
-        }
-
-        // TODO: use content-type or other module
-        if (mime.indexOf('charset') === -1) {
-            var charset = self.mime.charset(mime);
-            if (charset) { mime += '; charset=' + charset.toLowerCase(); }
-        }
-
-        return mime;
-    }
-
-    /**
-     * Get the default extension for a MIME type.
-     *
-     * @param {string} type
-     * @return {boolean|string}
-     */
-
-    function extension(type) {
-        if (!type || typeof type !== 'string') {
-            return false;
-        }
-
-        // TODO: use media-typer
-        var match = EXTRACT_TYPE_REGEXP.exec(type);
-
-        // get extensions
-        var exts = match && self.mime.extensions[match[1].toLowerCase()];
-
-        if (!exts || !exts.length) {
-            return false;
-        }
-
-        return exts[0];
-    }
-
-    /**
-     * Lookup the MIME type for a file path/extension.
-     *
-     * @param {string} path
-     * @return {boolean|string}
-     */
-
-    function lookup(path) {
-        if (!path || typeof path !== 'string') {
-            return false;
-        }
-
-        // get the extension ("ext" or ".ext" or full path)
-        var extension = extname('x.' + path)
-            .toLowerCase()
-            .substr(1);
-
-        if (!extension) {
-            return false;
-        }
-
-        return self.mime.types[extension] || false;
-    }
-
-    /**
-     * Populate the extensions and types maps.
-     * @private
-     */
-
-    function populateMaps(extensions, types) {
-        // source preference (least -> most)
-        var preference = ['nginx', 'apache', undefined, 'iana'];
-
-        Object.keys(db).forEach(function forEachMimeType(type) {
-            var mime = db[type];
-            var exts = mime.extensions;
+            // get extensions
+            var exts = match && self.mime.extensions[match[1].toLowerCase()];
 
             if (!exts || !exts.length) {
-                return;
+                return false;
             }
 
-            // mime -> extensions
-            extensions[type] = exts;
+            return exts[0];
+        }
 
-            // extension -> mime
-            for (var i = 0; i < exts.length; i++) {
-                var extension = exts[i];
+        /**
+         * Lookup the MIME type for a file path/extension.
+         *
+         * @param {string} path
+         * @return {boolean|string}
+         */
 
-                if (types[extension]) {
-                    var from = preference.indexOf(db[types[extension]].source);
-                    var to = preference.indexOf(mime.source);
+        function lookup(path) {
+            if (!path || typeof path !== 'string') {
+                return false;
+            }
 
-                    if (types[extension] !== 'application/octet-stream' &&
-                        (from > to || (from === to && types[extension].substr(0, 12) === 'application/'))) {
-                        // skip the remapping
-                        continue;
-                    }
+            // get the extension ("ext" or ".ext" or full path)
+            var extension = self.path.extname('x.' + path)
+                .toLowerCase()
+                .substr(1);
+
+            if (!extension) {
+                return false;
+            }
+
+            return self.mime.types[extension] || false;
+        }
+
+        /**
+         * Populate the extensions and types maps.
+         * @private
+         */
+
+        function populateMaps(extensions, types) {
+            // source preference (least -> most)
+            var preference = ['nginx', 'apache', undefined, 'iana'];
+
+            Object.keys(db).forEach(function forEachMimeType(type) {
+                var mime = db[type];
+                var exts = mime.extensions;
+
+                if (!exts || !exts.length) {
+                    return;
                 }
 
-                // set the extension -> mime
-                types[extension] = type;
-            }
-        });
-    }
+                // mime -> extensions
+                extensions[type] = exts;
 
-    populateMaps(self.mime.extensions, self.mime.types);
+                // extension -> mime
+                for (var i = 0; i < exts.length; i++) {
+                    var extension = exts[i];
+
+                    if (types[extension]) {
+                        var from = preference.indexOf(db[types[extension]].source);
+                        var to = preference.indexOf(mime.source);
+
+                        if (types[extension] !== 'application/octet-stream' &&
+                            (from > to || (from === to && types[extension].substr(0, 12) === 'application/'))) {
+                            // skip the remapping
+                            continue;
+                        }
+                    }
+
+                    // set the extension -> mime
+                    types[extension] = type;
+                }
+            });
+        }
+
+        populateMaps(self.mime.extensions, self.mime.types);
+    }());
 }

--- a/test/spec/LiveDevelopmentMultiBrowser-test.js
+++ b/test/spec/LiveDevelopmentMultiBrowser-test.js
@@ -179,6 +179,16 @@ define(function (require, exports, module) {
             await endPreviewSession();
         });
 
+        function _isRelatedStyleSheet(liveDoc, fileName) {
+            let relatedSheets = Object.keys(liveDoc.getRelated().stylesheets);
+            for(let relatedPath of relatedSheets){
+                if(relatedPath.endsWith(fileName)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         it("should send notifications for added/removed stylesheets through link nodes", async function () {
             let liveDoc;
             await awaitsForDone(SpecRunnerUtils.openProjectFiles(["simple1.html"]),
@@ -188,21 +198,12 @@ define(function (require, exports, module) {
             liveDoc = LiveDevMultiBrowser.getCurrentLiveDoc();
 
             let curDoc =  DocumentManager.getCurrentDocument();
-            curDoc.replaceRange('<link href="simple2.css" rel="stylesheet">\n', {line: 8, ch: 0});
-
-            await awaitsFor(
-                function relatedDocsReceived() {
-                    return (Object.getOwnPropertyNames(liveDoc.getRelated().stylesheets).length === 3);
-                },
-                "relatedDocuments.done.received",
-                10000
-            );
 
             curDoc.replaceRange('<link href="blank.css" rel="stylesheet">\n', {line: 8, ch: 0});
 
             await awaitsFor(
                 function relatedDocsReceived() {
-                    return (Object.getOwnPropertyNames(liveDoc.getRelated().stylesheets).length === 4);
+                    return _isRelatedStyleSheet(liveDoc, "blank.css");
                 },
                 "relatedDocuments.done.received",
                 10000


### PR DESCRIPTION
Fixes:
1. Live preview not working in safari
2. extensions and themes not installable in safari

Caused by safari's JS engine dropping scoped variables in `if` block statements in the service worker, causing variables(Eg. db) not found errors. Now, we create a separate function block.

## testing
1. Tested Live preview is working in chrome, Edge, Firefox and Safari in Mac
2. Tested Live preview integration tests is working in chrome, Edge, Firefox and Safari in Mac
3. Tested Extensions and themes install and use is working in chrome, Edge, Firefox and Safari in Mac 
4. Tested Extensions integration tests is working in Safari in Mac