### PR TITLE
fix: keep Find/Replace dialog open even if user clicks out

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "phoenix",
-    "version": "3.1.22-0",
+    "version": "3.2.1-0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "phoenix",
-            "version": "3.1.22-0",
+            "version": "3.2.1-0",
             "dependencies": {
                 "@bugsnag/js": "^7.18.0",
                 "@floating-ui/dom": "^0.5.4",

--- a/src/editor/EditorHelper/EditorPreferences.js
+++ b/src/editor/EditorHelper/EditorPreferences.js
@@ -151,7 +151,7 @@ define(function (require, exports, module) {
         description: Strings.DESCRIPTION_WORD_WRAP
     });
 
-    PreferencesManager.definePreference(AUTO_HIDE_SEARCH,   "boolean", true, {
+    PreferencesManager.definePreference(AUTO_HIDE_SEARCH,   "boolean", false, {
         description: Strings.DESCRIPTION_SEARCH_AUTOHIDE
     });
 


### PR DESCRIPTION
fixes: https://github.com/phcode-dev/phoenix/issues/1058