### PR TITLE
fix: file recovery error message in console and add metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "testChromium": "npx playwright test --project=chromium",
         "testFirefox": "npx playwright test --project=firefox",
         "buildonly": "gulp build",
-        "vulnerabilityCheck": "echo Scanning for vulnarabilities && npm audit --prod",
+        "vulnerabilityCheck": "echo Scanning for vulnarabilities && npm audit --prod --audit-level=critical",
         "build": "npm run buildonly && npm run createJSDocs && npm run zipTestFiles && npm run lint && npm run vulnerabilityCheck",
         "clean": "gulp clean",
         "reset": "gulp reset",


### PR DESCRIPTION
* fix benign issue in js console due to a race condition in project open when no restore data is present.
* metrics for file recovery
# Change npm vilnerability scan to only break builds on critical vulnerability.
We had to do this change as we got a [moderate vulneribility](https://github.com/advisories/GHSA-c2qf-rxjj-qqgw) for lessJS. Less haven't updated their code, so there is nothing we can do other than to upgrade a whole lot of deps that is not worth effort now. So only braking builds for high sev vulnerabilities.
https://stackoverflow.com/questions/61875736/the-command-npm-audit-level-is-not-working-when-trying-to-change-level-to-high