### PR TITLE
chore: move to prod url phcode.live for live preview

### DIFF
--- a/src/LiveDevelopment/LiveDevServerManager.js
+++ b/src/LiveDevelopment/LiveDevServerManager.js
@@ -119,8 +119,8 @@ define(function (require, exports, module) {
         }
     }
 
-    const LIVE_PREVIEW_STATIC_SERVER_BASE_URL = "http://localhost:8001/",
-        LIVE_PREVIEW_STATIC_SERVER_ORIGIN = "http://localhost:8001";
+    const LIVE_PREVIEW_STATIC_SERVER_BASE_URL = "https://phcode.live/",
+        LIVE_PREVIEW_STATIC_SERVER_ORIGIN = "http://phcode.live";
     // #LIVE_PREVIEW_STATIC_SERVER_BASE_URL_OVERRIDE uncomment below line if you are developing live preview server.
     // const LIVE_PREVIEW_STATIC_SERVER_BASE_URL = "http://localhost:8001/";
     // const LIVE_PREVIEW_STATIC_SERVER_ORIGIN = "http://localhost:8001";

--- a/src/LiveDevelopment/LiveDevServerManager.js
+++ b/src/LiveDevelopment/LiveDevServerManager.js
@@ -120,7 +120,7 @@ define(function (require, exports, module) {
     }
 
     const LIVE_PREVIEW_STATIC_SERVER_BASE_URL = "https://phcode.live/",
-        LIVE_PREVIEW_STATIC_SERVER_ORIGIN = "http://phcode.live";
+        LIVE_PREVIEW_STATIC_SERVER_ORIGIN = "https://phcode.live";
     // #LIVE_PREVIEW_STATIC_SERVER_BASE_URL_OVERRIDE uncomment below line if you are developing live preview server.
     // const LIVE_PREVIEW_STATIC_SERVER_BASE_URL = "http://localhost:8001/";
     // const LIVE_PREVIEW_STATIC_SERVER_ORIGIN = "http://localhost:8001";


### PR DESCRIPTION
## known issues
1. In chrome incognito mode, live preview doesn't work as it blocks third party cookies which prevents service worker registration somehow. Doesnt happen in edge.

## testing
1. works in chrome/chromium except in the incognito mode
2. works in edge in both private/normal mode
3. Works in firefox in normal mode. phoenix wont load in ff in private mode as idb is not available in private mode.
4. to test in safari