### PR TITLE
fix: live preview stability images in iframe panel in page loader

### DIFF
--- a/src/LiveDevelopment/BrowserScripts/DocumentObserver.js
+++ b/src/LiveDevelopment/BrowserScripts/DocumentObserver.js
@@ -48,6 +48,25 @@
         }, false);
     }
 
+    window.addEventListener('scroll', function () {
+        // save scroll position
+        sessionStorage.setItem("markdown-scroll-" + location.href, JSON.stringify({
+            scrollX: window.scrollX,
+            scrollY: window.scrollY
+        }));
+    });
+    function scrollToLastPosition() {
+        let saved = JSON.parse(sessionStorage.getItem("markdown-scroll-" + location.href));
+        if(saved){
+            window.scrollTo({
+                left: saved.scrollX,
+                top: saved.scrollY,
+                behavior: "instant"
+            });
+        }
+    }
+    window.addEventListener("load", scrollToLastPosition);
+
     /**
      * Retrieves related documents (external CSS and JS files)
      *

--- a/src/extensions/default/Phoenix-live-preview/main.js
+++ b/src/extensions/default/Phoenix-live-preview/main.js
@@ -168,7 +168,7 @@ define(function (require, exports, module) {
         }
         urlPinned = !pinStatus;
         LiveDevelopment.setLivePreviewPinned(urlPinned);
-        _loadPreview();
+        _loadPreview(true);
         Metrics.countEvent(Metrics.EVENT_TYPE.LIVE_PREVIEW, "pinURLBtn", "click");
     }
 
@@ -298,6 +298,9 @@ define(function (require, exports, module) {
             // panel-live-preview-title
             let previewDetails = await utils.getPreviewDetails();
             let newSrc = saved.currentSrc;
+            if(urlPinned && !force) {
+                return;
+            }
             if (!urlPinned && previewDetails.URL) {
                 newSrc = encodeURI(previewDetails.URL);
                 _setTitle(previewDetails.filePath);

--- a/src/extensions/default/Phoenix-live-preview/main.js
+++ b/src/extensions/default/Phoenix-live-preview/main.js
@@ -262,39 +262,15 @@ define(function (require, exports, module) {
         });
     }
 
-    function _renderMarkdown(fullPath, newSrc) {
-        currentLivePreviewURL = newSrc;
-        console.log(`Markdown Static server _updateInstrumentedURLSInWorker: `, [fullPath], newSrc);
-        window.messageSW({
-            type: 'setInstrumentedURLs',
-            root: "",
-            paths: [fullPath]
-        }).then((status)=>{
-            console.log(`Markdown server received msg from Service worker: setInstrumentedURLs done: `, status);
-            if(panel.isVisible()){
-                $iframe.attr('srcdoc', null);
-                $iframe.attr('src', newSrc);
-            }
-            _redirectAllTabs(newSrc);
-        }).catch(err=>{
-            console.error(`Markdown error while from sw rendering failed for ${fullPath}: `, err);
-        });
-    }
-
     function _renderPreview(previewDetails, newSrc) {
         let fullPath = previewDetails.fullPath;
-        if(previewDetails.isMarkdownFile){
-            _renderMarkdown(fullPath, newSrc);
-            Metrics.countEvent(Metrics.EVENT_TYPE.LIVE_PREVIEW, "render", "markdown");
-        } else {
-            currentLivePreviewURL = newSrc;
-            if(panel.isVisible()){
-                $iframe.attr('srcdoc', null);
-                $iframe.attr('src', newSrc);
-            }
-            _redirectAllTabs(newSrc);
-            Metrics.countEvent(Metrics.EVENT_TYPE.LIVE_PREVIEW, "render", utils.getExtension(fullPath));
+        currentLivePreviewURL = utils.isImage(fullPath) ? _getTabNavigationURL(newSrc) : newSrc;
+        Metrics.countEvent(Metrics.EVENT_TYPE.LIVE_PREVIEW, "render", utils.getExtension(fullPath));
+        if(panel.isVisible()) {
+            $iframe.attr('srcdoc', null);
+            $iframe.attr('src', currentLivePreviewURL);
         }
+        _redirectAllTabs(newSrc);
     }
 
     let savedScrollPositions = {};

--- a/src/extensions/default/Phoenix-live-preview/markdown.html
+++ b/src/extensions/default/Phoenix-live-preview/markdown.html
@@ -28,6 +28,25 @@
                 }
             }, false);
         }
+
+        window.addEventListener('scroll', function () {
+            // save scroll position
+            sessionStorage.setItem("markdown-scroll-" + location.href, JSON.stringify({
+                scrollX: window.scrollX,
+                scrollY: window.scrollY
+            }));
+        });
+        function scrollToLastPosition() {
+            let saved = JSON.parse(sessionStorage.getItem("markdown-scroll-" + location.href));
+            if(saved){
+                window.scrollTo({
+                    left: saved.scrollX,
+                    top: saved.scrollY,
+                    behavior: "instant"
+                });
+            }
+        }
+
     </script>
     <style>
 
@@ -92,7 +111,7 @@
 
     </style>
 </head>
-<body onload="hljs.highlightAll();">
+<body onload="scrollToLastPosition();hljs.highlightAll();">
 {{{markdownContent}}}
 </body>
 </html>

--- a/src/extensions/default/Phoenix-live-preview/utils.js
+++ b/src/extensions/default/Phoenix-live-preview/utils.js
@@ -53,8 +53,14 @@ define(function (require, exports, module) {
 
     function isPreviewableFile(filePath) {
         let extension = getExtension(filePath);
-        return ['html', 'xhtml', 'htm', 'jpg', 'jpeg', 'png', 'svg',
-            'pdf', 'md', 'markdown'].includes(extension.toLowerCase());
+        return isImage(filePath) || _isMarkdownFile(filePath) || _isHTMLFile(filePath) ||
+            ['pdf'].includes(extension.toLowerCase());
+    }
+
+    function isImage(filePath) {
+        let extension = getExtension(filePath);
+        return ["jpg", "jpeg", "png", "gif", "svg", "webp", "bmp", "ico", "avif"]
+            .includes(extension.toLowerCase());
     }
 
     function _isMarkdownFile(filePath) {
@@ -119,6 +125,7 @@ define(function (require, exports, module) {
     exports.getNoPreviewURL = getNoPreviewURL;
     exports.getExtension = getExtension;
     exports.isPreviewableFile = isPreviewableFile;
+    exports.isImage = isImage;
 });
 
 


### PR DESCRIPTION
* Images are now rendered in live preview iframe using the `pageLoader.html` which disables ctrl-s on live preview panel for images. This files save dialog popup on press of ctrl-s in images
* streamline live preview code