### PR TITLE
safari support is deprecated, use native builds in mac

### DIFF
--- a/src/assets/default-project/en/Newly_added_features.md
+++ b/src/assets/default-project/en/Newly_added_features.md
@@ -16,16 +16,6 @@ closed without saving edited files.
 
 ![image](https://github.com/phcode-dev/phoenix/assets/5336369/9cfd5720-947b-4f88-8dfa-cda940d912c6)
 
-## Safari Support (Beta)
-`Added on May,2023`
-
-Safari browser support is now in beta! Stay tuned for our **upcoming Web and native Mac/iOS apps** for full support. 
-
-### A note to Safari users
-Safari automatically deletes website data if a site is not revisited within 7 days.
-Phoenix relies on browser storage to save your projects, which may be removed due to this policy.
-**To prevent data loss**, please **download** your projects before closing the tab or stay tuned for our **upcoming Web and native Mac/iOS apps** for full support.
-
 ## Firefox Support
 `Added on April,2023`
 

--- a/src/assets/phoenix-splash/live-preview-error.html
+++ b/src/assets/phoenix-splash/live-preview-error.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>Phoenix editor</title>
+        <link rel="stylesheet" href="styles.css">
+        <script type="text/javascript">
+            function applyTranslations() {
+                const urlSearchParams = new URLSearchParams(window.location.search);
+                const params = Object.fromEntries(urlSearchParams.entries());
+                if(params.mainHeading){
+                    document.getElementById("mainHeading").innerHTML = decodeURIComponent(params.mainHeading);
+                }
+                if(params.mainSpan){
+                    document.getElementById("mainSpan").innerHTML = decodeURIComponent(params.mainSpan);
+                }
+            }
+        </script>
+    </head>
+
+    <body onload="applyTranslations()">
+        <img id="starsLeft"  src="images/stars-left.svg"/>
+        <div id="mainDiv">
+            <img id="logo"  src="images/phoenix-logo-broken.svg"/>
+            <div id="MainText" class="safari-text">
+                <h2 id="mainHeading">Uh Oh! <br>Your current browser doesn't support live preview.</h2>
+                <span id="mainSpan">
+                    Get the best live preview experience by downloading our native apps for Windows, Mac, and Linux from <a href="https://phcode.io" style="color: white">phcode.io</a>.<br>
+                </span><br>
+            </div>
+        </div>
+        <img id="cloudLeftTop"  src="images/vector-top-left.png"/>
+        <img id="cloudBottomRight"  src="images/vector-bottom-right.png"/>
+        <img id="starsRight"  src="images/stars-right.svg"/>
+        <img class="clouds" style="z-index: 3; transform: translate(0px, -1.55909px);" src="images/cloud1.svg"/>
+        <img class="clouds" style="z-index: 6; transform: translate(0px, -2.33863px);" src="images/cloud2.svg"/>
+        <img class="clouds" style="z-index: 5; transform: translate(0px, -3.89772px);" src="images/cloud3.svg"/>
+        <img class="clouds" style="z-index: 6; transform: translate(0px, -3.89772px);" src="images/cloud4.svg"/>
+    </body>
+</html>

--- a/src/extensions/default/Phoenix-live-preview/StaticServer.js
+++ b/src/extensions/default/Phoenix-live-preview/StaticServer.js
@@ -35,6 +35,8 @@ define(function (require, exports, module) {
         FileSystem = brackets.getModule("filesystem/FileSystem"),
         EventDispatcher = brackets.getModule("utils/EventDispatcher"),
         EventManager = brackets.getModule("utils/EventManager"),
+        ProjectManager = brackets.getModule("project/ProjectManager"),
+        Strings = brackets.getModule("strings"),
         markdownHTMLTemplate = require("text!markdown.html");
 
     EventDispatcher.makeEventDispatcher(exports);
@@ -255,6 +257,16 @@ define(function (require, exports, module) {
             liveDocument = this._liveDocuments[path],
             virtualDocument = this._virtualServingDocuments[path];
         let contents;
+        if(!ProjectManager.isWithinProject(data.path)) {
+            console.error("Security issue prevented: Live preview tried to access non project resource!!!", path);
+            messageToLivePreviewTabs({
+                type: 'REQUEST_RESPONSE',
+                requestID, //pass along the requestID
+                path,
+                contents: Strings.DESCRIPTION_LIVEDEV_SECURITY
+            });
+            return;
+        }
 
         if (virtualDocument) {
             // virtual document overrides takes precedence over live preview docs

--- a/src/extensions/default/Phoenix-live-preview/main.js
+++ b/src/extensions/default/Phoenix-live-preview/main.js
@@ -256,6 +256,17 @@ define(function (require, exports, module) {
             $iframe.attr('srcdoc', null);
         };
 
+        const popoutSupported = Phoenix.browser.isTauri || Phoenix.browser.desktop.isChromeBased;
+        if(!popoutSupported){
+            // live preview can be popped out currently in only chrome based browsers. The cross domain iframe
+            // that serves the live preview(phcode.live) is sandboxed to the tab in which phcode.dev resides.
+            // all iframes in the tab can communicate between each other, but when you popout another tab, it forms
+            // its own sandbox and firefox/safari prevents communication from iframe in one tab to another. chrome
+            // doesn't seem to enforce this restriction. Since this is a core usecase, we will try to enable this
+            // workflow whenever possible.
+            $livePreviewPopBtn.addClass("forced-hidden");
+        }
+
         panel = WorkspaceManager.createPluginPanel(LIVE_PREVIEW_PANEL_ID, $panel,
             PANEL_MIN_SIZE, $icon, INITIAL_PANEL_SIZE);
 

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -891,6 +891,8 @@ define({
     "DESCRIPTION_LIVEDEV_ENABLE_REVERSE_INSPECT": "false to disable live preview reverse inspect",
     "DESCRIPTION_LIVEDEV_NO_PREVIEW": "Nothing to preview!",
     "DESCRIPTION_LIVEDEV_NO_PREVIEW_DETAILS": "Please select an HTML file to preview",
+    "DESCRIPTION_LIVEDEV_MAIN_HEADING": "Uh Oh! <br>Your current browser doesn't support live preview.",
+    "DESCRIPTION_LIVEDEV_MAIN_SPAN": "Get the best live preview experience by downloading our native apps for Windows, Mac, and Linux from <a href=\"https://phcode.io\" style=\"color: white\">phcode.io</a>.<br>",
 
     // Strings for Auto Update
     "DOWNLOAD_FAILED": "Download failed.",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -893,6 +893,7 @@ define({
     "DESCRIPTION_LIVEDEV_NO_PREVIEW_DETAILS": "Please select an HTML file to preview",
     "DESCRIPTION_LIVEDEV_MAIN_HEADING": "Uh Oh! <br>Your current browser doesn't support live preview.",
     "DESCRIPTION_LIVEDEV_MAIN_SPAN": "Get the best live preview experience by downloading our native apps for Windows, Mac, and Linux from <a href=\"https://phcode.io\" style=\"color: white\">phcode.io</a>.<br>",
+    "DESCRIPTION_LIVEDEV_SECURITY": "Security Warning from phcode.dev<br><br> This live preview attempted to access a non-project file. Access was denied for your safety. Please exercise caution when working on untrusted projects.",
 
     // Strings for Auto Update
     "DOWNLOAD_FAILED": "Download failed.",

--- a/src/phoenix/virtualServer/webserver.js
+++ b/src/phoenix/virtualServer/webserver.js
@@ -114,6 +114,13 @@ if(!self.Serve){
                         const responseData = HtmlFormatter.formatFile(path, response.contents);
                         const headers = response.headers || {};
                         responseData.config.headers = { ...responseData.config.headers, ...headers};
+                        // VFS_SECURITY_POSTURE_X_FRAME_OPTIONS
+                        // prevent iframe embed security vulnerability. Here, a page in live preview hosted from
+                        // phcode.live can embed an iframe with phcode.dev/vfs.project.file url and gain access to
+                        // phcode.dev via iframe to parent frame post message exposing user file system. We prevent
+                        // such acceess. We cannot disable vfs hosting as its used by 'load project as extension'
+                        // workflow. But this should secure the access in most cases.
+                        responseData.config.headers['X-Frame-Options'] = 'SAMEORIGIN';
                         resolve(new Response(responseData.body, responseData.config));
                     };
                     return true;
@@ -137,6 +144,8 @@ if(!self.Serve){
                             responseData.config.headers['Content-Disposition'] =
                                 formatContentDisposition(path, stats);
                         }
+                        // search for VFS_SECURITY_POSTURE_X_FRAME_OPTIONS for details on why this x-frame-opt
+                        responseData.config.headers['X-Frame-Options'] = 'SAMEORIGIN';
 
                         resolve(new Response(responseData.body, responseData.config));
                         return;


### PR DESCRIPTION
## popout live preview disabled in non-chrome browsers(except tauri)
live preview can be popped out currently in only chrome based browsers. The cross domain iframe
that serves the live preview(phcode.live) is sandboxed to the tab in which phcode.dev resides.
all iframes in the tab can communicate between each other, but when you popout another tab, it forms
its own sandbox and firefox/safari prevents communication from iframe in one tab to another. chrome
doesn't seem to enforce this restriction. Since this is a core usecase, we will try to enable this
workflow whenever possible.

In tauri based native builds, this will not be an issue as IPC is done via node. Hence popout feature will be supported in all browsers in tauri.

## Safari support deprecated
in safari, service workers are disabled in third party iframes. We use phcode.live for secure sandboxing
live previews into its own domain apart from phcode.dev. Since safari doesn't support this, we are left
with using phcode.dev domain directly for live previews. That is a large attack surface for untrusted
code execution. so we will disable live previews in safari instead of shipping a security vulnerability.

![image](https://github.com/phcode-dev/phoenix/assets/5336369/5c537e41-5c15-42d8-bdda-65779fba1fd3)

## Disable iframe embedding of phcode.dev virtual served pages
prevent iframe embed security vulnerability: Here, a page in live preview hosted from
phcode.live can embed an iframe with phcode.dev/vfs.project.file url and gain access to
phcode.dev via iframe to parent frame post message exposing user file system. We prevent
such acceess. We cannot disable vfs hosting as its used by 'load project as extension'
workflow. But this should secure the access in most cases.

Now loading a vfs URL in an iframe will result in connection refused.

![image](https://github.com/phcode-dev/phoenix/assets/5336369/ae5d9eba-8c04-47be-8dbc-4d71a6632b9b)

## Live preview file access restrictions
Only current project files will be served by the virtual server to prevent a malicious live preview page from accessing random files in the disc.

![image](https://github.com/phcode-dev/phoenix/assets/5336369/9bf0e162-21dc-40a5-a28f-eb6c38e8b23a)

