### PR TITLE
fix: live preview navigation robustness on fast live preview switch with tabs

### DIFF
--- a/src/LiveDevelopment/LiveDevMultiBrowser.js
+++ b/src/LiveDevelopment/LiveDevMultiBrowser.js
@@ -544,7 +544,9 @@ define(function (require, exports, module) {
                     .on("ConnectionConnect.livedev", function (event, msg) {
                         if (_protocol.getConnectionIds().length >= 1) {
                             // check the page that connection comes from matches the current live document session
-                            if (_liveDocument &&  msg.url === _resolveUrl(_liveDocument.doc.file.fullPath)) {
+                            let url = new URL(msg.url);
+                            url = `${url.origin}${url.pathname}`;
+                            if (_liveDocument &&  url === _resolveUrl(_liveDocument.doc.file.fullPath)) {
                                 _setStatus(STATUS_ACTIVE);
                             }
                         }

--- a/src/LiveDevelopment/LiveDevMultiBrowser.js
+++ b/src/LiveDevelopment/LiveDevMultiBrowser.js
@@ -544,9 +544,9 @@ define(function (require, exports, module) {
                     .on("ConnectionConnect.livedev", function (event, msg) {
                         if (_protocol.getConnectionIds().length >= 1) {
                             // check the page that connection comes from matches the current live document session
-                            let url = new URL(msg.url);
-                            url = `${url.origin}${url.pathname}`;
-                            if (_liveDocument &&  url === _resolveUrl(_liveDocument.doc.file.fullPath)) {
+                            const url = new URL(msg.url);
+                            const urlString = `${url.origin}${url.pathname}`;
+                            if (_liveDocument &&  urlString === _resolveUrl(_liveDocument.doc.file.fullPath)) {
                                 _setStatus(STATUS_ACTIVE);
                             }
                         }

--- a/src/extensions/default/Phoenix-live-preview/redirectPage.html
+++ b/src/extensions/default/Phoenix-live-preview/redirectPage.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Redirecting page to live preview</title>
+    <script type="text/javascript">
+        location.href = "{{{redirectURL}}}";
+    </script>
+</head>
+<body>
+
+</body>
+</html>
+
+

--- a/src/extensions/default/Phoenix-live-preview/utils.js
+++ b/src/extensions/default/Phoenix-live-preview/utils.js
@@ -43,7 +43,9 @@ define(function (require, exports, module) {
     const ProjectManager          = brackets.getModule("project/ProjectManager"),
         Strings                   = brackets.getModule("strings"),
         DocumentManager     = brackets.getModule("document/DocumentManager"),
-        LiveDevelopment    = brackets.getModule("LiveDevelopment/main");
+        LiveDevelopment    = brackets.getModule("LiveDevelopment/main"),
+        LiveDevServerManager = brackets.getModule("LiveDevelopment/LiveDevServerManager"),
+        LivePreviewTransport  = brackets.getModule("LiveDevelopment/MultiBrowserImpl/transports/LivePreviewTransport");
 
     function getExtension(filePath) {
         filePath = filePath || '';
@@ -83,6 +85,11 @@ define(function (require, exports, module) {
         return `${window.Phoenix.baseURL}assets/phoenix-splash/live-preview-error.html?mainHeading=`+
             encodeURIComponent(`${Strings.DESCRIPTION_LIVEDEV_MAIN_HEADING}`) + "&mainSpan="+
             encodeURIComponent(`${Strings.DESCRIPTION_LIVEDEV_MAIN_SPAN}`);
+    }
+
+    function getPageLoaderURL(url) {
+        return `${LiveDevServerManager.getStaticServerBaseURLs().baseURL}pageLoader.html?`
+            +`broadcastChannel=${LivePreviewTransport.BROADCAST_CHANNEL_ID}&URL=${encodeURIComponent(url)}`;
     }
 
     function _isLivePreviewSupported() {
@@ -145,6 +152,7 @@ define(function (require, exports, module) {
     exports.getPreviewDetails = getPreviewDetails;
     exports.getNoPreviewURL = getNoPreviewURL;
     exports.getExtension = getExtension;
+    exports.getPageLoaderURL = getPageLoaderURL;
     exports.isPreviewableFile = isPreviewableFile;
     exports.isImage = isImage;
 });


### PR DESCRIPTION
When users rapidly switch between HTML files in the file panel, race conditions may arise. This happens when a request to serve the last live previewed page reaches the server just as the live preview is switched to another file. If the server realizes that the current request isn't for the actively live previewed page, it defaults to serving the raw, non-instrumented HTML file.

This can create a problem since the raw HTML file doesn't contain the necessary page navigation hooks. As a result, subsequent switches of HTML files in the file panel don't have any effect and the live preview appears to freeze on one page. This issue is particularly noticeable with popped-out tabs, while the embedded live preview can directly override the iframe URL, circumventing the issue.

To rectify this, we append a query string parameter to the live preview page that has been popped out into its own tab. Hence, if the server detects the "livePreview=true" parameter while serving an HTML page that isn't the current live preview, it won't serve the raw HTML page. Instead, it delivers the raw page embedded in a pageloader iframe, maintaining the connections necessary for page navigation.