### PR TITLE
UI change, show paths in recent project, dist test runner folder setup ofr tauri

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ test/thirdparty/jasmine-reporters
 
 # ignore compiled files
 /dist
+/dist-test
 /distToDeploy
 /src/.index.html
 /src/styles/brackets.min.css

--- a/src/assets/new-project/assets/css/responsive.css
+++ b/src/assets/new-project/assets/css/responsive.css
@@ -46,20 +46,18 @@
 
     .recent-project-card {
         padding: 15px 15px;
-        height: 530px;
     }
 
     .no-project-card {
         padding: 15px 15px;
-        height: 530px;
     }
 
     .project-content-right {
-        width: 330px;
+        width: 45%;
     }
 
     .project-content-left {
-        width: 330px;
+        width: 45%;
     }
 
     .website-detail span {
@@ -79,12 +77,12 @@
 @media (max-width: 720px) {
     .project-content-left {
         margin-left: 0px;
-        width: 300px;
+        width: 48%;
     }
   
     .project-content-right {
         margin-left: 15px;
-        width: 300px;
+        width: 48%;
 
     }
     

--- a/src/assets/new-project/assets/css/style.css
+++ b/src/assets/new-project/assets/css/style.css
@@ -708,7 +708,8 @@ img {
     height: 46px;
     width: 44px;
     transition: all .3s ease-in-out;
-    transform: translateY(8px);
+    -webkit-backface-visibility: hidden;
+    -webkit-transform: translateZ(0) scale(1.0, 1.0);
 }
 
 .project-type-list li a span {
@@ -730,7 +731,8 @@ img {
 }
 
 .project-type-list li a:hover img {
-    transform: translateY(0px);
+    transform: translateY(-8px);
+    -webkit-backface-visibility: hidden;
 }
 
 .project-type-list li a:hover span {
@@ -816,15 +818,41 @@ img {
     color: #FFFFFF;
 }
 
-.recent-project-list li a {
+.recent-project-list li {
     padding: 6px 10px;
     border-radius: 3px;
-    transition: all .3s ease-in-out;
     background: transparent;
+    overflow: hidden;
 }
 
-.recent-project-list li a:hover {
+.recent-project-list li:hover {
     background: #3F3F3F;
+    cursor: pointer;
+}
+
+.recent-project-metadata {
+    color: #8A8A8A;
+    font-size: 11px;
+    overflow: hidden;
+}
+
+.marquee {
+    animation: marquee 6.5s infinite linear; /* notice the infinite */
+    animation-play-state: paused;
+}
+
+.recent-project-list li:hover .marquee{
+    animation-play-state: running;
+    animation-fill-mode: forwards;
+}
+
+@keyframes marquee{
+    0% {
+        transform: translateX(0%)
+    }
+    100% {
+        transform: translateX(-100%)
+    }
 }
 
 .remove-btn {

--- a/src/assets/new-project/code-editor.html
+++ b/src/assets/new-project/code-editor.html
@@ -89,7 +89,7 @@
                     <li>
                         <a id="defaultProjectButton" href="#" class="tabable" tabindex="1">
                             <img src="images/logo.png" alt="image">
-                            <span class="localize">{{APP_NAME}} {{PHOENIX_DEFAULT_PROJECT}}</span>
+                            <span class="localize"> {{PHOENIX_DEFAULT_PROJECT}}</span>
                         </a>
                     </li>
                     <li>

--- a/src/extensions/default/Phoenix/new-project.js
+++ b/src/extensions/default/Phoenix/new-project.js
@@ -356,4 +356,7 @@ define(function (require, exports, module) {
     exports.getExploreProjectPath = ProjectManager.getExploreProjectPath;
     exports.getLocalProjectsPath = ProjectManager.getLocalProjectsPath;
     exports.getMountDir = Phoenix.VFS.getMountDir;
+    exports.path = Phoenix.path;
+    exports.getTauriDir = Phoenix.VFS.getTauriDir;
+    exports.getTauriPlatformPath = Phoenix.fs.getTauriPlatformPath;
 });

--- a/src/index.html
+++ b/src/index.html
@@ -125,6 +125,9 @@
                     'http://localhost:8000': true, // phcode dev server
                     'http://localhost:8001': true, // phcode dev live preview server
                     'http://localhost:5000': true, // playwright tests
+                    'http://127.0.0.1:8000': true, // phcode dev server
+                    'http://127.0.0.1:8001': true, // phcode dev live preview server
+                    'http://127.0.0.1:5000': true, // playwright tests
                     'https://phcode.live': true, // phcode prod live preview server
                     'https://phcode.dev': true,
                     'https://dev.phcode.dev': true,

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -1026,6 +1026,7 @@ define({
     "WEBPAGE_BOOTSTRAP_EXAMPLES": "Bootstrap Examples",
     "PROJECTS_AT_A_GLANCE": "Your Projects at a glance",
     "PROJECT_AT_GLANCE_DESCRIPTION": "Watch video to get started.",
+    "PROJECT_FROM_BROWSER": "Stored in Your Browser",
     // Guided tour
     "GUIDED_LIVE_PREVIEW": "Make some code changes in the HTML file to see live preview. </br> <a href='#' style='float:right;'>ok</a>",
     "GUIDED_LIVE_PREVIEW_POPOUT": "Click this button to popout live preview to a new tab. </br> <a href='#' style='float:right;'>ok</a>",

--- a/src/phoenix/init_vfs.js
+++ b/src/phoenix/init_vfs.js
@@ -37,6 +37,7 @@ function _setupVFS(fsLib, pathLib){
     Phoenix.VFS = {
         getRootDir: () => '/fs/',
         getMountDir: () => '/mnt/',
+        getTauriDir: () => '/tauri/',
         getAppSupportDir: () => '/fs/app/',
         getExtensionDir: () => EXTENSION_DIR,
         getUserExtensionDir: () => `${EXTENSION_DIR}user`,

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -118,6 +118,9 @@
           'http://localhost:8000': true, // phcode dev server
           'http://localhost:8001': true, // phcode dev live preview server
           'http://localhost:5000': true, // playwright tests
+          'http://127.0.0.1:8000': true, // phcode dev server
+          'http://127.0.0.1:8001': true, // phcode dev live preview server
+          'http://127.0.0.1:5000': true, // playwright tests
           'https://phcode.live': true, // phcode prod live preview server
           'https://phcode.dev': true,
           'https://dev.phcode.dev': true,

--- a/test/index-dist-test.html
+++ b/test/index-dist-test.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Starting tests...</title>
+    <script type="text/javascript">
+        location.href = "test/SpecRunner.html";
+    </script>
+</head>
+<body>
+ Redirecting to test runner....
+ Open this page only from `dist-test` folder.
+</body>
+</html>


### PR DESCRIPTION
We will load `dist-test` folder to run tests in Tauri with GitHub actions..

Initial draft.

## UI change, show paths in recent project:
 If path is larger than what can be shown, hovering will open a tooltip with the full path. 
Inline text marquee not used as it was not good UX- the path was always running.
![image](https://github.com/phcode-dev/phoenix/assets/5336369/3c3c3e14-0856-4894-afac-44c87e3766bc)

## Other fixes
1. in firefox and safari, the new project window used to flicker on hover on any icons in new project section.
   This was due to https://stackoverflow.com/questions/22422926/css-transition-div-shaking and is now fixed
1. the marquee code in CSS is kept though unused for future reference.