### PR TITLE
feat: new project-welcome screen settings

### DIFF
--- a/src/assets/new-project/assets/css/responsive.css
+++ b/src/assets/new-project/assets/css/responsive.css
@@ -247,6 +247,15 @@
     .preview-box {
         width: 100%;
     }
+
+    .settings-icon {
+        margin-top: 10px;
+    }
+
+    .dropdown {
+        right: 15px;
+        bottom: 10px;
+    }
 }
 
 @media (max-width: 400px) {

--- a/src/assets/new-project/assets/css/style.css
+++ b/src/assets/new-project/assets/css/style.css
@@ -1096,3 +1096,53 @@ img {
     transition: opacity 0.5s ease;
     transition-delay:0.2s;
 }
+
+.settings-icon {
+    color: #D0D0D0;
+}
+
+/* The container <div> - needed to position the dropdown content */
+.dropdown {
+    position: absolute;
+    right: 25px;
+    bottom: 20px;
+}
+
+.dropbtn {
+    width: 25px;
+    height: 25px;
+    padding: 1px;
+    text-align: center;
+}
+
+.dropbtn:hover {
+    background: #202020;
+}
+
+.dropbtnActive {
+    background: #202020;
+    border: 1px solid #202020;
+}
+
+/* Dropdown Content (Hidden by Default) */
+.dropdown-content {
+    display: none;
+    position: relative;
+    background-color: #121314;
+    min-width: 100px;
+    z-index: 1;
+}
+
+/* Links inside the dropdown */
+.dropdown-content div {
+    color: white;
+    padding: 3px 5px;
+    text-decoration: none;
+    text-align: left;
+}
+
+/* Change color of dropdown links on hover */
+.dropdown-content div:hover {
+    background-color: #284160;
+    cursor: default;
+}

--- a/src/assets/new-project/assets/js/code-editor.js
+++ b/src/assets/new-project/assets/js/code-editor.js
@@ -136,6 +136,53 @@ function _showFirstTimeExperience() {
     }
 }
 
+function _updateDropdown() {
+    let shouldShowWelcome = localStorage.getItem("new-project.showWelcomeScreen") || 'Y';
+    if(shouldShowWelcome === 'Y') {
+        document.getElementById("showWelcomeIndicator").style = "visibility: visible";
+    } else {
+        document.getElementById("showWelcomeIndicator").style = "visibility: hidden";
+    }
+}
+
+function _attachSettingBtnEventListeners() {
+    document.querySelector('.dropdown').addEventListener('click', function() {
+        let content = this.querySelector('.dropdown-content');
+        let dropbtn = this.querySelector('.dropbtn');
+        _updateDropdown();
+        if (content.style.display === 'block') {
+            content.style.display = 'none';
+            dropbtn.classList.remove('dropbtnActive');
+        } else {
+            content.style.display = 'block';
+            dropbtn.classList.add('dropbtnActive');
+        }
+    });
+
+    document.getElementById("showWelcome").addEventListener('click', (event)=>{
+        let shouldShowWelcome = localStorage.getItem("new-project.showWelcomeScreen") || 'Y';
+        shouldShowWelcome = shouldShowWelcome === 'Y'? 'N' : 'Y';
+        localStorage.setItem("new-project.showWelcomeScreen", shouldShowWelcome);
+    });
+
+    document.getElementById("showAbout").addEventListener('click', (event)=>{
+        newProjectExtension.showAboutBox();
+    });
+
+    // Event to close dropdown if clicked outside
+    document.addEventListener('click', function(event) {
+        let dropdown = document.querySelector('.dropdown');
+        let content = dropdown.querySelector('.dropdown-content');
+        let dropbtn = dropdown.querySelector('.dropbtn');
+
+        // If the target of the click isn't the dropdown or a descendant of the dropdown
+        if (!dropdown.contains(event.target)) {
+            content.style.display = 'none';
+            dropbtn.classList.remove('dropbtnActive');
+        }
+    });
+}
+
 function initCodeEditor() {
     document.getElementById("openFolderBtn").onclick = function() {
         Metrics.countEvent(Metrics.EVENT_TYPE.NEW_PROJECT, "main.Click", "open-folder");
@@ -166,4 +213,5 @@ function initCodeEditor() {
     _updateProjectCards();
     _showFirstTimeExperience();
     $("body").append($(`<script async defer src="https://buttons.github.io/buttons.js"></script>`));
+    _attachSettingBtnEventListeners();
 }

--- a/src/assets/new-project/code-editor.html
+++ b/src/assets/new-project/code-editor.html
@@ -138,6 +138,15 @@
             </div>
         </div>
     </div>
+    <div class="settings-icon dropdown" style="text-align: right; font-size: 15px;">
+        <div class="dropdown-content">
+            <div id="showWelcome"><span style="visibility: hidden" id="showWelcomeIndicator">✔ </span><span href="#" class="localize">{{PROJECT_SHOW_ON_STARTUP}}</span></div>
+            <div id="showAbout"><span style="visibility: hidden">✔ </span><span href="#" class="localize">{{CMD_ABOUT}}</span></div>
+        </div>
+        <div style="display: flex; justify-content: end">
+            <div class="dropbtn"><i class="fa-solid fa-gear"></i></div>
+        </div>
+    </div>
     <!-- focus guard in the end of the form -->
     <div class="focusguard" id="focusguard-2" tabindex="1000"></div>
     <!-- Nothing underneath this comment -->

--- a/src/extensions/default/HealthData/HealthDataNotification.js
+++ b/src/extensions/default/HealthData/HealthDataNotification.js
@@ -52,9 +52,14 @@ define(function (require, exports, module) {
         HealthDataPreview.previewHealthData();
     }
 
+    let popupShownInThisSession = false;
     function _showFirstLaunchPopup() {
         // call this only after newProjectExtn interface is available
         // Check whether the notification dialog should be shown. It will be shown only one time.
+        if(popupShownInThisSession){
+            return;
+        }
+        popupShownInThisSession = true;
         newProjectExtension.off(newProjectExtension.EVENT_NEW_PROJECT_DIALOGUE_CLOSED, _showFirstLaunchPopup);
         if(!window.testEnvironment){
             const alreadyShown = PreferencesManager.getViewState("healthDataNotificationShown");

--- a/src/extensions/default/Phoenix/new-project.js
+++ b/src/extensions/default/Phoenix/new-project.js
@@ -96,6 +96,11 @@ define(function (require, exports, module) {
 
     function init() {
         _addMenuEntries();
+        const shouldShowWelcome = localStorage.getItem("new-project.showWelcomeScreen") || 'Y';
+        if(shouldShowWelcome !== 'Y') {
+            Metrics.countEvent(Metrics.EVENT_TYPE.NEW_PROJECT, "dialogue", "disabled");
+            return;
+        }
         _showNewProjectDialogue();
     }
 
@@ -343,6 +348,10 @@ define(function (require, exports, module) {
         });
     }
 
+    function showAboutBox() {
+        CommandManager.execute(Commands.HELP_ABOUT);
+    }
+
     exports.init = init;
     exports.openFolder = openFolder;
     exports.closeDialogue = closeDialogue;
@@ -359,4 +368,5 @@ define(function (require, exports, module) {
     exports.path = Phoenix.path;
     exports.getTauriDir = Phoenix.VFS.getTauriDir;
     exports.getTauriPlatformPath = Phoenix.fs.getTauriPlatformPath;
+    exports.showAboutBox = showAboutBox;
 });

--- a/src/extensions/default/Phoenix/new-project.js
+++ b/src/extensions/default/Phoenix/new-project.js
@@ -99,6 +99,7 @@ define(function (require, exports, module) {
         const shouldShowWelcome = localStorage.getItem("new-project.showWelcomeScreen") || 'Y';
         if(shouldShowWelcome !== 'Y') {
             Metrics.countEvent(Metrics.EVENT_TYPE.NEW_PROJECT, "dialogue", "disabled");
+            guidedTour.startTourIfNeeded();
             return;
         }
         _showNewProjectDialogue();

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -1027,6 +1027,7 @@ define({
     "PROJECTS_AT_A_GLANCE": "Your Projects at a glance",
     "PROJECT_AT_GLANCE_DESCRIPTION": "Watch video to get started.",
     "PROJECT_FROM_BROWSER": "Stored in Your Browser",
+    "PROJECT_SHOW_ON_STARTUP": "Show This Dialogue On Startup",
     // Guided tour
     "GUIDED_LIVE_PREVIEW": "Make some code changes in the HTML file to see live preview. </br> <a href='#' style='float:right;'>ok</a>",
     "GUIDED_LIVE_PREVIEW_POPOUT": "Click this button to popout live preview to a new tab. </br> <a href='#' style='float:right;'>ok</a>",

--- a/src/phoenix/init_vfs.js
+++ b/src/phoenix/init_vfs.js
@@ -176,7 +176,7 @@ function _tryCreateDefaultProject() {
                         logger.reportError(err, "Error creating default project");
                     }
                     let indexFile = Phoenix.VFS.path.normalize(`${projectDir}/index.html`);
-                    Phoenix.VFS.fs.writeFile(indexFile, _SAMPLE_HTML, 'utf8');
+                    Phoenix.VFS.fs.writeFile(indexFile, _SAMPLE_HTML, 'utf8', ()=>{});
                     resolve();
                 });
                 return;


### PR DESCRIPTION
## Options added
1. About Box
2. Show the welcome screen on startup

![image](https://github.com/phcode-dev/phoenix/assets/5336369/7f8cf28b-4a02-4eb6-8017-a724c081a983)

## reduce the number of popup notifications
1. `click here to open new project dialogue` notification will now only be shown once instead of showing it till the user presses the button.
2. Fixed bug in which closing new project dialogue on first launch causes multiple health data popup notifications with every close.