### PR TITLE
open test runner in tauri and Phoenix.app.openURLInPhoenixWindow API

### DIFF
--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -2,6 +2,12 @@
     "file.newFile":  [
         "Alt-N"
     ],
+    "file.newFolder":  [
+        "Ctrl-Alt-N"
+    ],
+    "file.new_window":  [
+        "Alt-Shift-N"
+    ],
     "file.open":  [
         "Ctrl-O"
     ],
@@ -36,6 +42,9 @@
     ],
     "file.quit":  [
         "Ctrl-Q"
+    ],
+    "file.duplicateFile": [
+        "Alt-Shift-D"
     ],
     "edit.undo": [
         "Ctrl-Z"
@@ -331,9 +340,6 @@
             "key": "Alt-Down",
             "displayKey": "Alt-↓"
         }
-    ],
-    "navigate.newRule":  [
-        "Ctrl-Alt-N"
     ],
     "file.rename":  [
         "Shift-F2"

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -64,6 +64,7 @@ define(function (require, exports, module) {
     exports.FILE_OPEN_KEYMAP            = "file.openKeyMap";            // KeyBindingManager.js         _openUserKeyMap()
 
     // File shell callbacks - string must MATCH string in native code (appshell/command_callbacks.h)
+    exports.FILE_NEW_WINDOW             = "file.new_window";            // DocumentCommandHandlers.js   handleFileNewWindow()
     exports.FILE_CLOSE_WINDOW           = "file.close_window";          // DocumentCommandHandlers.js   handleFileCloseWindow()
     exports.FILE_QUIT                   = "file.quit";                  // DocumentCommandHandlers.js   handleFileQuit()
 

--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -68,6 +68,8 @@ define(function (require, exports, module) {
         menu = Menus.addMenu(Strings.FILE_MENU, Menus.AppMenuBar.FILE_MENU);
         menu.addMenuItem(Commands.FILE_NEW);
         menu.addMenuItem(Commands.FILE_NEW_FOLDER);
+        menu.addMenuItem(Commands.FILE_NEW_WINDOW);
+        menu.addMenuDivider();
         menu.addMenuItem(Commands.FILE_OPEN_FOLDER);
         menu.addMenuItem(Commands.FILE_CLOSE);
         menu.addMenuItem(Commands.FILE_CLOSE_ALL);

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1605,6 +1605,16 @@ define(function (require, exports, module) {
         );
     }
 
+    function handleFileNewWindow() {
+        let width = window.innerWidth;
+        let height = window.innerHeight;
+        brackets.app.openURLInPhoenixWindow(location.href, {
+            width,
+            height,
+            preferTabs: true
+        });
+    }
+
     /** Show a textfield to rename whatever is currently selected in the sidebar (or current doc if nothing else selected) */
     function handleFileRename() {
         // Prefer selected sidebar item (which could be a folder)
@@ -1938,6 +1948,7 @@ define(function (require, exports, module) {
     CommandManager.register(Strings.CMD_PREV_DOC_LIST_ORDER,         Commands.NAVIGATE_PREV_DOC_LIST_ORDER,   handleGoPrevDocListOrder);
 
     // Special Commands
+    CommandManager.register(Strings.CMD_NEW_BRACKETS_WINDOW,         Commands.FILE_NEW_WINDOW,                handleFileNewWindow);
     CommandManager.register(quitString,                              Commands.FILE_QUIT,                      handleFileQuit);
     CommandManager.register(Strings.CMD_SHOW_IN_TREE,                Commands.NAVIGATE_SHOW_IN_FILE_TREE,     handleShowInTree);
 

--- a/src/extensions/default/DebugCommands/main.js
+++ b/src/extensions/default/DebugCommands/main.js
@@ -74,7 +74,6 @@ define(function (require, exports, module) {
         DEBUG_RUN_UNIT_TESTS                  = "debug.runUnitTests",
         DEBUG_SHOW_PERF_DATA                  = "debug.showPerfData",
         DEBUG_RELOAD_WITHOUT_USER_EXTS        = "debug.reloadWithoutUserExts",
-        DEBUG_NEW_BRACKETS_WINDOW             = "debug.newBracketsWindow",
         DEBUG_SWITCH_LANGUAGE                 = "debug.switchLanguage",
         DEBUG_ENABLE_LOGGING                  = "debug.enableLogging",
         DEBUG_LIVE_PREVIEW_LOGGING            = "debug.livePreviewLogging",
@@ -115,10 +114,6 @@ define(function (require, exports, module) {
 
     function handleReloadWithoutUserExts() {
         CommandManager.execute(Commands.APP_RELOAD_WITHOUT_EXTS);
-    }
-
-    function handleNewBracketsWindow() {
-        Phoenix.app.openURLInPhoenixWindow(window.location.href);
     }
 
     function handleShowPerfData() {
@@ -718,7 +713,9 @@ define(function (require, exports, module) {
     }
 
     function _openVirtualServer() {
-        Phoenix.app.openURLInPhoenixWindow(window.fsServerUrl);
+        Phoenix.app.openURLInPhoenixWindow(window.fsServerUrl, {
+            preferTabs: true
+        });
     }
 
     function _handleShowDeveloperTools() {
@@ -734,7 +731,6 @@ define(function (require, exports, module) {
         extensionDevelopment.unloadCurrentExtension);
     CommandManager.register(Strings.CMD_REFRESH_WINDOW,             DEBUG_REFRESH_WINDOW,           handleReload);
     CommandManager.register(Strings.CMD_RELOAD_WITHOUT_USER_EXTS,   DEBUG_RELOAD_WITHOUT_USER_EXTS, handleReloadWithoutUserExts);
-    CommandManager.register(Strings.CMD_NEW_BRACKETS_WINDOW,        DEBUG_NEW_BRACKETS_WINDOW,      handleNewBracketsWindow);
 
     // Start with the "Run Tests" item disabled. It will be enabled later if the test file can be found.
     CommandManager.register(Strings.CMD_RUN_UNIT_TESTS,       DEBUG_RUN_UNIT_TESTS,         _runUnitTests);
@@ -767,7 +763,6 @@ define(function (require, exports, module) {
     menu.addMenuItem(DEBUG_UNLOAD_CURRENT_EXTENSION, undefined, undefined, undefined, {
         hideWhenCommandDisabled: true
     });
-    menu.addMenuItem(DEBUG_NEW_BRACKETS_WINDOW);
     menu.addMenuDivider();
     menu.addMenuItem(DEBUG_SWITCH_LANGUAGE);
     menu.addMenuDivider();

--- a/src/extensions/default/DebugCommands/main.js
+++ b/src/extensions/default/DebugCommands/main.js
@@ -19,7 +19,7 @@
  *
  */
 
-/*globals path, logger*/
+/*globals path, logger, Phoenix*/
 /*jslint regexp: true */
 
 define(function (require, exports, module) {
@@ -96,7 +96,6 @@ define(function (require, exports, module) {
     });
 
     // Implements the 'Run Tests' menu to bring up the Jasmine unit test window
-    var _testWindow = null;
     function _runUnitTests(spec) {
         let queryString = spec ? "?spec=" + spec : "?suite=unit";
         let testBaseURL = "../test/SpecRunner.html";
@@ -104,16 +103,10 @@ define(function (require, exports, module) {
             // must be a deployed in phcode.dev/other sites. point to site test url
             testBaseURL = "test/SpecRunner.html";
         }
-        if (_testWindow && !_testWindow.closed) {
-            if (_testWindow.location.search !== queryString) {
-                _testWindow.location.href = testBaseURL + queryString;
-            } else {
-                _testWindow.location.reload(true);
-            }
-        } else {
-            _testWindow = window.open(testBaseURL + queryString);
-            _testWindow.location.reload(true); // if it had been opened earlier, force a reload because it will be cached
-        }
+        Phoenix.app.openURLInPhoenixWindow(testBaseURL + queryString, {
+            windowTitle: "Test Runner",
+            preferTabs: true
+        });
     }
 
     function handleReload() {
@@ -125,7 +118,7 @@ define(function (require, exports, module) {
     }
 
     function handleNewBracketsWindow() {
-        window.open(window.location.href);
+        Phoenix.app.openURLInPhoenixWindow(window.location.href);
     }
 
     function handleShowPerfData() {
@@ -725,7 +718,7 @@ define(function (require, exports, module) {
     }
 
     function _openVirtualServer() {
-        window.open(window.fsServerUrl);
+        Phoenix.app.openURLInPhoenixWindow(window.fsServerUrl);
     }
 
     function _handleShowDeveloperTools() {

--- a/src/extensions/default/Phoenix/main.js
+++ b/src/extensions/default/Phoenix/main.js
@@ -48,7 +48,7 @@ define(function (require, exports, module) {
             })
             .appendTo($("#main-toolbar .bottom-buttons"));
         $icon.on('click', ()=>{
-            window.open(brackets.config.support_url);
+            Phoenix.app.openURLInDefaultBrowser(brackets.config.support_url);
         });
     }
     function _showUnSupportedBrowserDialogue() {

--- a/src/extensions/default/Phoenix/new-project.js
+++ b/src/extensions/default/Phoenix/new-project.js
@@ -72,7 +72,7 @@ define(function (require, exports, module) {
     function _addMenuEntries() {
         CommandManager.register(Strings.CMD_PROJECT_NEW, Commands.FILE_NEW_PROJECT, _showNewProjectDialogue);
         const fileMenu = Menus.getMenu(Menus.AppMenuBar.FILE_MENU);
-        fileMenu.addMenuItem(Commands.FILE_NEW_PROJECT, "Alt-Shift-N", Menus.AFTER, Commands.FILE_NEW);
+        fileMenu.addMenuItem(Commands.FILE_NEW_PROJECT, "Alt-Shift-P", Menus.AFTER, Commands.FILE_NEW_FOLDER);
     }
 
     function closeDialogue() {

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -686,7 +686,7 @@ define({
     "CMD_RELOAD_CURRENT_EXTENSION": "Reload Project As Extension",
     "CMD_UNLOAD_CURRENT_EXTENSION": "Unload Project As Extension",
     "CMD_RELOAD_WITHOUT_USER_EXTS": "Reload Without Extensions",
-    "CMD_NEW_BRACKETS_WINDOW": "New {APP_NAME} Window",
+    "CMD_NEW_BRACKETS_WINDOW": "New Window",
     "CMD_LAUNCH_SCRIPT_MAC": "Install Command Line Shortcut",
     "CMD_SWITCH_LANGUAGE": "Switch Language",
     "CMD_RUN_UNIT_TESTS": "Run Tests",

--- a/src/phoenix/init_vfs.js
+++ b/src/phoenix/init_vfs.js
@@ -53,7 +53,8 @@ function _setupVFS(fsLib, pathLib){
          * @param fullPath
          */
         isLocalDiscPath: function (fullPath) {
-            if(fullPath && fullPath.startsWith(Phoenix.VFS.getMountDir())){
+            if(fullPath &&
+                (fullPath.startsWith(Phoenix.VFS.getTauriDir()) || fullPath.startsWith(Phoenix.VFS.getMountDir()) )){
                 return true;
             }
             return false;


### PR DESCRIPTION
## Add tauri support for
1. Test runner now launches in tauri
2. `Phoenix.app.openURLInDefaultBrowser(url)` 
3. `Phoenix.app.openURLInPhoenixWindow`
    * In tauri, it will open a tauri window and load that url
    * In browser, it will create a new popout window. 
```js
openURLInPhoenixWindow: function (url, {
        windowTitle, windowLabel, fullscreen, resizable,
        height, minHeight, width, minWidth, acceptFirstMouse, preferTabs
    } = {})
 ``` 

## UI Menu changes
1. Add `file > New Window` menu to open a new phcode window, the shortcut is `Alt-Shift-N`
2. The shortcut is `Alt-Shift-N` was mapped to new Project, as we had only 2 people use the shortcut in the last month from health data, changes it to `New Window` (Same shortcut as vscode).
3. `File>New Project` shortcut is now `Alt-Shift-P`
4. `File>New Folder` shortcut added as `Ctrl-Alt-N`
5. `File>Duplicate file` shortcut added as `Alt-Shift-D`` 
6. `File>Download project` will not appear on tauri or fs access local disc paths.
7. `Debug>New Phoenix Window` removed as it is moved to `file>new window`
8. `Debug>Open Virtual Server working in tauri debug builds`. It has to be routed to tauri server to make it run from tauri urs/release builds.
9. `Navigate>new Rule` shortcut removed as I don't know what it does, and no usage data and looked like a better usecase would be to assign the shortcut to `File>Duplicate file`

Related: https://github.com/phcode-dev/phoenix-desktop/issues/86