### PR TITLE
fix: close with unsaved changes warning dialog in tauri

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1888,8 +1888,14 @@ define(function (require, exports, module) {
         };
     }
 
+    let closeInProgress;
     function attachTauriUnloadHandler() {
         window.__TAURI__.window.appWindow.onCloseRequested((event)=>{
+            if(closeInProgress){
+                event.preventDefault();
+                return;
+            }
+            closeInProgress = true;
             PreferencesManager.setViewState("windowClosingTime", new Date().getTime(), {}, false);
             event.preventDefault();
             _handleWindowGoingAway(null, closeSuccess=>{
@@ -1897,6 +1903,7 @@ define(function (require, exports, module) {
                 Phoenix.app.closeWindow();
             }, closeFail=>{
                 console.log('close fail: ', closeFail);
+                closeInProgress = false;
             });
         });
     }

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -162,8 +162,8 @@ define({
     "EXT_DELETED_MESSAGE": "<span class='dialog-filename'>{0}</span> has been deleted on disk outside of {APP_NAME}, but has unsaved changes in {APP_NAME}.<br /><br />Do you want to keep your changes?",
 
     // Window unload warning messages
-    "WINDOW_UNLOAD_WARNING": "Are you sure you want to navigate to a different URL and leave Brackets?",
-    "WINDOW_UNLOAD_WARNING_WITH_UNSAVED_CHANGES": "You have unsaved changes! Are you sure you want to navigate to a different URL and leave Brackets?",
+    "WINDOW_UNLOAD_WARNING": "Are you sure you want to navigate to a different URL and leave {APP_NAME}?",
+    "WINDOW_UNLOAD_WARNING_WITH_UNSAVED_CHANGES": "You have unsaved changes! Are you sure you want to navigate to a different URL and leave {APP_NAME}?",
 
     // Generic dialog/button labels
     "DONE": "Done",

--- a/src/phoenix/shell.js
+++ b/src/phoenix/shell.js
@@ -57,6 +57,12 @@ Phoenix.app = {
     getNodeState: function (cbfn){
         cbfn(new Error('Node cannot be run in phoenix browser mode'));
     },
+    closeWindow: function () {
+        if(!Phoenix.browser.isTauri){
+            throw new Error("closeWindow is not supported in browsers");
+        }
+        window.__TAURI__.window.appWindow.close();
+    },
     getDisplayLocation: function (fullVFSPath) {
         // reruns a user-friendly location that can be shown to the user to make some sense of the virtual file path.
         // The returned path may not be an actual path if it is not resolvable to a platform path, but a text indicating


### PR DESCRIPTION
Closing tauri windows when there are unsaved changes will now popup the unsaved changes dialog and prevent window close
![image](https://github.com/phcode-dev/phoenix/assets/5336369/ffb3bce0-a7b3-4839-8e11-4201fa026562)
