### PR TITLE
feat: zoom in tauri at reduced capacity

### DIFF
--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -160,8 +160,13 @@ define(function (require, exports, module) {
         let subMenu = menu.addSubMenu(Strings.CMD_ZOOM_UI, Commands.VIEW_ZOOM_SUBMENU);
         subMenu.addMenuItem(Commands.VIEW_ZOOM_IN);
         subMenu.addMenuItem(Commands.VIEW_ZOOM_OUT);
-        subMenu.addMenuItem(Commands.VIEW_INCREASE_FONT_SIZE);
-        subMenu.addMenuItem(Commands.VIEW_DECREASE_FONT_SIZE);
+        if(!Phoenix.browser.isTauri) {
+            // tauri doesnt support zoomin/out and the document.body.style.zoom = 1.5 trick didnt work
+            // as code mirror doesnt support css transform styles. so we just show increase and decrease
+            // font size as zoom. so we wont register redundant VIEW_INCREASE_FONT_SIZE commands in tauri
+            subMenu.addMenuItem(Commands.VIEW_INCREASE_FONT_SIZE);
+            subMenu.addMenuItem(Commands.VIEW_DECREASE_FONT_SIZE);
+        }
         subMenu.addMenuItem(Commands.VIEW_RESTORE_FONT_SIZE);
         menu.addMenuDivider();
         menu.addMenuItem(Commands.TOGGLE_ACTIVE_LINE);

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -546,8 +546,16 @@ define(function (require, exports, module) {
     // Register command handlers
     CommandManager.register(Strings.CMD_INCREASE_FONT_SIZE, Commands.VIEW_INCREASE_FONT_SIZE,  _handleIncreaseFontSize);
     CommandManager.register(Strings.CMD_DECREASE_FONT_SIZE, Commands.VIEW_DECREASE_FONT_SIZE,  _handleDecreaseFontSize);
-    CommandManager.register(Strings.CMD_ZOOM_IN, Commands.VIEW_ZOOM_IN,  _handleZoom, {eventSource: true});
-    CommandManager.register(Strings.CMD_ZOOM_OUT, Commands.VIEW_ZOOM_OUT,  _handleZoom, {eventSource: true});
+    if(Phoenix.browser.isTauri){
+        // tauri doesnt support zoomin/out and the document.body.style.zoom = 1.5 trick didnt work
+        // as code mirror doesnt support css transform styles. so we just show increase and decrease
+        // font size as zoom.
+        CommandManager.register(Strings.CMD_ZOOM_IN, Commands.VIEW_ZOOM_IN,  _handleIncreaseFontSize, {eventSource: true});
+        CommandManager.register(Strings.CMD_ZOOM_OUT, Commands.VIEW_ZOOM_OUT,  _handleDecreaseFontSize, {eventSource: true});
+    } else {
+        CommandManager.register(Strings.CMD_ZOOM_IN, Commands.VIEW_ZOOM_IN,  _handleZoom, {eventSource: true});
+        CommandManager.register(Strings.CMD_ZOOM_OUT, Commands.VIEW_ZOOM_OUT,  _handleZoom, {eventSource: true});
+    }
     CommandManager.register(Strings.CMD_RESTORE_FONT_SIZE,  Commands.VIEW_RESTORE_FONT_SIZE,   _handleRestoreFontSize);
     CommandManager.register(Strings.CMD_SCROLL_LINE_UP,     Commands.VIEW_SCROLL_LINE_UP,      _handleScrollLineUp);
     CommandManager.register(Strings.CMD_SCROLL_LINE_DOWN,   Commands.VIEW_SCROLL_LINE_DOWN,    _handleScrollLineDown);

--- a/src/view/fontrules/font-based-rules.less
+++ b/src/view/fontrules/font-based-rules.less
@@ -22,14 +22,33 @@
 @defaultmenuwidth: 300px/@defaultfontsize;
 
 @lineheight: @fontsize +  @fontsize * @lineheightoffset;
+@menuFontSize: @fontsize + 2;
+@titleFontSize: @fontsize + 6;
 
 .CodeMirror {
     font-size: @fontsize !important;
 }
 
-.codehint-menu .dropdown-menu li a, .inlinemenu-menu .dropdown-menu li a {
+.codehint-menu .dropdown-menu li a, .inlinemenu-menu .dropdown-menu li a{
     font-size: @fontsize !important;
     line-height: @lineheight  !important;
+}
+
+.modal-bar{
+    font-size: @menuFontSize !important;
+}
+
+.context-menu .dropdown-menu li a , .toolbar .nav .dropdown-menu li a{
+    font-size: @menuFontSize !important;
+    line-height: @lineheight  !important;
+}
+
+.toolbar .title  {
+    font-size: @titleFontSize !important;
+}
+
+#titlebar {
+    font-size: @menuFontSize !important;
 }
 
 span.brackets-js-hints-with-type-details {


### PR DESCRIPTION
tauri doesnt support zoomin/out and the document.body.style.zoom = 1.5 trick didnt work
as code mirror doesnt support css transform styles. so we just show increase and decrease font size as zoom in tauri.

Browser will default to browser native zoom that works.

Related: https://github.com/phcode-dev/phoenix/issues/1168 address when tauri fixes the issue.

## File tree font set not working
Unable to set file tree font sizes as it has custom selection hilight logic. need to use browser selection logic. Cant fix eazily without major refactor

## Font size constants
We should use font size css variables to eazily adjust fonts. Right now there is too many places to adjust css values.

