### PR TITLE
chore: fs lib overwrite protection

### DIFF
--- a/src/phoenix/init_vfs.js
+++ b/src/phoenix/init_vfs.js
@@ -288,12 +288,27 @@ const _createAppDirs = async function () {
 };
 
 
+const CORE_LIB_GUARD_INTERVAL = 5000;
 const _FS_ERROR_MESSAGE = 'Oops. Phoenix could not be started due to missing file system library.';
 export default function initVFS() {
     if(!window.fs || !window.path || !window.Phoenix){
         window.alert(_FS_ERROR_MESSAGE);
         throw new Error(_FS_ERROR_MESSAGE);
     }
+    const savedfs = window.fs, savedPath = window.path;
+    setInterval(()=>{
+        if(window.fs !== savedfs){
+            console.error("window.fs overwrite detected!! Some extension may have corrupted this." +
+                " attempting to revert to original lib.");
+            window.fs=savedfs;
+        }
+        if(window.path !== savedPath){
+            console.error("window.path overwrite detected!! Some extension may have corrupted this." +
+                " attempting to revert to original lib.");
+            window.path=savedPath;
+        }
+
+    }, CORE_LIB_GUARD_INTERVAL);
 
     _setupVFS(window.fs, window.path);
     window._phoenixfsAppDirsCreatePromise = _createAppDirs();

--- a/src/utils/ExtensionLoader.js
+++ b/src/utils/ExtensionLoader.js
@@ -207,6 +207,7 @@ define(function (require, exports, module) {
         }
         throw new Error("Config can only be loaded from an http url, but got" + baseConfig.baseUrl);
     }
+    const savedFSlib = window.fs;
 
     /**
      * Loads the extension module that lives at baseUrl into its own Require.js context
@@ -250,6 +251,13 @@ define(function (require, exports, module) {
             return extensionRequireDeferred.promise();
         }).then(function (module) {
             // Extension loaded normally
+            if(savedFSlib !== window.fs) {
+                console.error("fslib overwrite detected while loading extension. This means that" +
+                    " some extension tried to modify a core library. reverting to original lib..");
+                // note that the extension name here may not be that actual extension that did the
+                // overwrite. So we dont log the extension name here.
+                window.fs = savedFSlib;
+            }
             var initPromise;
 
             _extensions[name] = module;


### PR DESCRIPTION
it was found that older document toolbar extension overwrote the window.fs object as window.fs is a phcode new construct. This lead to fs becoming inoperative and unable to uninstall extension in phcode.

putting in guards to safeguard fs lib as much as possible.