### PR TITLE
fix: get around extension update issues in tauri

### DIFF
--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -607,6 +607,8 @@ define({
     // For NOT_FOUND_ERR, see generic strings above
     "EXTENSION_MANAGER_TITLE": "Extension Manager",
     "EXTENSION_MANAGER_ERROR_LOAD": "Unable to access the extension registry. Please try again later.",
+    "EXTENSION_UPDATE_RESTART_TITLE": "Restart To Update",
+    "EXTENSION_UPDATE_RESTART_MESSAGE": "To load updated extensions, please close all running instances of {APP_NAME} and restart the application.",
     "INSTALL_EXTENSION_DRAG": "Drag .zip here or",
     "INSTALL_EXTENSION_DROP": "Drop .zip to install",
     "INSTALL_EXTENSION_DROP_ERROR": "Install/Update aborted due to the following errors:",


### PR DESCRIPTION
In tauri, due to browser cache for asset urls, updates to extensions will still load old 
extension through the http cache. So we show a restart app for the update to take effect dialogue after we mark the update as done.

![image](https://github.com/phcode-dev/phoenix/assets/5336369/4fc6316b-5998-406d-adf5-dc96a1a078c6)

Didnt fix it properly as we are moving to new extension manager workflows and in current
situation, extnsion updates are once in a month in the extension store as we have disabled brackets
extension store.