### PR TITLE
fix: remove double click to rename feature as its bad ux

### DIFF
--- a/src/project/FileTreeView.js
+++ b/src/project/FileTreeView.js
@@ -63,11 +63,10 @@ define(function (require, exports, module) {
     // Constants
 
     // Time range from first click to second click to invoke renaming.
-    var CLICK_RENAME_MINIMUM  = 500,
-        RIGHT_MOUSE_BUTTON    = 2,
+    const RIGHT_MOUSE_BUTTON    = 2,
         LEFT_MOUSE_BUTTON     = 0;
 
-    var INDENTATION_WIDTH     = 10;
+    const INDENTATION_WIDTH     = 10;
 
     /**
      * @private

--- a/src/project/FileTreeView.js
+++ b/src/project/FileTreeView.js
@@ -497,9 +497,7 @@ define(function (require, exports, module) {
          * Ensures that we always have a state object.
          */
         getInitialState: function () {
-            return {
-                clickTimer: null
-            };
+            return {};
         },
 
         /**
@@ -527,17 +525,6 @@ define(function (require, exports, module) {
                 // project-files-container and then the file tree will be one self-contained
                 // functional unit.
                 ViewUtils.scrollElementIntoView($("#project-files-container"), $(Preact.findDOMNode(this)), true);
-            } else if (!isSelected && wasSelected && this.state.clickTimer !== null) {
-                this.clearTimer();
-            }
-        },
-
-        clearTimer: function () {
-            if (this.state.clickTimer !== null) {
-                window.clearTimeout(this.state.clickTimer);
-                this.setState({
-                    clickTimer: null
-                });
             }
         },
 
@@ -545,7 +532,6 @@ define(function (require, exports, module) {
             if (!this.props.entry.get("rename")) {
                 this.props.actions.startRename(this.myPath());
             }
-            this.clearTimer();
         },
 
         /**
@@ -563,14 +549,7 @@ define(function (require, exports, module) {
                 return;
             }
 
-            if (this.props.entry.get("selected") && !e.ctrlKey) {
-                if (this.state.clickTimer === null && !this.props.entry.get("rename")) {
-                    var timer = window.setTimeout(this.startRename, CLICK_RENAME_MINIMUM);
-                    this.setState({
-                        clickTimer: timer
-                    });
-                }
-            } else {
+            if (!(this.props.entry.get("selected") && !e.ctrlKey)) {
                 var language = LanguageManager.getLanguageForPath(this.myPath()),
                     doNotOpen = false;
                 if (language && language.isBinary() && "image" !== language.getId() &&
@@ -614,9 +593,6 @@ define(function (require, exports, module) {
          */
         handleDoubleClick: function () {
             if (!this.props.entry.get("rename")) {
-                if (this.state.clickTimer !== null) {
-                    this.clearTimer();
-                }
                 if (FileUtils.shouldOpenInExternalApplication(
                         FileUtils.getFileExtension(this.myPath()).toLowerCase()
                       )) {


### PR DESCRIPTION
* Double click to rename is a mac feature in finder. This is not available in windows or linux file explorers.
* Brackets implementing it across all os is confusing to the user in windows and linux when the user doesnt expect the file to be renamed on double clicked.
* On mac, other code editors like vscode do not have this feature. So it will be confusing workflow to mac devs too.
* Also for larger files, the file load delay will interfear with the double click timers and it will confuse the user as to weather the double click worked to rename or to open the file and ad to working set.