### PR TITLE
fix: mac fullscreen shortcut f11 is system shortcut show desktop

### DIFF
--- a/src/extensionsIntegrated/NoDistractions/main.js
+++ b/src/extensionsIntegrated/NoDistractions/main.js
@@ -42,8 +42,9 @@ define(function (require, exports, module) {
         CMD_TOGGLE_PANELS         = "view.togglePanels";
 
     //key binding keys
-    const togglePureCodeKey         = "Ctrl-Shift-2",
-        togglePureCodeKeyMac      = "Cmd-Shift-2",
+    const togglePureCodeKey         = "Shift-F11",
+        toggleFullScreenKey = "F11",
+        toggleFullScreenKeyMac = "Cmd-F11",
         togglePanelsKey           = "Ctrl-Shift-1",
         togglePanelsKeyMac        = "Cmd-Shift-1",
         togglePanelsKey_EN        = "Ctrl-Shift-`",
@@ -151,10 +152,8 @@ define(function (require, exports, module) {
         CommandManager.register(Strings.CMD_TOGGLE_PANELS, CMD_TOGGLE_PANELS, _togglePanels);
 
         Menus.getMenu(Menus.AppMenuBar.VIEW_MENU).addMenuItem(CMD_TOGGLE_PANELS, "", Menus.AFTER, Commands.VIEW_HIDE_SIDEBAR);
-        Menus.getMenu(Menus.AppMenuBar.VIEW_MENU).addMenuItem(CMD_TOGGLE_PURE_CODE, "", Menus.AFTER, CMD_TOGGLE_PANELS);
-        Menus.getMenu(Menus.AppMenuBar.VIEW_MENU).addMenuItem(CMD_TOGGLE_FULLSCREEN, "F11", Menus.AFTER, CMD_TOGGLE_PURE_CODE);
-
-        KeyBindingManager.addBinding(CMD_TOGGLE_PURE_CODE, [ {key: togglePureCodeKey}, {key: togglePureCodeKeyMac, platform: "mac"} ]);
+        Menus.getMenu(Menus.AppMenuBar.VIEW_MENU).addMenuItem(CMD_TOGGLE_PURE_CODE, togglePureCodeKey, Menus.AFTER, CMD_TOGGLE_PANELS);
+        Menus.getMenu(Menus.AppMenuBar.VIEW_MENU).addMenuItem(CMD_TOGGLE_FULLSCREEN, [ {key: toggleFullScreenKey}, {key: toggleFullScreenKeyMac, platform: "mac"} ], Menus.AFTER, CMD_TOGGLE_PURE_CODE);
 
         //default toggle panel shortcut was ctrl+shift+` as it is present in one vertical line in the keyboard. However, we later learnt
         //from IQE team than non-English keyboards does not have the ` char. So added one more shortcut ctrl+shift+1 which will be preferred


### PR DESCRIPTION
* In Mac `fullscreen` shortcut is `Cmd-F11` and in Win/Linux Its Just `F11`
* Changes No distractions mode shortcut to `Shift-F11` in all platforms instead of `Ctrl-Shift-2` to be more intuitive as people using no distractions are also more likeley to use full screen and shence can do both without moving hands much.

![image](https://github.com/phcode-dev/phoenix/assets/5336369/bb096729-1df8-4f47-acb2-25a85d672b09)

Toggle Panels and Toggle sidebar not changed as it will likeley in future change to `Shift-Escape` key workflow, See: https://github.com/phcode-dev/phoenix/issues/1234