### PR TITLE
style: window titles will start with project names instead of file name

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -104,7 +104,7 @@ define(function (require, exports, module) {
     * String template for window title when a file is open.
     * @type {string}
     */
-    var WINDOW_TITLE_STRING_DOC = "{0} ({1}) " + _osDash + " {2}";
+    var WINDOW_TITLE_STRING_DOC = "{0} " + _osDash + " {1}";
 
     /**
      * Container for _$titleWrapper; if changing title changes this element's height, must kick editor to resize
@@ -289,7 +289,7 @@ define(function (require, exports, module) {
             var projectName = projectRoot.name;
             // Construct shell/browser window title, e.g. "• index.html (myProject) — Brackets"
             if (currentlyViewedPath) {
-                windowTitle = StringUtils.format(WINDOW_TITLE_STRING_DOC, readOnlyString + _currentTitlePath, projectName, brackets.config.app_title);
+                windowTitle = StringUtils.format(WINDOW_TITLE_STRING_DOC, readOnlyString + projectName, _currentTitlePath);
                 // Display dirty dot when there are unsaved changes
                 if (currentDoc && currentDoc.isDirty) {
                     windowTitle = "• " + windowTitle;

--- a/test/spec/DocumentCommandHandlers-integ-test.js
+++ b/test/spec/DocumentCommandHandlers-integ-test.js
@@ -925,7 +925,7 @@ define(function (require, exports, module) {
                 expect(DocumentManager.getCurrentDocument().isDirty).toBe(false);
 
                 // verify no dot in titlebar
-                const expectedTitle = "test.js (DocumentCommandHandlers-test-files) " + WINDOW_TITLE_DOT + " " + brackets.config.app_title;
+                const expectedTitle = `DocumentCommandHandlers-test-files ${WINDOW_TITLE_DOT} test.js`;
                 expect(testWindow.document.title).toBe(expectedTitle);
                 if(Phoenix.browser.isTauri) {
                     await awaitsFor(async ()=> {
@@ -945,7 +945,7 @@ define(function (require, exports, module) {
                 expect(doc.isDirty).toBe(true);
 
                 // verify dot in titlebar
-                const expectedTitle = "• test.js (DocumentCommandHandlers-test-files) " + WINDOW_TITLE_DOT + " " + brackets.config.app_title;
+                const expectedTitle = `• DocumentCommandHandlers-test-files ${WINDOW_TITLE_DOT} test.js`;
                 expect(testWindow.document.title).toBe(expectedTitle);
                 if(Phoenix.browser.isTauri) {
                     await awaitsFor(async ()=> {


### PR DESCRIPTION
This will help eazily identify projects if there are multiple windows and tabs instead of file names that may be common in many projects.

Fixes: https://github.com/phcode-dev/phoenix/issues/945

## Browser UI
### Tab heading with file open
![image](https://github.com/phcode-dev/phoenix/assets/5336369/eb56a202-e73b-4b02-9e6f-6aee37dce506)
### Tab heading with no file open
![image](https://github.com/phcode-dev/phoenix/assets/5336369/91ad71e1-cdaf-428d-b9bf-17e2bd46ab0c)
### With an edit/dirty document
![image](https://github.com/phcode-dev/phoenix/assets/5336369/94b641e2-18a0-45a5-ac2c-84426dff3b89)


## Desktop UI
### With files open
![image](https://github.com/phcode-dev/phoenix/assets/5336369/78f39ef4-d5e1-430a-a691-26a1bb1a68b5)
### With no files open
![image](https://github.com/phcode-dev/phoenix/assets/5336369/2e8b14e1-b98f-49f8-a466-1311b6acf3fb)
### Multiple window peek titles
![image](https://github.com/phcode-dev/phoenix/assets/5336369/2f121382-b0c0-449c-b26a-3f0f4e857ef6)
### With an edit/dirty document
![image](https://github.com/phcode-dev/phoenix/assets/5336369/5139eb77-bf3e-4bb4-b77e-a9341984f7ce)

