### PR TITLE
fix: clipboard edit menu>paste not working in tauri

### DIFF
--- a/src/phoenix/shell.js
+++ b/src/phoenix/shell.js
@@ -63,6 +63,26 @@ Phoenix.app = {
         }
         window.__TAURI__.window.appWindow.close();
     },
+    clipboardReadText: function () {
+        if(Phoenix.browser.isTauri){
+            return window.__TAURI__.clipboard.readText();
+        } else if(window.navigator && window.navigator.clipboard){
+            return window.navigator.clipboard.readText();
+        }
+        return Promise.reject(new Error("clipboardReadText: Unable to access clipboard text."));
+    },
+    copyToClipboard: function (textToCopy) {
+        if(Phoenix.browser.isTauri){
+            return window.__TAURI__.clipboard.writeText(textToCopy);
+        }
+        const textArea = document.createElement("textarea");
+        textArea.value = textToCopy;
+        document.body.appendChild(textArea);
+        textArea.select();
+        document.execCommand("copy");
+        document.body.removeChild(textArea);
+        return Promise.resolve();
+    },
     isFullscreen: function () {
         if(!Phoenix.browser.isTauri) {
             // use browser full screen api in browsers.
@@ -174,14 +194,6 @@ Phoenix.app = {
         const nativeWindow = window.open(url, '_blank', features);
         nativeWindow.isTauriWindow = false;
         return nativeWindow;
-    },
-    copyToClipboard: function (textToCopy) {
-        const textArea = document.createElement("textarea");
-        textArea.value = textToCopy;
-        document.body.appendChild(textArea);
-        textArea.select();
-        document.execCommand("copy");
-        document.body.removeChild(textArea);
     },
     getApplicationSupportDirectory: Phoenix.VFS.getAppSupportDir,
     getExtensionsDirectory: Phoenix.VFS.getExtensionDir,

--- a/src/phoenix/shell.js
+++ b/src/phoenix/shell.js
@@ -74,6 +74,8 @@ Phoenix.app = {
     copyToClipboard: function (textToCopy) {
         if(Phoenix.browser.isTauri){
             return window.__TAURI__.clipboard.writeText(textToCopy);
+        } else if(window.navigator && window.navigator.clipboard){
+            return window.navigator.clipboard.writeText(textToCopy);
         }
         const textArea = document.createElement("textarea");
         textArea.value = textToCopy;


### PR DESCRIPTION
The issue at hand is that users are unable to perform paste actions when clicking on "Edit" menu > "Paste" or the editor context menu > "Paste" in Tauri desktop builds. This problem arises because the browser clipboard APIs are not available in Tauri, necessitating the use of Tauri's own clipboard access APIs.

Clipboard API in browser will usually popup a clipboard access popup which the user have to click agree manually. In tauri this popup never comes. So we add tauris clipboard APIs.

### Add integration tests for tauri clipboard access
 Integration tests for Tauri clipboard access added. It's important to note that these tests will exclusively function in the Tauri environment. Regrettably, browsers do not permit unattended clipboard access due to security considerations. As a result, the copy-paste test is disabled when running in a browser context.
