### PR TITLE
feat: sub menu refactor phoenix diagnostic tools to not confuse user

### DIFF
--- a/src/extensions/default/DebugCommands/main.js
+++ b/src/extensions/default/DebugCommands/main.js
@@ -52,6 +52,8 @@ define(function (require, exports, module) {
 
     const KeyboardPrefs = JSON.parse(require("text!keyboard.json"));
 
+    const DIAGNOSTICS_SUBMENU = "debug-diagnostics-sub-menu";
+
     // default preferences file name
     const DEFAULT_PREFERENCES_FILENAME = "defaultPreferences.json",
         SUPPORTED_PREFERENCE_TYPES   = ["number", "boolean", "string", "array", "object"];
@@ -786,34 +788,36 @@ define(function (require, exports, module) {
 
     CommandManager.register(Strings.CMD_OPEN_PREFERENCES, DEBUG_OPEN_PREFERENCES_IN_SPLIT_VIEW, handleOpenPrefsInSplitView);
     const debugMenu = Menus.getMenu(Menus.AppMenuBar.DEBUG_MENU);
-    // Show Developer Tools (optionally enabled)
-    if(brackets.app.toggleDevtools){
-        CommandManager.register(Strings.CMD_SHOW_DEV_TOOLS, DEBUG_SHOW_DEVELOPER_TOOLS, _handleShowDeveloperTools);
-        debugMenu.addMenuItem(DEBUG_SHOW_DEVELOPER_TOOLS, KeyboardPrefs.showDeveloperTools);
-    }
     debugMenu.addMenuItem(DEBUG_REFRESH_WINDOW, KeyboardPrefs.refreshWindow);
     debugMenu.addMenuItem(DEBUG_RELOAD_WITHOUT_USER_EXTS, KeyboardPrefs.reloadWithoutUserExts);
     debugMenu.addMenuItem(DEBUG_LOAD_CURRENT_EXTENSION);
     debugMenu.addMenuItem(DEBUG_UNLOAD_CURRENT_EXTENSION, undefined, undefined, undefined, {
         hideWhenCommandDisabled: true
     });
-    debugMenu.addMenuItem(DEBUG_RUN_UNIT_TESTS);
-    debugMenu.addMenuItem(DEBUG_SHOW_PERF_DATA);
-    debugMenu.addMenuDivider();
-    debugMenu.addMenuItem(DEBUG_ENABLE_LOGGING);
-    debugMenu.addMenuItem(DEBUG_ENABLE_PHNODE_INSPECTOR, undefined, undefined, undefined, {
-        hideWhenCommandDisabled: true
-    });
-    debugMenu.addMenuItem(DEBUG_GET_PHNODE_INSPECTOR_URL, undefined, undefined, undefined, {
-        hideWhenCommandDisabled: true
-    });
-    debugMenu.addMenuItem(DEBUG_LIVE_PREVIEW_LOGGING);
-    debugMenu.addMenuDivider();
-    debugMenu.addMenuItem(DEBUG_OPEN_VFS);
     debugMenu.addMenuItem(DEBUG_OPEN_EXTENSION_FOLDER, undefined, undefined, undefined, {
         hideWhenCommandDisabled: true
     });
-    debugMenu.addMenuItem(DEBUG_OPEN_VIRTUAL_SERVER, undefined, undefined, undefined, {
+    debugMenu.addMenuDivider();
+    // Show Developer Tools (optionally enabled)
+    if(brackets.app.toggleDevtools){
+        CommandManager.register(Strings.CMD_SHOW_DEV_TOOLS, DEBUG_SHOW_DEVELOPER_TOOLS, _handleShowDeveloperTools);
+        debugMenu.addMenuItem(DEBUG_SHOW_DEVELOPER_TOOLS, KeyboardPrefs.showDeveloperTools);
+    }
+    const diagnosticsSubmenu = debugMenu.addSubMenu(Strings.CMD_DIAGNOSTIC_TOOLS, DIAGNOSTICS_SUBMENU);
+    diagnosticsSubmenu.addMenuItem(DEBUG_RUN_UNIT_TESTS);
+    diagnosticsSubmenu.addMenuDivider();
+    diagnosticsSubmenu.addMenuItem(DEBUG_ENABLE_LOGGING);
+    diagnosticsSubmenu.addMenuItem(DEBUG_ENABLE_PHNODE_INSPECTOR, undefined, undefined, undefined, {
+        hideWhenCommandDisabled: true
+    });
+    diagnosticsSubmenu.addMenuItem(DEBUG_GET_PHNODE_INSPECTOR_URL, undefined, undefined, undefined, {
+        hideWhenCommandDisabled: true
+    });
+    diagnosticsSubmenu.addMenuItem(DEBUG_LIVE_PREVIEW_LOGGING);
+    diagnosticsSubmenu.addMenuDivider();
+    diagnosticsSubmenu.addMenuItem(DEBUG_SHOW_PERF_DATA);
+    diagnosticsSubmenu.addMenuItem(DEBUG_OPEN_VFS);
+    diagnosticsSubmenu.addMenuItem(DEBUG_OPEN_VIRTUAL_SERVER, undefined, undefined, undefined, {
         hideWhenCommandDisabled: true
     });
 

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -485,6 +485,7 @@ define({
 
     // Debug menu commands
     "CMD_OPEN_VFS": "Open Virtual File System",
+    "CMD_DIAGNOSTIC_TOOLS": "{APP_NAME} Diagnostic Tools",
     "CMD_OPEN_EXTENSIONS_FOLDER": "Open Extensions Folder\u2026",
     "CMD_OPEN_VIRTUAL_SERVER": "Open Virtual Server",
 
@@ -685,7 +686,7 @@ define({
     // extensions/default/DebugCommands
     "DEBUG_MENU": "Debug",
     "ERRORS": "Errors",
-    "CMD_SHOW_DEV_TOOLS": "Show Developer Tools",
+    "CMD_SHOW_DEV_TOOLS": "{APP_NAME} Developer Tools",
     "CMD_REFRESH_WINDOW": "Reload With Extensions",
     "CMD_LOAD_CURRENT_EXTENSION": "Load Project As Extension",
     "CMD_RELOAD_CURRENT_EXTENSION": "Reload Project As Extension",
@@ -694,7 +695,7 @@ define({
     "CMD_NEW_BRACKETS_WINDOW": "New Window",
     "CMD_LAUNCH_SCRIPT_MAC": "Install Command Line Shortcut",
     "CMD_SWITCH_LANGUAGE": "Switch Language\u2026",
-    "CMD_RUN_UNIT_TESTS": "Run Tests",
+    "CMD_RUN_UNIT_TESTS": "Run {APP_NAME} Tests",
     "CMD_SHOW_PERF_DATA": "Show Performance Data",
     "CMD_ENABLE_LOGGING": "Enable Detailed Logs",
     "CMD_ENABLE_PHNODE_INSPECTOR": "Enable PhNode Inspector",


### PR DESCRIPTION
UX change so that the user doesnt get confused with debug and dev tools for their project vs tools to debug and diagnose phoenix.

## Before
![image](https://github.com/phcode-dev/phoenix/assets/5336369/84a6277c-d4f5-46c5-9977-fa34321fd1a9)


## After
### In Browser
![image](https://github.com/phcode-dev/phoenix/assets/5336369/29c44d5f-b531-4750-8f04-27ee51f2b300)

### In Desktop
![image](https://github.com/phcode-dev/phoenix/assets/5336369/8058bc65-e6d7-4adc-bcd6-11f13b3a3fc6)
