### PR TITLE
chore: createNodeConnector API returns ready to use node connector instead of promise

### DIFF
--- a/docs/generatedApiDocs/NodeConnector-API.md
+++ b/docs/generatedApiDocs/NodeConnector-API.md
@@ -158,7 +158,7 @@ two-way communication (exec function, send/receive events) with the other side.
 
 *   Throws **[Error][3]** If a node connector with the same ID already exists.
 
-Returns **[Promise][4]** A promise that resolves to an NodeConnector Object.
+Returns **{execPeer: [function][4], triggerPeer: [function][4], on: [function][4], off: [function][4]}** A promise that resolves to an NodeConnector Object.
 
 [1]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
@@ -166,4 +166,4 @@ Returns **[Promise][4]** A promise that resolves to an NodeConnector Object.
 
 [3]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error
 
-[4]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
+[4]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function

--- a/src-node/node-connector.js
+++ b/src-node/node-connector.js
@@ -41,11 +41,15 @@
  * Node Connector Creation:
  *
  * - Named Node Connectors serve as the foundation for further communication between Node and Phoenix.
- *   A Node Connector can be created only once via the `global.createNodeConnector` API in node and
- *   `createNodeConnector` API in `NodeConnector` module.
+ *   A named Node Connector can be created only once via the `global.createNodeConnector` API in node and
+ *   `createNodeConnector` API in `NodeConnector` module. Note that multiple `NodeConnector` can be created with
+ *   different names.
  *
- * - The API returns a promise that resolves to a Node Connector object when the Node Connector with the same ID
- *   is opened on the other side (Phoenix).
+ * - The API returns Node Connector object that can be immediately used to execute `execPeer` and `triggerPeer` APIs.
+ *   When the Node Connector with the same ID is opened on the other side (Phoenix), it will receive the events.
+ *
+ * Note:  Events or execPeer requests will be queued for upto 10 seconds to give time for the connector to be
+ *  created at the other end before it calls quites and rejects all exec requests at timeout.
  *
  * Usage:
  *

--- a/src-node/node-connector.js
+++ b/src-node/node-connector.js
@@ -59,9 +59,27 @@ const WebSocket = require('ws');
 const nodeConnectorIDMap = {};
 const nodeExecHandlerMap = {};
 let currentCommandID = 0;
+// This holds the list {resolve, reject} for all waiting exec functions executed with execPeer here.
 const pendingExecPromiseMap = {};
-const pendingPeerNodeConnectorSetupResolveMap = {};
-const isPeerNodeConnectorSetupMap = {};
+
+// If a NodeConnector has been created on this end, we can promptly process events and exec messages. However,
+// in cases where a NodeConnector hasn't been created yet on this end, we temporarily queue execs and event triggers
+// for up to 10 seconds. This approach ensures that the other side remains unaware of the status of the NodeConnector
+// at both ends, allowing them to initiate message transmission via the WebSocket as soon as they invoke the
+// createNodeConnector API on their side.
+
+// Timeout duration for NodeConnector creation (10 seconds)
+const NODE_CONNECTOR_CREATE_TIMEOUT = 10000;
+// Max number of messages to queue for a single node connector.
+const MAX_QUEUE_LENGTH = 2000;
+
+// These arrays hold queues of event and exec messages received from the other side while a NodeConnector
+// was not yet created on this end. Messages are queued for up to 10 seconds.
+const pendingNodeConnectorExecMap = {};
+const pendingNodeConnectorEventMap = {};
+
+// This timer clears the pending maps above if a NodeConnector is not created within 10 seconds.
+const isTimerRunningMap = {};
 
 /**
  *
@@ -136,8 +154,7 @@ const WS_COMMAND = {
     EXEC: "exec",
     EVENT: "event",
     LARGE_DATA_SOCKET_ANNOUNCE: "largeDataSock",
-    CONTROL_SOCKET_ANNOUNCE: "controlSock",
-    NODE_CONNECTOR_ANNOUNCE: "nodeConnectorCreated"
+    CONTROL_SOCKET_ANNOUNCE: "controlSock"
 };
 
 const WS_ERR_CODES = {
@@ -158,8 +175,9 @@ function _drainPendingSendBuffer() {
     const copyPendingSendBuffer = pendingSendBuffer;
     // empty to prevent race conditions
     pendingSendBuffer = [];
-    while (copyPendingSendBuffer.length > 0) {
-        const {commandObject, dataBuffer} = copyPendingSendBuffer.pop();
+    for(let i=0; i<copyPendingSendBuffer.length; i++) {
+        // Execute in order as we received the event
+        const {commandObject, dataBuffer} = copyPendingSendBuffer[i];
         _sendWithAppropriateSocket(commandObject, dataBuffer);
     }
 }
@@ -178,18 +196,6 @@ function _sendWithAppropriateSocket(commandObject, dataBuffer) {
         socketToUse = largeDataSocketMain;
     }
     socketToUse.send(mergeMetadataAndArrayBuffer(commandObject, dataBuffer));
-}
-
-function _sendCommand(commandCode, dataObjectToSend = null, dataBuffer = null) {
-    currentCommandID++;
-    const commandID = currentCommandID;
-    const command = {
-        commandCode: commandCode,
-        commandID: commandID,
-        data: dataObjectToSend
-    };
-    _sendWithAppropriateSocket(command, dataBuffer);
-    return commandID;
 }
 
 function _sendExec(nodeConnectorID, commandID, execHandlerFnName, dataObjectToSend = null, dataBuffer = null) {
@@ -267,12 +273,55 @@ function _isJSONStringifiable(result) {
     }
 }
 
+function _errNClearQueue(nodeConnectorID) {
+    const pendingExecList = pendingNodeConnectorExecMap[nodeConnectorID];
+    pendingNodeConnectorExecMap[nodeConnectorID] = [];
+    for(let i=0; i<pendingExecList.length; i++) {
+        const {ws, metadata} = pendingExecList[i];
+        _sendError(ws, metadata,
+            new Error(`NodeConnector ${nodeConnectorID} not found to exec function ${metadata.execHandlerFnName}`));
+    }
+}
+
+function _queueExec(nodeConnectorID, ws, metadata, bufferData) {
+    let pendingExecList = pendingNodeConnectorExecMap[nodeConnectorID];
+    if(!pendingExecList){
+        pendingExecList = [];
+        pendingNodeConnectorExecMap[nodeConnectorID] = pendingExecList;
+    }
+    if(pendingExecList.length > MAX_QUEUE_LENGTH) {
+        _sendError(ws, metadata,
+            new Error(`Too Many exec while waiting for NodeConnector ${nodeConnectorID} creation to exec fn ${metadata.execHandlerFnName}`));
+        return;
+    }
+    pendingExecList.push({ws, metadata, bufferData});
+    if(!isTimerRunningMap[nodeConnectorID]){
+        isTimerRunningMap[nodeConnectorID] = true;
+        setTimeout(() => {
+            // the node connector was not established
+            isTimerRunningMap[nodeConnectorID] = false;
+            _errNClearQueue(nodeConnectorID);
+        }, NODE_CONNECTOR_CREATE_TIMEOUT);
+    }
+}
+
+function _drainExecQueue(nodeConnectorID) {
+    let pendingExecList = pendingNodeConnectorExecMap[nodeConnectorID] || [];
+    pendingNodeConnectorExecMap[nodeConnectorID] = [];
+    for(let i=0; i<pendingExecList.length; i++) {
+        const {ws, metadata, bufferData} = pendingExecList[i];
+        _execNodeConnectorFn(ws, metadata, bufferData);
+    }
+}
+
 function _execNodeConnectorFn(ws, metadata, dataBuffer) {
     const nodeConnectorID = metadata.nodeConnectorID;
     const execHandlerFnName = metadata.execHandlerFnName;
     const moduleExports = nodeExecHandlerMap[nodeConnectorID];
     if(!moduleExports){
-        throw new Error("Unable to find moduleExports to exec function for "+ JSON.stringify(metadata));
+        // node connector not yet created. Queue it.
+        _queueExec(nodeConnectorID, ws, metadata, dataBuffer);
+        return;
     }
     try{
         if(typeof moduleExports[execHandlerFnName] !== 'function'){
@@ -303,11 +352,44 @@ function _execNodeConnectorFn(ws, metadata, dataBuffer) {
     }
 }
 
+function _queueEvent(nodeConnectorID, ws, metadata, bufferData) {
+    let pendingEventList = pendingNodeConnectorEventMap[nodeConnectorID];
+    if(!pendingEventList){
+        pendingEventList = [];
+        pendingNodeConnectorEventMap[nodeConnectorID] = pendingEventList;
+    }
+    if(pendingEventList.length > MAX_QUEUE_LENGTH) {
+        _sendError(ws, metadata,
+            new Error(`Too Many events: ${metadata.eventName} while waiting for NodeConnector ${nodeConnectorID} creation`));
+        return;
+    }
+    pendingEventList.push({ws, metadata, bufferData});
+    if(!isTimerRunningMap[nodeConnectorID]){
+        isTimerRunningMap[nodeConnectorID] = true;
+        setTimeout(() => {
+            // the node connector was not established
+            isTimerRunningMap[nodeConnectorID] = false;
+            _errNClearQueue(nodeConnectorID);
+        }, NODE_CONNECTOR_CREATE_TIMEOUT);
+    }
+}
+
+function _drainEventQueue(nodeConnectorID) {
+    let pendingEventList = pendingNodeConnectorEventMap[nodeConnectorID] || [];
+    pendingNodeConnectorEventMap[nodeConnectorID] = [];
+    for(let i=0; i<pendingEventList.length; i++) {
+        const {ws, metadata, bufferData} = pendingEventList[i];
+        _triggerEvent(ws, metadata, bufferData);
+    }
+}
+
 function _triggerEvent(ws, metadata, dataBuffer) {
     const nodeConnectorID = metadata.nodeConnectorID;
     const nodeConnector = nodeConnectorIDMap[nodeConnectorID];
     if(!nodeConnector){
-        throw new Error("Unable to find nodeConnectorID to _triggerEvent for "+ JSON.stringify(metadata));
+        // node connector not yet created. Queue it.
+        _queueEvent(nodeConnectorID, ws, metadata, dataBuffer);
+        return;
     }
     nodeConnector.trigger(metadata.eventName, metadata.data, dataBuffer);
 }
@@ -326,15 +408,6 @@ function processWSCommand(ws, metadata, dataBuffer) {
             ws.isLargeData = false;
             controlSocketMain = ws;
             _drainPendingSendBuffer();
-            return;
-        case WS_COMMAND.NODE_CONNECTOR_ANNOUNCE:
-            const nodeConnectorID = metadata.data;
-            // this message signals that a node connector with the given nodeConnectorID is setup at the other side.
-            if(pendingPeerNodeConnectorSetupResolveMap[nodeConnectorID]) {
-                // this means that createNodeConnector in this side is waiting for this message. So resolve it.
-                pendingPeerNodeConnectorSetupResolveMap[nodeConnectorID]();
-            }
-            isPeerNodeConnectorSetupMap[nodeConnectorID] = true;
             return;
         case WS_COMMAND.EXEC:
             _execNodeConnectorFn(ws, metadata, dataBuffer);
@@ -369,19 +442,12 @@ function processWSCommand(ws, metadata, dataBuffer) {
     }
 }
 
-/*Returns a promise that resolves when a node connector for the given nodeConnectorID is created in the other side*/
-function _waitForPeerNodeConnector(nodeConnectorID) {
-    if(isPeerNodeConnectorSetupMap[nodeConnectorID]){
-        return Promise.resolve();
-    }
-    return new Promise((resolve)=>{
-        pendingPeerNodeConnectorSetupResolveMap[nodeConnectorID] = resolve;
-    });
-}
-
-async function createNodeConnector(nodeConnectorID, moduleExports) {
+function createNodeConnector(nodeConnectorID, moduleExports) {
     if(nodeConnectorIDMap[nodeConnectorID]) {
         throw new Error("A node connector of the name is already registered: " + nodeConnectorID);
+    }
+    if(!_isObject(moduleExports) || !nodeConnectorID) {
+        throw new Error("Invalid Argument. Expected createNodeConnector(string, module/Object) for " + nodeConnectorID);
     }
 
     nodeExecHandlerMap[nodeConnectorID] = moduleExports;
@@ -433,12 +499,20 @@ async function createNodeConnector(nodeConnectorID, moduleExports) {
     EventDispatcher.makeEventDispatcher(newNodeConnector);
     nodeConnectorIDMap[nodeConnectorID] = newNodeConnector;
 
-    // now if phoenix is waiting for WS_COMMAND.NODE_CONNECTOR_ANNOUNCE to setup node connector on its side, we
-    // raise it here. If phoenix NODE_CONNECTOR_ANNOUNCE call happens after this fn is called in node, then
-    // it will be handled at processWSCommand fn.
-    const peerConnectionPromise = _waitForPeerNodeConnector(nodeConnectorID);
-    _sendCommand(WS_COMMAND.NODE_CONNECTOR_ANNOUNCE, nodeConnectorID);
-    await peerConnectionPromise;
+    // At this point, it's possible that a node connector has been created on the other end, and it might have sent
+    // us exec and trigger events that need to be processed. These events will be queued for execution, and we will
+    // handle them after the current event loop call.
+    // We use a setTimeout with a zero-millisecond delay to ensure that the event queues are drained during the
+    // next tick of the event loop.
+    setTimeout(() => {
+        _drainExecQueue(nodeConnectorID);
+        _drainEventQueue(nodeConnectorID);
+    }, 0);
+
+
+    // At this time, the node connector at the other side may not be created, but it is still safe to use this
+    // node connector now as the events will be queued at the other end for up to 10 seconds for a node connector
+    // to be created at the other end.
     return newNodeConnector;
 }
 

--- a/src-node/test-connection.js
+++ b/src-node/test-connection.js
@@ -170,3 +170,11 @@ exports.testInvalidArgsNodeConnector = async function () {
     _verifyFailToCreateNodeConnector("invalidExports", 45); // invalid exports
     _verifyFailToCreateNodeConnector("invalidExports", null); // invalid exports
 };
+
+exports.createNodeConnector = async function (connectorName) {
+    NodeConnector.createNodeConnector(connectorName, exports)
+        .on("testEventInNode", (_evt, data, buffer)=>{
+            console.log(_evt, data, buffer);
+            nodeConnector.triggerPeer("testEventInPhoenix", data, buffer);
+        });
+};

--- a/src-node/test-connection.js
+++ b/src-node/test-connection.js
@@ -1,16 +1,12 @@
 const NodeConnector = require("./node-connector");
 
-let nodeConnector;
 const TEST_NODE_CONNECTOR_ID = "ph_test_connector";
-NodeConnector.createNodeConnector(TEST_NODE_CONNECTOR_ID, exports)
-    .then(nodeConnectorObj =>{
-        nodeConnector = nodeConnectorObj;
-        nodeConnector.on("hello", console.log);
-        nodeConnector.on("testEventInNode", (_evt, data, buffer)=>{
-            console.log(_evt, data, buffer);
-            nodeConnector.triggerPeer("testEventInPhoenix", data, buffer);
-        });
-    });
+const nodeConnector = NodeConnector.createNodeConnector(TEST_NODE_CONNECTOR_ID, exports);
+nodeConnector.on("hello", console.log);
+nodeConnector.on("testEventInNode", (_evt, data, buffer)=>{
+    console.log(_evt, data, buffer);
+    nodeConnector.triggerPeer("testEventInPhoenix", data, buffer);
+});
 
 exports.echoTest = function (data, buffer) {
     console.log("Node fn called echoTest");
@@ -155,4 +151,22 @@ exports.testErrExecCases = async function () {
     await _shouldErrorOut("", buffer);
     await _shouldErrorOut(34, buffer);
     await _shouldErrorOut(null, buffer);
+};
+
+
+function _verifyFailToCreateNodeConnector(id, exp) {
+    let err;
+    try{
+        NodeConnector.createNodeConnector(id, exp);
+    } catch (e) {
+        err = e;
+    }
+    expectEqual(typeof err.message, "string");
+}
+
+exports.testInvalidArgsNodeConnector = async function () {
+    _verifyFailToCreateNodeConnector(TEST_NODE_CONNECTOR_ID, exports); // already there
+    _verifyFailToCreateNodeConnector("noExportsTest"); // no exports
+    _verifyFailToCreateNodeConnector("invalidExports", 45); // invalid exports
+    _verifyFailToCreateNodeConnector("invalidExports", null); // invalid exports
 };

--- a/src/NodeConnector.js
+++ b/src/NodeConnector.js
@@ -187,6 +187,51 @@ define(function (require, exports, module) {
         return !!window.PhNodeEngine;
     }
 
+    /**
+     * Terminate the PhNodeEngine node if it is available. Else does nothing.
+     *
+     * @return {void}
+     */
+    function terminateNode() {
+        if(isNodeAvailable()){
+            window.PhNodeEngine.terminateNode();
+        }
+    }
+
+    /**
+     * Sets weather to enable node inspector in next boot.
+     *
+     * @param {boolean} enabled - true to enable, else false.
+     */
+    function setInspectEnabled(enabled) {
+        window.PhNodeEngine.setInspectEnabled(enabled);
+    }
+
+    /**
+     * Returns whether node inspector is enabled. If node is not present, always returns false.
+     *
+     * @returns {boolean} True if inspect mode is enabled, false otherwise.
+     */
+    function isInspectEnabled() {
+        if(isNodeAvailable()){
+            return window.PhNodeEngine.isInspectEnabled();
+        }
+        return false;
+    }
+
+    /**
+     * Retrieves the node inspector port for the Phoenix Node.js engine.
+     *
+     * @returns {number} The inspection port number.
+     */
+    function getInspectPort() {
+        return window.PhNodeEngine.getInspectPort();
+    }
+
     exports.createNodeConnector = createNodeConnector;
     exports.isNodeAvailable = isNodeAvailable;
+    exports.terminateNode = terminateNode;
+    exports.isInspectEnabled = isInspectEnabled;
+    exports.setInspectEnabled = setInspectEnabled;
+    exports.getInspectPort = getInspectPort;
 });

--- a/src/NodeConnector.js
+++ b/src/NodeConnector.js
@@ -142,13 +142,10 @@
  *
  * * ## Caveats
  *
- * - Ensure that the `nodeConnectedPromise` is resolved before using the `nodeConnector` to avoid potential issues
- *   related to communication readiness.
  * - Be cautious when sending large binary data, as it may affect performance and memory usage.
  * - Properly handle exceptions and errors when executing functions to maintain robust communication.
  * - Functions called with `execPeer` and `triggerPeer` must be asynchronous and accept a single argument. An optional
  *   second argument can be used to transfer large binary data as an ArrayBuffer.
- *
  *
  * For more event handling operations and details, refer to the documentation for the `utils/EventDispatcher` module.
  *
@@ -174,13 +171,23 @@ define(function (require, exports, module) {
      * @param {string} nodeConnectorID - The unique identifier for the new node connector.
      * @param {Object} moduleExports - The exports of the module that contains the functions to be executed on the other side.
      *
-     * @returns {Promise} - A promise that resolves to an NodeConnector Object.
+     * @returns {{execPeer:function, triggerPeer:function, trigger:function, on:function, off:function, one:function}} - A NodeConnector Object. Also contains all the APIs supported by `utils/EventDispatcher` module.
      *
-     * @throws {Error} - If a node connector with the same ID already exists.
+     * @throws {Error} - If a node connector with the same ID already exists/invalid args passed.
      */
     function createNodeConnector(nodeConnectorID, moduleExports) {
         return window.PhNodeEngine.createNodeConnector(nodeConnectorID, moduleExports);
     }
 
+    /**
+     * Checks if Node.js Engine is available.
+     *
+     * @returns {boolean} Returns true if Node.js Engine is available.
+     */
+    function isNodeAvailable() {
+        return !!window.PhNodeEngine;
+    }
+
     exports.createNodeConnector = createNodeConnector;
+    exports.isNodeAvailable = isNodeAvailable;
 });

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -27,7 +27,7 @@ define(function (require, exports, module) {
 
 
     // Load dependent modules
-    var AppInit             = require("utils/AppInit"),
+    const AppInit             = require("utils/AppInit"),
         CommandManager      = require("command/CommandManager"),
         Commands            = require("command/Commands"),
         DeprecationWarning  = require("utils/DeprecationWarning"),
@@ -57,6 +57,7 @@ define(function (require, exports, module) {
         WorkspaceManager    = require("view/WorkspaceManager"),
         LanguageManager     = require("language/LanguageManager"),
         NewFileContentManager     = require("features/NewFileContentManager"),
+        NodeConnector = require("NodeConnector"),
         _                   = require("thirdparty/lodash");
 
     /**
@@ -1790,7 +1791,7 @@ define(function (require, exports, module) {
 
             // Defer for a more successful reload - issue #11539
             window.setTimeout(function () {
-                window.PhNodeEngine && window.PhNodeEngine.terminateNode();
+                NodeConnector.terminateNode();
                 window.location.href = href;
             }, 1000);
         }).fail(function () {
@@ -1901,7 +1902,7 @@ define(function (require, exports, module) {
             event.preventDefault();
             _handleWindowGoingAway(null, closeSuccess=>{
                 console.log('close success: ', closeSuccess);
-                window.PhNodeEngine && window.PhNodeEngine.terminateNode();
+                NodeConnector.terminateNode();
                 Phoenix.app.closeWindow();
             }, closeFail=>{
                 console.log('close fail: ', closeFail);

--- a/src/extensions/default/DebugCommands/main.js
+++ b/src/extensions/default/DebugCommands/main.js
@@ -46,6 +46,7 @@ define(function (require, exports, module) {
         Locales                = brackets.getModule("nls/strings"),
         ProjectManager         = brackets.getModule("project/ProjectManager"),
         ExtensionLoader        = brackets.getModule("utils/ExtensionLoader"),
+        NodeConnector          = brackets.getModule("NodeConnector"),
         extensionDevelopment   = require("extensionDevelopment"),
         PerfDialogTemplate     = require("text!htmlContent/perf-dialog.html"),
         LanguageDialogTemplate = require("text!htmlContent/language-dialog.html");
@@ -693,7 +694,7 @@ define(function (require, exports, module) {
         CommandManager.get(DEBUG_LIVE_PREVIEW_LOGGING).setEnabled(isLogging);
         logger.loggingOptions.logLivePreview = window.isLoggingEnabled(LOG_LIVE_PREVIEW_KEY);
         CommandManager.get(DEBUG_LIVE_PREVIEW_LOGGING).setChecked(logger.loggingOptions.logLivePreview);
-        CommandManager.get(DEBUG_ENABLE_PHNODE_INSPECTOR).setChecked(window.PhNodeEngine && window.PhNodeEngine.isInspectEnabled());
+        CommandManager.get(DEBUG_ENABLE_PHNODE_INSPECTOR).setChecked(NodeConnector.isInspectEnabled());
     }
 
     function _handleLogging() {
@@ -702,7 +703,7 @@ define(function (require, exports, module) {
     }
 
     function _handlePhNodeInspectEnable() {
-        window.PhNodeEngine.setInspectEnabled(!window.PhNodeEngine.isInspectEnabled());
+        NodeConnector.setInspectEnabled(!NodeConnector.isInspectEnabled());
         _updateLogToConsoleMenuItemChecked();
     }
 
@@ -717,8 +718,8 @@ define(function (require, exports, module) {
   </p>
   <p>2. Select Option 'Open dedicated DevTools for Node'</p>
   <p>
-    3. Use the URL in connection tab'<code>localhost:${window.PhNodeEngine.getInspectPort()}</code>'
-    <button onclick="Phoenix.app.copyToClipboard('localhost:${window.PhNodeEngine.getInspectPort()}')">
+    3. Use the URL in connection tab'<code>localhost:${NodeConnector.getInspectPort()}</code>'
+    <button onclick="Phoenix.app.copyToClipboard('localhost:${NodeConnector.getInspectPort()}')">
       <i class="fas fa-copy"></i> Copy
     </button>
   </p>

--- a/src/node-loader.js
+++ b/src/node-loader.js
@@ -138,9 +138,8 @@ function nodeLoader() {
         const copyPendingSendBuffer = pendingSendBuffer;
         // empty to prevent race conditions
         pendingSendBuffer = [];
-        for(let i=0; i<copyPendingSendBuffer.length; i++) {
-            // Execute in order as we received the event
-            const {commandObject, dataBuffer} = copyPendingSendBuffer[i];
+        // Using a for...of loop for better readability
+        for(let {commandObject, dataBuffer} of copyPendingSendBuffer) {
             _sendWithAppropriateSocket(commandObject, dataBuffer);
         }
     }
@@ -256,10 +255,11 @@ function nodeLoader() {
     function _errNClearQueue(nodeConnectorID) {
         const pendingExecList = pendingNodeConnectorExecMap[nodeConnectorID];
         pendingNodeConnectorExecMap[nodeConnectorID] = [];
-        for(let i=0; i<pendingExecList.length; i++) {
-            const {ws, metadata} = pendingExecList[i];
-            _sendError(ws, metadata,
-                new Error(`NodeConnector ${nodeConnectorID} not found to exec function ${metadata.execHandlerFnName}`));
+        for(const { ws, metadata } of pendingExecList) {
+            _sendError(
+                ws, metadata,
+                new Error(`NodeConnector ${nodeConnectorID} not found to exec function ${metadata.execHandlerFnName}`)
+            );
         }
     }
 
@@ -288,8 +288,7 @@ function nodeLoader() {
     function _drainExecQueue(nodeConnectorID) {
         let pendingExecList = pendingNodeConnectorExecMap[nodeConnectorID] || [];
         pendingNodeConnectorExecMap[nodeConnectorID] = [];
-        for(let i=0; i<pendingExecList.length; i++) {
-            const {ws, metadata, bufferData} = pendingExecList[i];
+        for(const {ws, metadata, bufferData} of pendingExecList) {
             _execPhcodeConnectorFn(ws, metadata, bufferData);
         }
     }
@@ -357,8 +356,7 @@ function nodeLoader() {
     function _drainEventQueue(nodeConnectorID) {
         let pendingEventList = pendingNodeConnectorEventMap[nodeConnectorID] || [];
         pendingNodeConnectorEventMap[nodeConnectorID] = [];
-        for(let i=0; i<pendingEventList.length; i++) {
-            const {ws, metadata, bufferData} = pendingEventList[i];
+        for(const {ws, metadata, bufferData} of pendingEventList) {
             _triggerEvent(ws, metadata, bufferData);
         }
     }


### PR DESCRIPTION
<!-- Generated by documentation.js. Update this documentation by updating the source code. -->

## NodeConnector

Node Connector Communication Module

This module simplifies communication between Node.js and Phoenix (phcode). A `NodeConnector` acts as an intermediary,
allowing you to execute functions in Node.js from Phoenix and vice versa. You can use the `execPeer` method to call
functions on the other side and handle communication seamlessly. Use `triggerPeer` to trigger events
on the other side.

## Setting Up a `NodeConnector`

To establish communication between two modules, such as `x.js` in Phoenix and `y.js` in Node.js, follow these steps:

### Create `NodeConnector` in Phoenix (`x.js`)

```js
const NodeConnector = require('NodeConnector');
const XY_NODE_CONNECTOR_ID = 'ext_x_y'; // Use a unique ID
let nodeConnector = NodeConnector.createNodeConnector(XY_NODE_CONNECTOR_ID, exports);

exports.modifyImage = async function(imageName, imageArrayBuffer) {
  // Perform image operations with the imageArrayBuffer
  // To return an ArrayBuffer, return an object with a `buffer` key.
  return {
    operationDone: 'colored, cropped',
    buffer: imageArrayBuffer,
  };
};
```

### Create `NodeConnector` in Node.js (`y.js`)

```js
const XY_NODE_CONNECTOR_ID = 'ext_x_y'; // Use the same unique ID
let nodeConnector = global.createNodeConnector(XY_NODE_CONNECTOR_ID, exports);

exports.getPWDRelative = async function(subPath) {
  return process.cwd + '/' + subPath;
};
```

With these steps, a `NodeConnector` is set up, enabling two-way communication.

## Executing Functions

To call a Node.js function from Phoenix, use the `execPeer` method.

```js
// In `x.js` (Phoenix)
const fullPath = await nodeConnector.execPeer('getPWDRelative', 'sub/path.html');
```

To execute a Phoenix function from Node.js and transfer binary data, pass an optional ArrayBuffer.

```js
// In `y.js` (Node.js)
const { operationDone, buffer } = await nodeConnector.execPeer('modifyImage', {name:'theHills.png'}, imageAsArrayBuffer);
```

## Event Handling

The `NodeConnector` object implements all the APIs supported by `utils/EventDispatcher`. You can trigger and listen
to events between Node.js and Phoenix using the `triggerPeer` and (`on`, `one` or `off`) methods.

```js
// In `y.js` (Node.js)
nodeConnector.on('phoenixProjectOpened', (_event, projectPath) => {
  console.log(projectPath);
});

nodeConnector.one('phoenixProjectOpened', (_event, projectPath) => {
  console.log(projectPath + "will be received only once");
});
```

To raise an event from Phoenix to Node.js:

```js
// In `x.js` (Phoenix)
nodeConnector.triggerPeer('phoenixProjectOpened', '/x/project/folder');
```

To Switch off events

```js
nodeConnector.off('phoenixProjectOpened'); // will switch off all event handlers of that name.
```

By Default, all events handlers with the eventName is removed when you call `nodeConnector.off(eventName)` fn.
To selectively switch off event handlers, please see reference for `utils/EventDispatcher` module.

### Handling ArrayBuffer Data in Function Execution

When executing functions that send or receive binary data, ensure that the functions are asynchronous and accept an
optional ArrayBuffer as a parameter. To return binary data, use an object with a `buffer` key.

Example of calling a function in Node.js with binary data transfer:

```js
// In `y.js` (Node.js)
const { operationDone, buffer } = await nodeConnector.execPeer('modifyImage', {name:'name.png'}, imageArrayBuffer);
```

### Handling ArrayBuffer Data in Event Handling

Use the `triggerPeer` method to send binary data in events. Include the ArrayBuffer as an optional parameter.

Example of sending binary data in an event from Phoenix to Node.js:

```js
// In `x.js` (Phoenix)
const imageArrayBuffer = getSomeImageArrayBuffer(); // Get the ArrayBuffer
nodeConnector.triggerPeer('imageEdited', 'name.png', imageArrayBuffer);
```

*   ## Caveats

<!---->

*   Be cautious when sending large binary data, as it may affect performance and memory usage. Transferring large
    data is fully supported, but be mindful of performance.
*   Functions called with `execPeer` and `triggerPeer` must be asynchronous and accept a single argument. An optional
    second argument can be used to transfer large binary data as an ArrayBuffer.

For more event handling operations and details, refer to the documentation for the `utils/EventDispatcher` module.

## createNodeConnector

Creates a new node connector with the specified ID and module exports.

Returns a NodeConnector Object (which is an EventDispatcher with
additional `execPeer` and `triggerPeer` methods. `peer` here means, if you are executing `execPeer`
in Phoenix, it will execute the named function in node side, and vice versa. You can right away start
using `execPeer`, `triggerPeer`(to send/receive events) APIs without waiting to check if the
other side nodeConnector is created.

Note: If the NodeConnector has not been created on the other end, requests made with `execPeer` or
`triggerPeer` will be temporarily queued for up to 10 seconds to allow time for the connector to be created.
If the connector is not created within this timeout period, all queued `execPeer` requests will be rejected,
and all queued events will be dropped. It is recommended to call the `createNodeConnector` API on both ends
within a timeframe of less than 10 seconds(ideally same time) for seamless communication.

*   execPeer: A function that executes a peer function with specified parameters.
*   triggerPeer: A function that triggers an event to be sent to a peer.
*   Also contains all the APIs supported by `utils/EventDispatcher` module.

### Parameters

*   `nodeConnectorID` **[string][1]** The unique identifier for the new node connector.
*   `moduleExports` **[Object][2]** The exports of the module that contains the functions to be executed on the other side.

<!---->

*   Throws **[Error][3]** If a node connector with the same ID already exists/invalid args passed.

Returns **{execPeer: [function][4], triggerPeer: [function][4], trigger: [function][4], on: [function][4], off: [function][4], one: [function][4]}** A NodeConnector Object. Also contains all the APIs supported by `utils/EventDispatcher` module.

## isNodeAvailable

Checks if Node.js Engine is available.

Returns **[boolean][5]** Returns true if Node.js Engine is available.

[1]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String

[2]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object

[3]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error

[4]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function

[5]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
