### PR TITLE
chore: privacy aware node bugsnag crash reporting

### DIFF
--- a/src-node/index.js
+++ b/src-node/index.js
@@ -81,7 +81,7 @@ function randomNonce(byteLength) {
 }
 
 let debugMode = false;
-const COMMAND_RESPONSE_PREFIX = 'phnodeResp_1!5$:'; // a prefix thats not likely to just start with in stdio
+const COMMAND_RESPONSE_PREFIX = 'phnodeResp_1!5$:'; // a string thats not likely to just start with in stdio
 const COMMAND_ERROR_PREFIX = 'phnodeErr_1!5$:';
 // Generate a random 64-bit url. This should take 100 million+ of years to crack with current http connection speed.
 const PHOENIX_FS_URL = `/PhoenixFS${randomNonce(8)}`;
@@ -119,8 +119,9 @@ const userHomeDir = os.homedir();
 
 function _stripSensitiveInfo(message) {
     message = message || '';
-    message = nodeBinPath && message.replace(nodeBinPath, ''); // remove sensitive user path info from stack
-    message = nodeSrcPath && message.replace(nodeSrcPath, '');
+    // remove sensitive user path info from stack
+    message = nodeSrcPath && message.replace(nodeSrcPath, '');// this should be first in order due to a windows path quirk
+    message = nodeBinPath && message.replace(nodeBinPath, '');
     message = userHomeDir && message.replace(userHomeDir, '');
     return message;
 }

--- a/src-node/index.js
+++ b/src-node/index.js
@@ -195,11 +195,12 @@ rl.on('line', (line) => {
     processCommand(line);
 });
 
+const localhostOnly = 'localhost';
 function getFreePort() {
     return new Promise((resolve)=>{
         const server = net.createServer();
 
-        server.listen(0, () => {
+        server.listen(0, localhostOnly, () => {
             const port = server.address().port;
             server.close(() => {
                 resolve(port);
@@ -222,7 +223,7 @@ getFreePort().then((port) => {
     // PhoenixFS.setDebugMode(true); // uncomment this line to enable more logging in phoenix fs lib
 
     // Start the HTTP server on port 3000
-    server.listen(port, () => {
+    server.listen(port, localhostOnly, () => {
         serverPortResolve(port);
         savedConsoleLog(`Server running on http://localhost:${port}`);
         savedConsoleLog(`Phoenix node tauri FS url is ws://localhost:${port}${PHOENIX_FS_URL}`);

--- a/src/node-loader.js
+++ b/src/node-loader.js
@@ -18,7 +18,7 @@
  *
  */
 
-/*global Phoenix, fs*/
+/*global Phoenix, fs, logger*/
 
 function nodeLoader() {
     const phcodeExecHandlerMap = {};
@@ -584,7 +584,8 @@ function nodeLoader() {
             HEART_BEAT: "heartBeat",
             GET_ENDPOINTS: "getEndpoints"
         };
-        const COMMAND_RESPONSE_PREFIX = 'phnodeResp:';
+        const COMMAND_RESPONSE_PREFIX = 'phnodeResp_1!5$:'; // a string thats not likely to just start with in
+        const COMMAND_ERROR_PREFIX = 'phnodeErr_1!5$:';
         let command, child;
         let resolved = false;
         let commandID = 0, pendingCommands = {};
@@ -624,6 +625,11 @@ function nodeLoader() {
                             const jsonMsg = JSON.parse(line);
                             pendingCommands[jsonMsg.commandID].resolve(jsonMsg.message);
                             delete pendingCommands[jsonMsg.commandID];
+                        } else if(line.startsWith(COMMAND_ERROR_PREFIX)){
+                            // its a js response object
+                            line = line.replace(COMMAND_ERROR_PREFIX, "");
+                            const err = JSON.parse(line);
+                            logger.reportError(err, `PhNode ${err.type}:${err.code?err.code:''}`);
                         } else {
                             console.log(`PhNode: ${line}`);
                         }


### PR DESCRIPTION
* Catch uncaught exceptions and erros in node and log in bugsnag, strip all user file system paths from stack for privacy.
* fix: bind phNode api server to localhost only to prevent windows firewall dialog