### PR TITLE
Live Preview Desktop first draft

### DIFF
--- a/src/LiveDevelopment/BrowserScripts/LivePreviewTransportRemote.js
+++ b/src/LiveDevelopment/BrowserScripts/LivePreviewTransportRemote.js
@@ -49,15 +49,15 @@
     let sentTitle, sentFavIconURL;
 
     function convertImgToBase64(url, callback) {
-        var canvas = document.createElement('CANVAS');
-        var ctx = canvas.getContext('2d');
-        var img = new Image();
+        let canvas = document.createElement('CANVAS');
+        const ctx = canvas.getContext('2d');
+        const img = new Image();
         img.crossOrigin = 'Anonymous';
         img.onload = function() {
             canvas.height = img.height;
             canvas.width = img.width;
             ctx.drawImage(img, 0, 0);
-            var dataURL = canvas.toDataURL();
+            const dataURL = canvas.toDataURL();
             callback(dataURL);
             canvas = null;
         };

--- a/src/LiveDevelopment/BrowserScripts/LivePreviewTransportRemote.js
+++ b/src/LiveDevelopment/BrowserScripts/LivePreviewTransportRemote.js
@@ -46,6 +46,45 @@
         type: "setupBroadcast",
         broadcastChannel: window.LIVE_PREVIEW_BROADCAST_CHANNEL_ID,
         clientID});
+    let sentTitle, sentFavIconURL;
+
+    function convertImgToBase64(url, callback) {
+        var canvas = document.createElement('CANVAS');
+        var ctx = canvas.getContext('2d');
+        var img = new Image();
+        img.crossOrigin = 'Anonymous';
+        img.onload = function() {
+            canvas.height = img.height;
+            canvas.width = img.width;
+            ctx.drawImage(img, 0, 0);
+            var dataURL = canvas.toDataURL();
+            callback(dataURL);
+            canvas = null;
+        };
+        img.src = url;
+    }
+
+    setInterval(()=>{
+        const favIcon = document.querySelector("link[rel~='icon']");
+        const faviconUrl = favIcon && favIcon.href;
+        if(sentFavIconURL !== faviconUrl){
+            sentFavIconURL = faviconUrl;
+            convertImgToBase64(faviconUrl, function(base64) {
+                worker.postMessage({
+                    type: "updateTitleIcon",
+                    faviconBase64: base64
+                });
+            });
+        }
+
+        if(sentTitle!== document.title) {
+            sentTitle = document.title;
+            worker.postMessage({
+                type: "updateTitleIcon",
+                title: document.title
+            });
+        }
+    }, 1000);
 
     const WebSocketTransport = {
         _channelOpen: false,

--- a/src/LiveDevelopment/BrowserScripts/pageLoaderWorker.js
+++ b/src/LiveDevelopment/BrowserScripts/pageLoaderWorker.js
@@ -49,7 +49,7 @@ function _setupBroadcastChannel(broadcastChannel, clientID) {
     _sendOnlineHeartbeat();
     setInterval(()=>{
         _sendOnlineHeartbeat();
-    }, 1000);
+    }, 3000);
 }
 
 function updateTitleAndFavicon(event) {

--- a/src/LiveDevelopment/BrowserScripts/pageLoaderWorker.js
+++ b/src/LiveDevelopment/BrowserScripts/pageLoaderWorker.js
@@ -25,11 +25,13 @@
  */
 
 
+let _livePreviewNavigationChannel;
+
 function _setupBroadcastChannel(broadcastChannel, clientID) {
     if(!broadcastChannel){
         return;
     }
-    const _livePreviewNavigationChannel=new BroadcastChannel(broadcastChannel);
+    _livePreviewNavigationChannel=new BroadcastChannel(broadcastChannel);
     _livePreviewNavigationChannel.onmessage = (event) => {
         const type = event.data.type;
         switch (type) {
@@ -50,10 +52,20 @@ function _setupBroadcastChannel(broadcastChannel, clientID) {
     }, 1000);
 }
 
+function updateTitleAndFavicon(event) {
+    _livePreviewNavigationChannel.postMessage({
+        type: 'UPDATE_TITLE_AND_ICON',
+        title: event.data.title,
+        faviconBase64: event.data.faviconBase64,
+        URL: location.href
+    });
+}
+
 onmessage = (event) => {
     const type = event.data.type;
     switch (type) {
     case 'setupBroadcast': _setupBroadcastChannel(event.data.broadcastChannel, event.data.clientID); break;
+    case 'updateTitleIcon': updateTitleAndFavicon(event); break;
     default: console.error("Live Preview page worker: received unknown event:", event);
     }
 };

--- a/src/LiveDevelopment/LiveDevMultiBrowser.js
+++ b/src/LiveDevelopment/LiveDevMultiBrowser.js
@@ -606,10 +606,12 @@ define(function (require, exports, module) {
         _createLiveDocumentForFrame(initialDoc);
 
         // start listening for requests
-        _server.start();
+        _server.start()
+            .then(()=>{
+                // open browser to the url
+                _open(initialDoc);
+            });
 
-        // open browser to the url
-        _open(initialDoc);
     }
 
     /**

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -329,7 +329,7 @@ define(function (require, exports, module) {
      * If all you need is the Document's getText() value, use the faster getDocumentText() instead.
      *
      * @param {!string} fullPath
-     * @param {!object} fileObj actual File|RemoteFile or some other protocol adapter handle
+     * @param {object?} fileObj actual File|RemoteFile or some other protocol adapter handle
      * @return {$.Promise} A promise object that will be resolved with the Document, or rejected
      *      with a FileSystemError if the file is not yet open and can't be read from disk.
      */

--- a/src/extensions/default/HealthData/SendToAnalytics.js
+++ b/src/extensions/default/HealthData/SendToAnalytics.js
@@ -136,6 +136,13 @@ define(function (require, exports, module) {
         if(Phoenix.browser.isTauri) {
             Metrics.valueEvent(PERFORMANCE, "startup", "tauriBoot", window._tauriBootVars.bootstrapTime);
         }
+        if(window.nodeSetupDonePromise) {
+            window.nodeSetupDonePromise
+                .then(()=>{
+                    window.PhNodeEngine && window.PhNodeEngine._nodeLoadTime
+                    && Metrics.valueEvent(PERFORMANCE, "startup", "nodeBoot", window.PhNodeEngine._nodeLoadTime);
+                });
+        }
     }
 
     // Themes

--- a/src/extensions/default/HealthData/SendToAnalytics.js
+++ b/src/extensions/default/HealthData/SendToAnalytics.js
@@ -132,6 +132,10 @@ define(function (require, exports, module) {
             Number(healthReport["AppStartupTime"]));
         Metrics.valueEvent(PERFORMANCE, "startup", "ModuleDepsResolved",
             Number(healthReport["ModuleDepsResolved"]));
+        Metrics.valueEvent(PERFORMANCE, "startup", "PhStore", PhStore._storageBootstrapTime);
+        if(Phoenix.browser.isTauri) {
+            Metrics.valueEvent(PERFORMANCE, "startup", "tauriBoot", window._tauriBootVars.bootstrapTime);
+        }
     }
 
     // Themes

--- a/src/extensions/default/Phoenix-live-preview/StaticServer.js
+++ b/src/extensions/default/Phoenix-live-preview/StaticServer.js
@@ -79,17 +79,14 @@ define(function (require, exports, module) {
             }, pageLoaderID);
             return;
         case EVENT_GET_CONTENT:
-            const requestPath = message.path,
-                requestID = message.requestID,
-                url = message.url;
-            getContent(requestPath, url)
+            getContent(message.path,  message.url)
                 .then(response =>{
                     // response has the following attributes set
                     // response.contents: <text or arrayBuffer content>,
                     // response.path
                     // headers: {'Content-Type': 'text/html'} // optional headers
                     response.type = 'REQUEST_RESPONSE';
-                    response.requestID = requestID;
+                    response.requestID = message.requestID;
                     _sendToLivePreviewServerTabs(response, pageLoaderID);
                 })
                 .catch(console.error);
@@ -478,7 +475,6 @@ define(function (require, exports, module) {
             let timeDiff = endTime - livePreviewTabs.get(tab).lastSeen; // in ms
             if(timeDiff > TAB_HEARTBEAT_TIMEOUT){
                 livePreviewTabs.delete(tab);
-                // todo fix the image load and after five secs live preview off bug
                 exports.trigger('BROWSER_CLOSE', { data: { message: {clientID: tab}}});
             }
         }

--- a/src/extensions/default/Phoenix-live-preview/StaticServer.js
+++ b/src/extensions/default/Phoenix-live-preview/StaticServer.js
@@ -362,7 +362,7 @@ define(function (require, exports, module) {
     /**
      * See BaseServer#start. Starts listenting to StaticServerDomain events.
      */
-    StaticServer.prototype.start = function () {
+    StaticServer.prototype.start = async function () {
         _staticServerInstance = this;
 
         // load the hidden iframe that loads the service worker server page once. we will reuse the same server

--- a/src/extensions/default/Phoenix-live-preview/StaticServer.js
+++ b/src/extensions/default/Phoenix-live-preview/StaticServer.js
@@ -200,14 +200,6 @@ define(function (require, exports, module) {
         BaseServer.prototype.clear.call(this);
     };
 
-    /**
-     * @private
-     * Send HTTP response data back to the StaticServerSomain
-     */
-    StaticServer.prototype._send = function (location, response) {
-        this._nodeDomain.exec("writeFilteredResponse", location.root, location.pathname, response);
-    };
-
     function _sendMarkdown(fullPath, requestID) {
         DocumentManager.getDocumentForPath(fullPath)
             .done(function (doc) {

--- a/src/extensions/default/Phoenix-live-preview/StaticServer.js
+++ b/src/extensions/default/Phoenix-live-preview/StaticServer.js
@@ -302,8 +302,9 @@ define(function (require, exports, module) {
     }
 
     /**
-     * return a page loader url after stripping the PHCODE_LIVE_PREVIEW_QUERY_PARAM
-     * "https://phcode.live/pageLoader.html?broadcastChannel=PH-697797864197_livePreview&URL=https%3A%2...
+     * return a page loader html with redirect script tag that just redirects the page to the given redirectURL.
+     * Strips the PHCODE_LIVE_PREVIEW_QUERY_PARAM in redirectURL also, indicating this is not a live previewed url.
+     *
      * @param redirectURL
      * @return {string}
      * @private
@@ -469,8 +470,8 @@ define(function (require, exports, module) {
         });
     });
 
-    // If we didn't receive heartbeat message from a tab for 5 seconds, we assume tab closed
-    const TAB_HEARTBEAT_TIMEOUT = 5000; // in millis secs
+    // If we didn't receive heartbeat message from a tab for 10 seconds, we assume tab closed
+    const TAB_HEARTBEAT_TIMEOUT = 10000; // in millis secs
     setInterval(()=>{
         let endTime = new Date();
         for(let tab of livePreviewTabs.keys()){

--- a/src/extensions/default/Phoenix-live-preview/StaticServer.js
+++ b/src/extensions/default/Phoenix-live-preview/StaticServer.js
@@ -389,7 +389,7 @@ define(function (require, exports, module) {
 
     function getContent(path, url) {
         if(!_staticServerInstance){
-            return;
+            return Promise.reject("Static serve not started!");
         }
         if(!url.startsWith(_staticServerInstance._baseUrl)) {
             return Promise.reject("Not serving content as url belongs to another phcode instance: " + url);

--- a/src/extensions/default/Phoenix-live-preview/StaticServer.js
+++ b/src/extensions/default/Phoenix-live-preview/StaticServer.js
@@ -314,7 +314,7 @@ define(function (require, exports, module) {
         // strip this query param as the redirection will be done by the page loader and not the content iframe.
         url.searchParams.delete(PHCODE_LIVE_PREVIEW_QUERY_PARAM);
         let templateVars = {
-            redirectURL: utils.getPageLoaderURL(url.href)
+            redirectURL: url.href
         };
         return Mustache.render(redirectionHTMLTemplate, templateVars);
     }

--- a/src/extensions/default/Phoenix-live-preview/StaticServer.js
+++ b/src/extensions/default/Phoenix-live-preview/StaticServer.js
@@ -43,8 +43,7 @@ define(function (require, exports, module) {
         HilightJSText = require("text!../../../thirdparty/highlight.js/highlight.min.js"),
         GFMCSSText = require("text!../../../thirdparty/gfm.min.css"),
         markdownHTMLTemplate = require("text!markdown.html"),
-        redirectionHTMLTemplate = require("text!redirectPage.html"),
-        utils = require('utils');
+        redirectionHTMLTemplate = require("text!redirectPage.html");
 
     const EVENT_GET_PHOENIX_INSTANCE_ID = 'GET_PHOENIX_INSTANCE_ID';
     const EVENT_GET_CONTENT = 'GET_CONTENT';
@@ -388,6 +387,12 @@ define(function (require, exports, module) {
     };
 
     function getContent(path, url) {
+        if(!_staticServerInstance){
+            return;
+        }
+        if(!url.startsWith(_staticServerInstance._baseUrl)) {
+            return Promise.reject("Not serving content as url belongs to another phcode instance: " + url);
+        }
         if(_isMarkdownFile(path)){
             return _getMarkdown(path);
         }
@@ -472,6 +477,7 @@ define(function (require, exports, module) {
             let timeDiff = endTime - livePreviewTabs.get(tab).lastSeen; // in ms
             if(timeDiff > TAB_HEARTBEAT_TIMEOUT){
                 livePreviewTabs.delete(tab);
+                // todo fix the image load and after five secs live preview off bug
                 exports.trigger('BROWSER_CLOSE', { data: { message: {clientID: tab}}});
             }
         }

--- a/src/extensions/default/Phoenix-live-preview/main.js
+++ b/src/extensions/default/Phoenix-live-preview/main.js
@@ -230,7 +230,8 @@ define(function (require, exports, module) {
             $iframe.attr('srcdoc', null);
         };
 
-        const popoutSupported = Phoenix.browser.isTauri || Phoenix.browser.desktop.isChromeBased;
+        const popoutSupported = Phoenix.browser.isTauri
+            || Phoenix.browser.desktop.isChromeBased || Phoenix.browser.desktop.isFirefox;
         if(!popoutSupported){
             // live preview can be popped out currently in only chrome based browsers. The cross domain iframe
             // that serves the live preview(phcode.live) is sandboxed to the tab in which phcode.dev resides.
@@ -301,7 +302,11 @@ define(function (require, exports, module) {
     }
 
     let livePreviewEnabledOnProjectSwitch = false;
-    async function _projectOpened() {
+    async function _projectOpened(_evt, projectRoot) {
+        navigatorChannel.postMessage({
+            type: 'PROJECT_SWITCH',
+            projectRoot: projectRoot.fullPath
+        });
         if(urlPinned){
             _togglePinUrl();
         }

--- a/src/extensions/default/Phoenix-live-preview/main.js
+++ b/src/extensions/default/Phoenix-live-preview/main.js
@@ -59,14 +59,13 @@ define(function (require, exports, module) {
         utils = require('utils');
 
     const LIVE_PREVIEW_PANEL_ID = "live-preview-panel",
-        NAVIGATOR_REDIRECT_PAGE = "REDIRECT_PAGE",
         IFRAME_EVENT_SERVER_READY = 'SERVER_READY';
     let serverReady = false;
     const LIVE_PREVIEW_IFRAME_HTML = `
     <iframe id="panel-live-preview-frame" title="Live Preview" style="border: none"
              width="100%" height="100%" seamless="true"
              src='about:blank'
-             sandbox="allow-same-origin allow-scripts allow-popups allow-forms allow-modals allow-pointer-lock">
+             sandbox="allow-same-origin allow-scripts allow-forms allow-modals allow-pointer-lock">
     </iframe>
     `;
 

--- a/src/extensions/default/Phoenix-live-preview/main.js
+++ b/src/extensions/default/Phoenix-live-preview/main.js
@@ -60,6 +60,7 @@ define(function (require, exports, module) {
 
     const LIVE_PREVIEW_PANEL_ID = "live-preview-panel",
         IFRAME_EVENT_SERVER_READY = 'SERVER_READY';
+    const EVENT_UPDATE_TITLE_ICON = 'UPDATE_TITLE_AND_ICON';
     let serverReady = false;
     const LIVE_PREVIEW_IFRAME_HTML = `
     <iframe id="panel-live-preview-frame" title="Live Preview" style="border: none"
@@ -393,6 +394,15 @@ define(function (require, exports, module) {
         StaticServer.on(IFRAME_EVENT_SERVER_READY, function (_evt, event) {
             serverReady = true;
             _loadPreview(true);
+        });
+        StaticServer.on(EVENT_UPDATE_TITLE_ICON, function(_ev, event){
+            const title = event.data.message.title;
+            const faviconBase64 = event.data.message.faviconBase64;
+            navigatorChannel.postMessage({
+                type: 'UPDATE_TITLE_ICON',
+                title,
+                faviconBase64
+            });
         });
 
         let consecutiveEmptyClientsCount = 0;

--- a/src/extensions/default/Phoenix-live-preview/markdown.html
+++ b/src/extensions/default/Phoenix-live-preview/markdown.html
@@ -5,10 +5,18 @@
     <title>Markdown- Phoenix</title>
 
 
-    <link rel="stylesheet" href="{{{BOOTSTRAP_LIB_CSS}}}">
-    <link href="{{{HIGHLIGHT_JS_CSS}}}" rel="stylesheet">
-    <script src="{{{HIGHLIGHT_JS}}}"></script>
-    <link rel="stylesheet" href="{{{GFM_CSS}}}" />
+    <style>
+        {{{BOOTSTRAP_LIB_CSS}}}
+    </style>
+    <style>
+        {{{HIGHLIGHT_JS_CSS}}}
+    </style>
+    <script>
+        {{{HIGHLIGHT_JS}}}
+    </script>
+    <style>
+        {{{GFM_CSS}}}
+    </style>
     <script type="text/javascript">
         function inIframe () {
             try {

--- a/src/extensions/default/Phoenix-live-preview/panel.html
+++ b/src/extensions/default/Phoenix-live-preview/panel.html
@@ -11,6 +11,7 @@
                 title="live preview server"
                 src="about:blank"
                 style="width:100%;"
+                sandbox="allow-same-origin allow-scripts"
                 hidden>
         </iframe>
     </div>

--- a/src/extensions/default/Phoenix-live-preview/panel.html
+++ b/src/extensions/default/Phoenix-live-preview/panel.html
@@ -19,7 +19,7 @@
         <div style="width: 3px;"></div>
         <iframe id="panel-live-preview-frame" title="Live Preview" style="border: none"
                 width="100%" height="100%" seamless="true" srcdoc='<img width="50px" src="styles/images/Spinner-1s-200px.svg">'
-                sandbox="allow-same-origin allow-scripts allow-popups allow-forms allow-modals allow-pointer-lock">
+                sandbox="allow-same-origin allow-scripts allow-forms allow-modals allow-pointer-lock">
         </iframe>
     </div>
 </div>

--- a/src/extensions/default/Phoenix-live-preview/utils.js
+++ b/src/extensions/default/Phoenix-live-preview/utils.js
@@ -44,8 +44,7 @@ define(function (require, exports, module) {
         Strings                   = brackets.getModule("strings"),
         DocumentManager     = brackets.getModule("document/DocumentManager"),
         LiveDevelopment    = brackets.getModule("LiveDevelopment/main"),
-        LiveDevServerManager = brackets.getModule("LiveDevelopment/LiveDevServerManager"),
-        LivePreviewTransport  = brackets.getModule("LiveDevelopment/MultiBrowserImpl/transports/LivePreviewTransport");
+        LiveDevServerManager = brackets.getModule("LiveDevelopment/LiveDevServerManager");
 
     function getExtension(filePath) {
         filePath = filePath || '';
@@ -89,8 +88,10 @@ define(function (require, exports, module) {
 
     function getPageLoaderURL(url) {
         return `${Phoenix.baseURL}live-preview-loader.html?`
-            +`virtualServerURL=${encodeURIComponent(LiveDevServerManager.getStaticServerBaseURLs().baseURL)}`+
-            `&phoenixInstanceID=${Phoenix.PHOENIX_INSTANCE_ID}&initialURL=${encodeURIComponent(url)}`;
+            +`virtualServerURL=${encodeURIComponent(LiveDevServerManager.getStaticServerBaseURLs().baseURL)}`
+            +`&phoenixInstanceID=${Phoenix.PHOENIX_INSTANCE_ID}&initialURL=${encodeURIComponent(url)}`
+            +`&localMessage=${encodeURIComponent(Strings.DESCRIPTION_LIVEDEV_SECURITY_POPOUT_MESSAGE)}`
+            +`&okMessage=${encodeURIComponent(Strings.TRUST_PROJECT)}`;
     }
 
     function _isLivePreviewSupported() {

--- a/src/extensions/default/Phoenix-live-preview/utils.js
+++ b/src/extensions/default/Phoenix-live-preview/utils.js
@@ -88,8 +88,9 @@ define(function (require, exports, module) {
     }
 
     function getPageLoaderURL(url) {
-        return `${LiveDevServerManager.getStaticServerBaseURLs().baseURL}pageLoader.html?`
-            +`broadcastChannel=${LivePreviewTransport.BROADCAST_CHANNEL_ID}&URL=${encodeURIComponent(url)}`;
+        return `${Phoenix.baseURL}live-preview-loader.html?`
+            +`virtualServerURL=${encodeURIComponent(LiveDevServerManager.getStaticServerBaseURLs().baseURL)}`+
+            `&phoenixInstanceID=${Phoenix.PHOENIX_INSTANCE_ID}&initialURL=${encodeURIComponent(url)}`;
     }
 
     function _isLivePreviewSupported() {

--- a/src/extensions/default/Phoenix-live-preview/utils.js
+++ b/src/extensions/default/Phoenix-live-preview/utils.js
@@ -91,6 +91,7 @@ define(function (require, exports, module) {
             +`virtualServerURL=${encodeURIComponent(LiveDevServerManager.getStaticServerBaseURLs().baseURL)}`
             +`&phoenixInstanceID=${Phoenix.PHOENIX_INSTANCE_ID}&initialURL=${encodeURIComponent(url)}`
             +`&localMessage=${encodeURIComponent(Strings.DESCRIPTION_LIVEDEV_SECURITY_POPOUT_MESSAGE)}`
+            +`&initialProjectRoot=${encodeURIComponent(ProjectManager.getProjectRoot().fullPath)}`
             +`&okMessage=${encodeURIComponent(Strings.TRUST_PROJECT)}`;
     }
 

--- a/src/index.html
+++ b/src/index.html
@@ -146,6 +146,7 @@
                 const appLocalDirPromise =  window.__TAURI__.path.appLocalDataDir();
                 const tempDirPromise = window.__TAURI__.os.tempdir();
                 window._tauriBootVars = {};
+                const tauriBootStartTime = Date.now();
                 window._tauriBootVarsPromise = Promise.all([appNamePromise, documentDirPromise,
                     appLocalDirPromise, tempDirPromise])
                     .then((results) => {
@@ -164,6 +165,7 @@
 
                         window._tauriBootVars.appLocalDir = results[2];
                         window._tauriBootVars.tempDir = results[3];
+                        window._tauriBootVars.bootstrapTime = Date.now() - tauriBootStartTime;
                         localStorage.setItem(TAURI_BOOT_VARS_LOCALSTORAGE_KEY, JSON.stringify(window._tauriBootVars));
                     });
             }

--- a/src/live-preview-loader.html
+++ b/src/live-preview-loader.html
@@ -99,6 +99,18 @@
             'https://create.phcode.dev': true
         };
 
+        function isTrustedURL(url) {
+            if(!url){
+                return false;
+            }
+            for(let trustedUrl of Object.keys(TRUSTED_ORIGINS)){
+                if(url.startsWith(trustedUrl)){
+                    return true;
+                }
+            }
+            return false;
+        }
+
         const pageLoaderID = crypto.randomUUID();
         let securityAlertAcknowledged = false;
         let previewURL;
@@ -121,23 +133,25 @@
             navigatorChannel.onmessage = (event) => {
                 _debugLog("Live Preview loader channel: Browser received event from Phoenix: ", JSON.stringify(event.data));
                 const type = event.data.type;
+                const dialog = document.getElementById('outer-container');
                 switch (type) {
                     case "REDIRECT_PAGE":
-                        const url = event.data.url;
-                        previewURL = url;
+                        previewURL = event.data.url;
                         if(!securityAlertAcknowledged){
                             return;
                         }
-                        _debugLog("Loading page: ", url);
-                        document.getElementById("previewFrame").src = url;
+                        _debugLog("Loading page: ", previewURL);
+                        if(isTrustedURL(previewURL)){
+                            document.getElementById("previewFrame").src = previewURL;
+                        }
                         return;
                     case "UPDATE_TITLE_ICON":
                         // The live preview frame will send us its title and favicon for us to set the window
                         // title and favicon. If it is that message, then, set it up
-                        const title = event.data.title;
-                        const faviconBase64 = event.data.faviconBase64;
-                        title && (document.title = title);
-                        if(faviconBase64){
+                        if(event.data.title || event.data.title === '') {
+                            document.title = event.data.title;
+                        }
+                        if(event.data.faviconBase64){
                             // Update the favicon
                             let link = document.querySelector("link[rel~='icon']");
                             if (!link) {
@@ -150,10 +164,11 @@
                         return;
                     case "PROJECT_SWITCH":
                         currentProjectRoot = event.data.projectRoot;
-                        const dialog = document.getElementById('outer-container');
                         if(trustedProjects[currentProjectRoot] && dialog){
                             dialog.style.display = 'none';
-                            document.getElementById('previewFrame').src = decodeURIComponent(previewURL);
+                            if(isTrustedURL(previewURL)){
+                                document.getElementById('previewFrame').src = decodeURIComponent(previewURL);
+                            }
                             securityAlertAcknowledged = true;
                             return;
                         }
@@ -203,7 +218,9 @@
             document.getElementById('okButton').addEventListener('click', function() {
                 const dialog = document.getElementById('outer-container');
                 dialog.style.display = 'none';
-                document.getElementById('previewFrame').src = decodeURIComponent(previewURL);
+                if(isTrustedURL(previewURL)) {
+                    document.getElementById('previewFrame').src = decodeURIComponent(previewURL);
+                }
                 securityAlertAcknowledged = true;
                 trustedProjects[currentProjectRoot] = true;
             });
@@ -226,7 +243,9 @@
             setupNavigationWatcher(phoenixInstanceID);
             let livepreviewServerIframe = document.getElementById("live-preview-server-iframe");
             let serverURL = `${decodeURIComponent(virtualServerURL)}?parentOrigin=${location.origin}`;
-            livepreviewServerIframe.setAttribute("src", serverURL);
+            if(isTrustedURL(serverURL)) {
+                livepreviewServerIframe.setAttribute("src", serverURL);
+            }
 
             okMessage && (document.getElementById('okButton').textContent = decodeURIComponent(okMessage));
             localiseMessage && (document.getElementById('dialog-message').textContent = decodeURIComponent(localiseMessage));

--- a/src/live-preview-loader.html
+++ b/src/live-preview-loader.html
@@ -16,6 +16,74 @@
             border: none; /* Removes the default border around an iframe */
         }
     </style>
+    <style>
+
+        .outer-container {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            z-index: 2;
+        }
+
+        .dialog-container {
+            border: 1px solid #ccc;
+            background-color: #fff;
+            padding: 20px;
+            box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1);
+            /* Other styles remain the same */
+        }
+
+        .dialog-title {
+            font-size: 1.2em;
+            margin-bottom: 10px;
+        }
+
+        .dialog-message {
+            margin-bottom: 20px;
+        }
+
+        .dialog-buttons {
+            text-align: right;
+        }
+
+        button {
+            padding: 5px 10px;
+            margin-left: 10px;
+            background-color: #eee; /* Light background for buttons */
+            color: #000; /* Dark text for buttons */
+            border: 1px solid #ccc; /* Border for buttons */
+        }
+
+        /* Dark theme styles */
+        @media (prefers-color-scheme: dark) {
+
+            .outer-container {
+                background-color: #1e1e1e; /* Dark background for the body */
+                color: #ffffff; /* Light text color for dark theme */
+            }
+
+            .dialog-container {
+                border: 1px solid #444; /* Darker border for the dialog */
+                background-color: #2a2a2a; /* Dark background for the dialog */
+            }
+
+            button {
+                background-color: #4a4a4a; /* Darker background for buttons */
+                color: #fff; /* Light text for buttons */
+                border: 1px solid #6a6a6a; /* Border for buttons */
+            }
+
+            button:hover {
+                background-color: #5a5a5a; /* Lighter background on hover for buttons */
+            }
+        }
+
+    </style>
     <script>
         const TRUSTED_ORIGINS = {
             'http://localhost:8000': true, // phcode dev server
@@ -32,6 +100,8 @@
         };
 
         const pageLoaderID = crypto.randomUUID();
+        let securityAlertAcknowledged = false;
+        let previewURL;
         function setupNavigationWatcher(controllingPhoenixInstanceID) {
             let livepreviewServerIframe = document.getElementById("live-preview-server-iframe");
             const LOG_LIVE_PREVIEW_KEY= "logLivePreview";
@@ -52,6 +122,10 @@
                 switch (type) {
                     case "REDIRECT_PAGE":
                         const url = event.data.url;
+                        previewURL = url;
+                        if(!securityAlertAcknowledged){
+                            return;
+                        }
                         _debugLog("Loading page: ", url);
                         document.getElementById("previewFrame").src = url;
                         break;
@@ -132,22 +206,46 @@
             const initialURL = queryParams.get('initialURL');
             const phoenixInstanceID = queryParams.get('phoenixInstanceID');
             const virtualServerURL = queryParams.get('virtualServerURL');
+            const localiseMessage = queryParams.get('localMessage');
+            const okMessage = queryParams.get('okMessage');
+
             if(!phoenixInstanceID || !initialURL || !virtualServerURL){
                 console.error("Expected required query strings: phoenixInstanceID, initialURL, virtualServerURL");
                 return;
             }
             let livepreviewServerIframe = document.getElementById("live-preview-server-iframe");
-            let url = `${decodeURIComponent(virtualServerURL)}?parentOrigin=${location.origin}`;
+            let serverURL = `${decodeURIComponent(virtualServerURL)}?parentOrigin=${location.origin}`;
             livepreviewServerIframe.addEventListener('load', function() {
-                document.getElementById('previewFrame').src = decodeURIComponent(initialURL);
                 setupNavigationWatcher(phoenixInstanceID);
             });
-            livepreviewServerIframe.setAttribute("src", url);
+            livepreviewServerIframe.setAttribute("src", serverURL);
+
+            okMessage && (document.getElementById('okButton').textContent = decodeURIComponent(okMessage));
+            localiseMessage && (document.getElementById('dialog-message').textContent = decodeURIComponent(localiseMessage));
+            const dialog = document.getElementById('outer-container');
+            previewURL = decodeURIComponent(initialURL);
+            document.getElementById('okButton').addEventListener('click', function() {
+                dialog.style.display = 'none';
+                document.getElementById('previewFrame').src = decodeURIComponent(previewURL);
+                securityAlertAcknowledged = true;
+            });
         }
 
     </script>
 </head>
 <body onload="navigateToInitialURL()">
+    <div id="outer-container" class="outer-container">
+        <div id='dialog-container' class="dialog-container">
+            <div class="dialog-title">Phoenix Code Live Preview</div>
+            <div id="dialog-message" class="dialog-message">
+                You are about to open an HTML file for live preview. Please proceed only if you trust the source of this project. Click 'OK' to continue, or close this window if you do not trust the source.
+            </div>
+            <div class="dialog-buttons">
+                <button id="okButton">Trust Project</button>
+            </div>
+        </div>
+    </div>
+
     <iframe id="live-preview-server-iframe"
             title="live preview server"
             src="about:blank"

--- a/src/live-preview-loader.html
+++ b/src/live-preview-loader.html
@@ -164,10 +164,19 @@
                             dialog.style.display = 'flex';
                         }
                         return;
+                    case 'TAB_LOADER_ONLINE': return; // loop-back message do nothing, this is for phoenix ot process.
                     default:
-                        console.error("Unknown live preivew broadcast message received!: ", event);
+                    console.error("Unknown live preivew broadcast message received!: ", event);
                 }
             }
+            setInterval(()=>{
+                // send page loader heartbeat
+                navigatorChannel.postMessage({
+                    type: 'TAB_LOADER_ONLINE',
+                    pageLoaderID: pageLoaderID,
+                    url: previewURL
+                });
+            }, 3000);
             livePreviewChannel.onmessage = (event) => {
                 _debugLog("Live Preview message channel: Browser received event from Phoenix: ", JSON.stringify(event.data));
                 if(event.data.pageLoaderID && event.data.pageLoaderID !== pageLoaderID){

--- a/src/live-preview-loader.html
+++ b/src/live-preview-loader.html
@@ -102,6 +102,8 @@
         const pageLoaderID = crypto.randomUUID();
         let securityAlertAcknowledged = false;
         let previewURL;
+        let trustedProjects = [];
+        let currentProjectRoot;
         function setupNavigationWatcher(controllingPhoenixInstanceID) {
             let livepreviewServerIframe = document.getElementById("live-preview-server-iframe");
             const LOG_LIVE_PREVIEW_KEY= "logLivePreview";
@@ -128,6 +130,22 @@
                         }
                         _debugLog("Loading page: ", url);
                         document.getElementById("previewFrame").src = url;
+                        break;
+                    case "PROJECT_SWITCH":
+                        currentProjectRoot = event.data.projectRoot;
+                        const dialog = document.getElementById('outer-container');
+                        if(trustedProjects[currentProjectRoot] && dialog){
+                            dialog.style.display = 'none';
+                            document.getElementById('previewFrame').src = decodeURIComponent(previewURL);
+                            securityAlertAcknowledged = true;
+                            return;
+                        }
+                        securityAlertAcknowledged = false;
+                        _debugLog("Project switched. Disable live preview tabs for security on untrusted project.");
+                        document.getElementById("previewFrame").src = 'about:blank';
+                        if(dialog){
+                            dialog.style.display = 'flex';
+                        }
                         break;
                     default:
                         console.error("Unknown live preivew broadcast message received!: ", event);
@@ -172,6 +190,14 @@
                 }
             });
 
+            document.getElementById('okButton').addEventListener('click', function() {
+                const dialog = document.getElementById('outer-container');
+                dialog.style.display = 'none';
+                document.getElementById('previewFrame').src = decodeURIComponent(previewURL);
+                securityAlertAcknowledged = true;
+                trustedProjects[currentProjectRoot] = true;
+            });
+
             // todo how ot send the title and favicon below
             // function convertImgToBase64(url, callback) {
             //     var canvas = document.createElement('CANVAS');
@@ -208,6 +234,7 @@
             const virtualServerURL = queryParams.get('virtualServerURL');
             const localiseMessage = queryParams.get('localMessage');
             const okMessage = queryParams.get('okMessage');
+            currentProjectRoot = queryParams.get('initialProjectRoot');
 
             if(!phoenixInstanceID || !initialURL || !virtualServerURL){
                 console.error("Expected required query strings: phoenixInstanceID, initialURL, virtualServerURL");
@@ -222,13 +249,7 @@
 
             okMessage && (document.getElementById('okButton').textContent = decodeURIComponent(okMessage));
             localiseMessage && (document.getElementById('dialog-message').textContent = decodeURIComponent(localiseMessage));
-            const dialog = document.getElementById('outer-container');
             previewURL = decodeURIComponent(initialURL);
-            document.getElementById('okButton').addEventListener('click', function() {
-                dialog.style.display = 'none';
-                document.getElementById('previewFrame').src = decodeURIComponent(previewURL);
-                securityAlertAcknowledged = true;
-            });
         }
 
     </script>

--- a/src/live-preview-loader.html
+++ b/src/live-preview-loader.html
@@ -130,7 +130,24 @@
                         }
                         _debugLog("Loading page: ", url);
                         document.getElementById("previewFrame").src = url;
-                        break;
+                        return;
+                    case "UPDATE_TITLE_ICON":
+                        // The live preview frame will send us its title and favicon for us to set the window
+                        // title and favicon. If it is that message, then, set it up
+                        const title = event.data.title;
+                        const faviconBase64 = event.data.faviconBase64;
+                        title && (document.title = title);
+                        if(faviconBase64){
+                            // Update the favicon
+                            let link = document.querySelector("link[rel~='icon']");
+                            if (!link) {
+                                link = document.createElement('link');
+                                link.rel = 'icon';
+                                document.getElementsByTagName('head')[0].appendChild(link);
+                            }
+                            link.href = event.data.faviconBase64;
+                        }
+                        return;
                     case "PROJECT_SWITCH":
                         currentProjectRoot = event.data.projectRoot;
                         const dialog = document.getElementById('outer-container');
@@ -146,7 +163,7 @@
                         if(dialog){
                             dialog.style.display = 'flex';
                         }
-                        break;
+                        return;
                     default:
                         console.error("Unknown live preivew broadcast message received!: ", event);
                 }
@@ -167,27 +184,11 @@
                     return;
                 }
 
-                // The live preview frame will send us its title and favicon for us to set the window
-                // title and favicon. IF its that message, then, set it up
-                if (event.data.title && event.data.faviconBase64) {
-                    // Update the title of the parent page
-                    document.title = event.data.title;
-
-                    // Update the favicon
-                    let link = document.querySelector("link[rel~='icon']");
-                    if (!link) {
-                        link = document.createElement('link');
-                        link.rel = 'icon';
-                        document.getElementsByTagName('head')[0].appendChild(link);
-                    }
-                    link.href = event.data.faviconBase64;
-                } else {
-                    // this is for phoenix to process, pass it on
-                    livePreviewChannel.postMessage({
-                        pageLoaderID: pageLoaderID,
-                        data: event.data
-                    });
-                }
+                // this is for phoenix to process, pass it on
+                livePreviewChannel.postMessage({
+                    pageLoaderID: pageLoaderID,
+                    data: event.data
+                });
             });
 
             document.getElementById('okButton').addEventListener('click', function() {
@@ -197,33 +198,6 @@
                 securityAlertAcknowledged = true;
                 trustedProjects[currentProjectRoot] = true;
             });
-
-            // todo how ot send the title and favicon below
-            // function convertImgToBase64(url, callback) {
-            //     var canvas = document.createElement('CANVAS');
-            //     var ctx = canvas.getContext('2d');
-            //     var img = new Image();
-            //     img.crossOrigin = 'Anonymous';
-            //     img.onload = function() {
-            //         canvas.height = img.height;
-            //         canvas.width = img.width;
-            //         ctx.drawImage(img, 0, 0);
-            //         var dataURL = canvas.toDataURL();
-            //         callback(dataURL);
-            //         canvas = null;
-            //     };
-            //     img.src = url;
-            // }
-            //
-            // window.onload = function() {
-            //     var faviconUrl = document.querySelector("link[rel~='icon']").href;
-            //     convertImgToBase64(faviconUrl, function(base64) {
-            //         window.parent.postMessage({
-            //             title: document.title,
-            //             faviconBase64: base64
-            //         }, '*'); // Replace '*' with actual parent origin for security
-            //     });
-            // };
 
         }
 

--- a/src/live-preview-loader.html
+++ b/src/live-preview-loader.html
@@ -214,11 +214,9 @@
                 console.error("Expected required query strings: phoenixInstanceID, initialURL, virtualServerURL");
                 return;
             }
+            setupNavigationWatcher(phoenixInstanceID);
             let livepreviewServerIframe = document.getElementById("live-preview-server-iframe");
             let serverURL = `${decodeURIComponent(virtualServerURL)}?parentOrigin=${location.origin}`;
-            livepreviewServerIframe.addEventListener('load', function() {
-                setupNavigationWatcher(phoenixInstanceID);
-            });
             livepreviewServerIframe.setAttribute("src", serverURL);
 
             okMessage && (document.getElementById('okButton').textContent = decodeURIComponent(okMessage));

--- a/src/live-preview-loader.html
+++ b/src/live-preview-loader.html
@@ -137,9 +137,9 @@
                 return;
             }
             let livepreviewServerIframe = document.getElementById("live-preview-server-iframe");
-            let url = `${virtualServerURL}?parentOrigin=${location.origin}`;
+            let url = `${decodeURIComponent(virtualServerURL)}?parentOrigin=${location.origin}`;
             livepreviewServerIframe.addEventListener('load', function() {
-                document.getElementById('previewFrame').src = initialURL;
+                document.getElementById('previewFrame').src = decodeURIComponent(initialURL);
                 setupNavigationWatcher(phoenixInstanceID);
             });
             livepreviewServerIframe.setAttribute("src", url);

--- a/src/live-preview.html
+++ b/src/live-preview.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Phoenix Live Preview Loader...</title>
+    <style>
+        html, body {
+            margin: 0;
+            padding: 0;
+            height: 100%;
+            overflow: hidden;
+        }
+        iframe {
+            width: 100%;
+            height: 100%;
+            border: none; /* Removes the default border around an iframe */
+        }
+    </style>
+    <script>
+        const TRUSTED_ORIGINS = {
+            'http://localhost:8000': true, // phcode dev server
+            'http://localhost:8001': true, // phcode dev live preview server
+            'http://localhost:5000': true, // playwright tests
+            'http://127.0.0.1:8000': true, // phcode dev server
+            'http://127.0.0.1:8001': true, // phcode dev live preview server
+            'http://127.0.0.1:5000': true, // playwright tests
+            'https://phcode.live': true, // phcode prod live preview server
+            'https://phcode.dev': true,
+            'https://dev.phcode.dev': true,
+            'https://staging.phcode.dev': true,
+            'https://create.phcode.dev': true
+        };
+
+        const pageLoaderID = crypto.randomUUID();
+        function setupNavigationWatcher(controllingPhoenixInstanceID) {
+            let livepreviewServerIframe = document.getElementById("live-preview-server-iframe");
+            const LOG_LIVE_PREVIEW_KEY= "logLivePreview";
+            let loggingEnabled = localStorage.getItem(LOG_LIVE_PREVIEW_KEY) || "false";
+            const isLoggingEnabled = loggingEnabled.toLowerCase() === 'true';
+            function _debugLog(...args) {
+                if(isLoggingEnabled) {
+                    console.log(...args);
+                }
+            }
+            const LOADER_BROADCAST_ID = `live-preview-loader-${controllingPhoenixInstanceID}`;
+            const navigatorChannel = new BroadcastChannel(LOADER_BROADCAST_ID);
+            const LIVE_PREVIEW_MESSENGER_CHANNEL = `live-preview-messenger-${controllingPhoenixInstanceID}`;
+            const livePreviewChannel = new BroadcastChannel(LIVE_PREVIEW_MESSENGER_CHANNEL);
+            navigatorChannel.onmessage = (event) => {
+                _debugLog("Live Preview loader channel: Browser received event from Phoenix: ", JSON.stringify(event.data));
+                const type = event.data.type;
+                switch (type) {
+                    case "REDIRECT_PAGE":
+                        const url = event.data.url;
+                        _debugLog("Loading page: ", url);
+                        document.getElementById("previewFrame").src = url;
+                        break;
+                    default:
+                        console.error("Unknown live preivew broadcast message received!: ", event);
+                }
+            }
+            livePreviewChannel.onmessage = (event) => {
+                _debugLog("Live Preview message channel: Browser received event from Phoenix: ", JSON.stringify(event.data));
+                if(event.data.pageLoaderID && event.data.pageLoaderID !== pageLoaderID){
+                    // this message is not for this page loader window.
+                    return;
+                }
+                // This is intended to the embedded live preview server frame which processes the request. just pass
+                livepreviewServerIframe.contentWindow.postMessage(event.data.data, '*');
+            }
+            // These messages are sent from either the live preview frame or the server frame.
+            window.addEventListener('message', function(event) {
+                // Security check: ensure the message is from the expected domain
+                if (!TRUSTED_ORIGINS[event.origin]) {
+                    return;
+                }
+
+                // The live preview frame will send us its title and favicon for us to set the window
+                // title and favicon. IF its that message, then, set it up
+                if (event.data.title && event.data.faviconBase64) {
+                    // Update the title of the parent page
+                    document.title = event.data.title;
+
+                    // Update the favicon
+                    let link = document.querySelector("link[rel~='icon']");
+                    if (!link) {
+                        link = document.createElement('link');
+                        link.rel = 'icon';
+                        document.getElementsByTagName('head')[0].appendChild(link);
+                    }
+                    link.href = event.data.faviconBase64;
+                } else {
+                    // this is for phoenix to process, pass it on
+                    livePreviewChannel.postMessage({
+                        pageLoaderID: pageLoaderID,
+                        data: event.data
+                    });
+                }
+            });
+
+            // todo how ot send the title and favicon below
+            // function convertImgToBase64(url, callback) {
+            //     var canvas = document.createElement('CANVAS');
+            //     var ctx = canvas.getContext('2d');
+            //     var img = new Image();
+            //     img.crossOrigin = 'Anonymous';
+            //     img.onload = function() {
+            //         canvas.height = img.height;
+            //         canvas.width = img.width;
+            //         ctx.drawImage(img, 0, 0);
+            //         var dataURL = canvas.toDataURL();
+            //         callback(dataURL);
+            //         canvas = null;
+            //     };
+            //     img.src = url;
+            // }
+            //
+            // window.onload = function() {
+            //     var faviconUrl = document.querySelector("link[rel~='icon']").href;
+            //     convertImgToBase64(faviconUrl, function(base64) {
+            //         window.parent.postMessage({
+            //             title: document.title,
+            //             faviconBase64: base64
+            //         }, '*'); // Replace '*' with actual parent origin for security
+            //     });
+            // };
+
+        }
+
+        function navigateToInitialURL() {
+            const queryParams = new URLSearchParams(window.location.search);
+            const initialURL = queryParams.get('initialURL');
+            const phoenixInstanceID = queryParams.get('phoenixInstanceID');
+            const virtualServerURL = queryParams.get('virtualServerURL');
+            if(!phoenixInstanceID || !initialURL || !virtualServerURL){
+                console.error("Expected required query strings: phoenixInstanceID, initialURL, virtualServerURL");
+                return;
+            }
+            let livepreviewServerIframe = document.getElementById("live-preview-server-iframe");
+            let url = `${virtualServerURL}?parentOrigin=${location.origin}`;
+            livepreviewServerIframe.addEventListener('load', function() {
+                document.getElementById('previewFrame').src = initialURL;
+                setupNavigationWatcher(phoenixInstanceID);
+            });
+            livepreviewServerIframe.setAttribute("src", url);
+        }
+
+    </script>
+</head>
+<body onload="navigateToInitialURL()">
+    <iframe id="live-preview-server-iframe"
+            title="live preview server"
+            src="about:blank"
+            style="width:100%;"
+            sandbox="allow-same-origin allow-scripts"
+            hidden>
+    </iframe>
+    <iframe id="previewFrame"
+            title="live preview"
+            src="about:blank"
+            sandbox="allow-same-origin allow-scripts allow-popups allow-forms allow-modals allow-pointer-lock">
+    </iframe>
+</body>
+</html>

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -904,6 +904,8 @@ define({
     "DESCRIPTION_LIVEDEV_MAIN_HEADING": "Uh Oh! <br>Your current browser doesn't support live preview.",
     "DESCRIPTION_LIVEDEV_MAIN_SPAN": "Get the best live preview experience by downloading our native apps for Windows, Mac, and Linux from <a href=\"https://phcode.io\" style=\"color: white\">phcode.io</a>.<br>",
     "DESCRIPTION_LIVEDEV_SECURITY": "Security Warning from phcode.dev<br><br> This live preview attempted to access a non-project file. Access was denied for your safety. Please exercise caution when working on untrusted projects.",
+    "DESCRIPTION_LIVEDEV_SECURITY_POPOUT_MESSAGE": "You are about to open a file for live preview. Please proceed only if you trust the source of this project. Click 'Trust Project' to continue, or close this window if you do not trust the source.",
+    "TRUST_PROJECT": "Trust Project",
 
     // Strings for Auto Update
     "DOWNLOAD_FAILED": "Download failed.",

--- a/src/node-loader.js
+++ b/src/node-loader.js
@@ -613,6 +613,8 @@ function nodeLoader() {
 
         window.__TAURI__.path.resolveResource("src-node/index.js")
             .then(async nodeSrcPath=>{
+                // node is designed such that it is not required at boot time to lower startup time.
+                // Keep this so to increase boot speed.
                 const inspectPort = Phoenix.isTestWindow ? getRandomNumber(5000, 50000) : 9229;
                 const argsArray = isInspectEnabled() ? [`--inspect=${inspectPort}`, nodeSrcPath] : [nodeSrcPath, ''];
                 command = window.__TAURI__.shell.Command.sidecar('phnode', argsArray);
@@ -688,6 +690,8 @@ function nodeLoader() {
                         fs.forceUseNodeWSEndpoint(true);
                         setNodeWSEndpoint(message.phoenixNodeURL);
                         resolve(message);
+                        // node is designed such that it is not required at boot time to lower startup time.
+                        // Keep this so to increase boot speed.
                         window.PhNodeEngine._nodeLoadTime = Date.now() - nodeLoadstartTime;
                     });
                 execNode(NODE_COMMANDS.SET_DEBUG_MODE, window.debugMode);

--- a/src/phoenix/shell.js
+++ b/src/phoenix/shell.js
@@ -212,7 +212,7 @@ Phoenix.app = {
     getUserProjectsDirectory: Phoenix.VFS.getUserProjectsDirectory,
     getTempDirectory: Phoenix.VFS.getTempDir,
     ERR_CODES: ERR_CODES,
-    getElapsedMilliseconds: function () {
+    getTimeSinceStartup: function () {
         return Date.now() - Phoenix.startTime; // milliseconds elapsed since app start
     },
     language: navigator.language

--- a/src/storage.js
+++ b/src/storage.js
@@ -278,7 +278,7 @@
         watchExternalChanges,
         unwatchExternalChanges,
         storageReadyPromise,
-        _storageBootstrapTime: Phoenix.app.getTimeSinceStartup()
+        _storageBootstrapTime: Date.now() - Phoenix.startTime
     };
     if(Phoenix.isTestWindow) {
         PhStore._setTestKey = function (testKey) {

--- a/src/storage.js
+++ b/src/storage.js
@@ -277,7 +277,8 @@
         flushDB,
         watchExternalChanges,
         unwatchExternalChanges,
-        storageReadyPromise
+        storageReadyPromise,
+        _storageBootstrapTime: Phoenix.app.getTimeSinceStartup()
     };
     if(Phoenix.isTestWindow) {
         PhStore._setTestKey = function (testKey) {

--- a/src/utils/PerfUtils.js
+++ b/src/utils/PerfUtils.js
@@ -35,7 +35,7 @@ define(function (require, exports, module) {
      * Flag to enable/disable performance data gathering. Default is true (enabled)
      * @type {boolean} enabled
      */
-    var enabled = brackets && !!brackets.app.getElapsedMilliseconds;
+    var enabled = brackets && !!brackets.app.getTimeSinceStartup;
 
     /**
      * Performance data is stored in this hash object. The key is the name of the
@@ -161,7 +161,7 @@ define(function (require, exports, module) {
             return;
         }
 
-        var time = brackets.app.getElapsedMilliseconds();
+        var time = brackets.app.getTimeSinceStartup();
         var id = _generatePerfMeasurements(name);
         var i;
 
@@ -191,7 +191,7 @@ define(function (require, exports, module) {
             id = new PerfMeasurement(id, id);
         }
 
-        let elapsedTime = brackets.app.getElapsedMilliseconds();
+        let elapsedTime = brackets.app.getTimeSinceStartup();
 
         if (activeTests[id.id]) {
             elapsedTime -= activeTests[id.id].startTime;
@@ -241,7 +241,7 @@ define(function (require, exports, module) {
      * @param {Object} id  Timer id.
      */
     function updateMeasurement(id) {
-        var elapsedTime = brackets.app.getElapsedMilliseconds();
+        var elapsedTime = brackets.app.getTimeSinceStartup();
 
         if (updatableTests[id.id]) {
             // update existing measurement

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -117,6 +117,7 @@
         const appLocalDirPromise =  window.__TAURI__.path.appLocalDataDir();
         const tempDirPromise = window.__TAURI__.os.tempdir();
         window._tauriBootVars = {};
+        const tauriBootStartTime = Date.now();
         window._tauriBootVarsPromise = Promise.all([appNamePromise, documentDirPromise,
           appLocalDirPromise, tempDirPromise])
                 .then((results) => {
@@ -131,6 +132,7 @@
                   //Documents dir special case for tests
                   window._tauriBootVars.appLocalDir = results[2];
                   window._tauriBootVars.tempDir = results[3];
+                  window._tauriBootVars.bootstrapTime = Date.now() - tauriBootStartTime;
                 });
       }
       setupTauriBootVars();

--- a/test/spec/LiveDevelopmentMultiBrowser-test.js
+++ b/test/spec/LiveDevelopmentMultiBrowser-test.js
@@ -479,8 +479,7 @@ define(function (require, exports, module) {
             await awaits(500);
             iFrame = testWindow.document.getElementById("panel-live-preview-frame");
             let srcURL = new URL(iFrame.src);
-            expect(srcURL.pathname.endsWith("pageLoader.html")).toBeTrue();
-            expect(srcURL.searchParams.get("URL").endsWith("sub/icon_chevron.png")).toBeTrue();
+            expect(srcURL.pathname.endsWith("sub/icon_chevron.png")).toBeTrue();
 
             // now switch back to old file
             await _editFileAndVerifyLivePreview("simple1.html", {line: 11, ch: 45}, 'hello world ',
@@ -511,7 +510,7 @@ define(function (require, exports, module) {
             await endPreviewSession();
         }, 30000);
 
-        it("should pin live previews ping html file", async function () {
+        it("should pin live previews pin html file", async function () {
             await awaitsForDone(SpecRunnerUtils.openProjectFiles(["simple1.html"]),
                 "SpecRunnerUtils.openProjectFiles simple1.html");
 
@@ -534,8 +533,7 @@ define(function (require, exports, module) {
             await awaits(1000);
             let outerIFrame = testWindow.document.getElementById("panel-live-preview-frame");
             let srcURL = new URL(outerIFrame.src);
-            expect(srcURL.pathname.endsWith("pageLoader.html")).toBeTrue();
-            expect(srcURL.searchParams.get("URL").endsWith("sub/icon_chevron.png")).toBeTrue();
+            expect(srcURL.pathname.endsWith("sub/icon_chevron.png")).toBeTrue();
 
             await endPreviewSession();
         }, 30000);


### PR DESCRIPTION
Externally opened tabs will now show a live preview warning. This is so that if a live preview has the same url as `phcode.dev` and it may mislead the user if the live preview tries to show off itself as phcode.dev when user opens an untrusted project.

So on evry project switch/new tab open, we will show the trust live preview dialog. This is only an issue in browser as in desktop, live previews will be loaded from loaclhost instead of virtual server at `phcode.dev`.
![image](https://github.com/phcode-dev/phoenix/assets/5336369/d7fa944a-75f2-4c6d-b0ee-55646a824564)