### PR TITLE
feat: add a trust project for live preview in phoenix iframe- browser only

### DIFF
--- a/src/extensions/default/Phoenix-live-preview/trust-project.html
+++ b/src/extensions/default/Phoenix-live-preview/trust-project.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Phoenix Live Preview Loader...</title>
+    <style>
+        html, body {
+            margin: 0;
+            padding: 0;
+            height: 100%;
+            overflow: hidden;
+        }
+        iframe {
+            width: 100%;
+            height: 100%;
+            border: none; /* Removes the default border around an iframe */
+        }
+    </style>
+    <style>
+
+        .outer-container {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            z-index: 2;
+        }
+
+        .dialog-container {
+            border: 1px solid #ccc;
+            background-color: #fff;
+            padding: 20px;
+            box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1);
+            /* Other styles remain the same */
+        }
+
+        .dialog-title {
+            font-size: 1.2em;
+            margin-bottom: 10px;
+        }
+
+        .dialog-message {
+            margin-bottom: 20px;
+        }
+
+        .dialog-buttons {
+            text-align: right;
+        }
+
+        button {
+            padding: 5px 10px;
+            margin-left: 10px;
+            background-color: #eee; /* Light background for buttons */
+            color: #000; /* Dark text for buttons */
+            border: 1px solid #ccc; /* Border for buttons */
+        }
+
+        /* Dark theme styles */
+        @media (prefers-color-scheme: dark) {
+
+            .outer-container {
+                background-color: #1e1e1e; /* Dark background for the body */
+                color: #ffffff; /* Light text color for dark theme */
+            }
+
+            .dialog-container {
+                border: 1px solid #444; /* Darker border for the dialog */
+                background-color: #2a2a2a; /* Dark background for the dialog */
+            }
+
+            button {
+                background-color: #4a4a4a; /* Darker background for buttons */
+                color: #fff; /* Light text for buttons */
+                border: 1px solid #6a6a6a; /* Border for buttons */
+            }
+
+            button:hover {
+                background-color: #5a5a5a; /* Lighter background on hover for buttons */
+            }
+        }
+
+    </style>
+    <script>
+        let okMessageTemplate;
+        let currentProjectRoot;
+
+        function getTrustOkButton() {
+            if(! okMessageTemplate){
+                return "Trust Project?";
+            }
+            if(!currentProjectRoot){
+                return okMessageTemplate.replace("{0}", "");
+            }
+            let projectName = currentProjectRoot;
+            if(projectName.endsWith("/")){
+                projectName = projectName.slice(0, -1);
+            }
+            projectName = projectName.split("/");
+            projectName = projectName[projectName.length-1];
+            return okMessageTemplate.replace("{0}", projectName);
+        }
+
+        function navigateToInitialURL() {
+            const queryParams = new URLSearchParams(window.location.search);
+            const localiseMessage = queryParams.get('localMessage');
+            okMessageTemplate = decodeURIComponent(queryParams.get('okMessage'));
+            currentProjectRoot = queryParams.get('initialProjectRoot');
+
+            if(!okMessageTemplate || !currentProjectRoot){
+                console.error("Expected required query strings: okMessageTemplate, currentProjectRoot");
+                return;
+            }
+
+            document.getElementById('okButton').textContent = getTrustOkButton();
+            localiseMessage && (document.getElementById('dialog-message').textContent = decodeURIComponent(localiseMessage));
+            document.getElementById('okButton').addEventListener('click', function() {
+                window.parent._trustCurrentProjectForLivePreview();
+            });
+        }
+
+    </script>
+</head>
+<body onload="navigateToInitialURL()">
+<div id="outer-container" class="outer-container">
+    <div id='dialog-container' class="dialog-container">
+        <div class="dialog-title">Phoenix Code Live Preview</div>
+        <div id="dialog-message" class="dialog-message">
+            You are about to open an HTML file for live preview. Please proceed only if you trust the source of this project. Click 'OK' to continue, or close this window if you do not trust the source.
+        </div>
+        <div class="dialog-buttons">
+            <button id="okButton">Trust Project</button>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/live-preview-loader.html
+++ b/src/live-preview-loader.html
@@ -98,6 +98,7 @@
             'https://staging.phcode.dev': true,
             'https://create.phcode.dev': true
         };
+        let okMessageTemplate;
 
         function isTrustedURL(url) {
             if(!url){
@@ -116,6 +117,23 @@
         let previewURL;
         let trustedProjects = [];
         let currentProjectRoot;
+
+        function getTrustOkButton() {
+            if(! okMessageTemplate){
+                return "Trust Project?";
+            }
+            if(!currentProjectRoot){
+                return okMessageTemplate.replace("{0}", "");
+            }
+            let projectName = currentProjectRoot;
+            if(projectName.endsWith("/")){
+                projectName = projectName.slice(0, -1);
+            }
+            projectName = projectName.split("/");
+            projectName = projectName[projectName.length-1];
+            return okMessageTemplate.replace("{0}", projectName);
+        }
+
         function setupNavigationWatcher(controllingPhoenixInstanceID) {
             let livepreviewServerIframe = document.getElementById("live-preview-server-iframe");
             const LOG_LIVE_PREVIEW_KEY= "logLivePreview";
@@ -164,6 +182,7 @@
                         return;
                     case "PROJECT_SWITCH":
                         currentProjectRoot = event.data.projectRoot;
+                        document.getElementById('okButton').textContent = getTrustOkButton();
                         if(trustedProjects[currentProjectRoot] && dialog){
                             dialog.style.display = 'none';
                             if(isTrustedURL(previewURL)){
@@ -233,7 +252,7 @@
             const phoenixInstanceID = queryParams.get('phoenixInstanceID');
             const virtualServerURL = queryParams.get('virtualServerURL');
             const localiseMessage = queryParams.get('localMessage');
-            const okMessage = queryParams.get('okMessage');
+            okMessageTemplate = decodeURIComponent(queryParams.get('okMessage'));
             currentProjectRoot = queryParams.get('initialProjectRoot');
 
             if(!phoenixInstanceID || !initialURL || !virtualServerURL){
@@ -247,7 +266,7 @@
                 livepreviewServerIframe.setAttribute("src", serverURL);
             }
 
-            okMessage && (document.getElementById('okButton').textContent = decodeURIComponent(okMessage));
+            document.getElementById('okButton').textContent = getTrustOkButton();
             localiseMessage && (document.getElementById('dialog-message').textContent = decodeURIComponent(localiseMessage));
             previewURL = decodeURIComponent(initialURL);
         }

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -905,7 +905,7 @@ define({
     "DESCRIPTION_LIVEDEV_MAIN_SPAN": "Get the best live preview experience by downloading our native apps for Windows, Mac, and Linux from <a href=\"https://phcode.io\" style=\"color: white\">phcode.io</a>.<br>",
     "DESCRIPTION_LIVEDEV_SECURITY": "Security Warning from phcode.dev<br><br> This live preview attempted to access a non-project file. Access was denied for your safety. Please exercise caution when working on untrusted projects.",
     "DESCRIPTION_LIVEDEV_SECURITY_POPOUT_MESSAGE": "You are about to open a file for live preview. Please proceed only if you trust the source of this project. Click 'Trust Project' to continue, or close this window if you do not trust the source.",
-    "TRUST_PROJECT": "Trust Project",
+    "TRUST_PROJECT": "Trust Project - {0}",
 
     // Strings for Auto Update
     "DOWNLOAD_FAILED": "Download failed.",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -905,6 +905,7 @@ define({
     "DESCRIPTION_LIVEDEV_MAIN_SPAN": "Get the best live preview experience by downloading our native apps for Windows, Mac, and Linux from <a href=\"https://phcode.io\" style=\"color: white\">phcode.io</a>.<br>",
     "DESCRIPTION_LIVEDEV_SECURITY": "Security Warning from phcode.dev<br><br> This live preview attempted to access a non-project file. Access was denied for your safety. Please exercise caution when working on untrusted projects.",
     "DESCRIPTION_LIVEDEV_SECURITY_POPOUT_MESSAGE": "You are about to open a file for live preview. Please proceed only if you trust the source of this project. Click 'Trust Project' to continue, or close this window if you do not trust the source.",
+    "DESCRIPTION_LIVEDEV_SECURITY_TRUST_MESSAGE": "You are about to open a file for live preview. Please proceed by clicking 'Trust Project' only if you trust the source of this project!",
     "TRUST_PROJECT": "Trust Project - {0}",
 
     // Strings for Auto Update

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -756,7 +756,7 @@ define(function (require, exports, module) {
     }
 
     function getExploreProjectPath() {
-        return `${getLocalProjectsPath()}explore`;
+        return `${getLocalProjectsPath()}explore/`;
     }
 
     /**


### PR DESCRIPTION
## Improve live preview safety.
 In desktop builds, each project is securely sandboxed in its own live preview server:port domain.
This setup ensures security within the browser sandbox, eliminating the need for a trust confirmation dialog. We can display the live preview immediately.

 In browsers, since all live previews for all projects uses the same `phcode.live` domain,  untrusted projects can access data of past opened projects. So we have to show a `trust project?`  dialog in live preview in browser.

 Future plans for browser versions include adopting a similar approach to dynamically generate URLs in the format `project-name.phcode.live`. This will streamline the workflow by removing the current reliance on users to manually verify and trust each project in the browser.

![image](https://github.com/phcode-dev/phoenix/assets/5336369/2b09e7ff-30fc-4e92-bb16-76289c8d014c)


## Other fixes
![image](https://github.com/phcode-dev/phoenix/assets/5336369/f48e076a-33e7-4a12-84ba-1e80453668f2)

```console
QuickViewManager.js:457 [Deprecation] Listener added for a synchronous 'DOMSubtreeModified' DOM Mutation Event. This event type is deprecated (https://w3c.github.io/uievents/#legacy-event-types) and work is underway to remove it from this browser. Usage of this event listener will cause performance issues today, and represents a risk of future incompatibility. Consider using MutationObserver instead.
```