### PR TITLE
fix: 1.live preview start speed, 2.flicker 3.not showing in untrusted projects

### DIFF
--- a/src/extensions/default/Phoenix-live-preview/StaticServer.js
+++ b/src/extensions/default/Phoenix-live-preview/StaticServer.js
@@ -51,6 +51,7 @@ define(function (require, exports, module) {
     const EVENT_TAB_ONLINE = 'TAB_ONLINE';
     const EVENT_REPORT_ERROR = 'REPORT_ERROR';
     const EVENT_UPDATE_TITLE_ICON = 'UPDATE_TITLE_AND_ICON';
+    const EVENT_SERVER_READY = 'SERVER_READY';
 
     EventDispatcher.makeEventDispatcher(exports);
     const PHCODE_LIVE_PREVIEW_QUERY_PARAM = "phcodeLivePreview";
@@ -569,4 +570,5 @@ define(function (require, exports, module) {
     exports.getTabPopoutURL = getTabPopoutURL;
     exports.hasActiveLivePreviews = hasActiveLivePreviews;
     exports.PHCODE_LIVE_PREVIEW_QUERY_PARAM = PHCODE_LIVE_PREVIEW_QUERY_PARAM;
+    exports.EVENT_SERVER_READY = EVENT_SERVER_READY;
 });


### PR DESCRIPTION
## Fixes three issues

1. Increase live preview startup speed by removing 1 second start delay and only relying on server start event to trigger preview show.
2. Live preview briefls flickers a github 404 on very first boot(test in incognito window) as the vritual server is being setup. This is fixed as we now only open preview pane after server start event.
3. On untrusted projects on boot, the live preview was a blank page which never switched on.