### PR TITLE
chore: move to indexed db for PhStore instead of localstorage with 5MB Storage limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ src/phoenix/virtualfs.js.map
 /src/thirdparty/tinycolor.js
 /src/thirdparty/jquery.knob.min.js
 /src/thirdparty/underscore-min.js
+/src/thirdparty/idb-keyval.js
 /src/thirdparty/bootstrap
 /src/thirdparty/highlight.js
 /src/thirdparty/gfm.min.css

--- a/gulpfile.js/thirdparty-lib-copy.js
+++ b/gulpfile.js/thirdparty-lib-copy.js
@@ -110,6 +110,9 @@ let copyThirdPartyLibs = series(
     // underscore
     copyFiles.bind(copyFiles, ['node_modules/underscore/underscore-min.js'], 'src/thirdparty'),
     copyLicence.bind(copyLicence, 'node_modules/underscore/LICENSE', 'underscore'),
+    // idb-keyval
+    renameFile.bind(renameFile, 'node_modules/idb-keyval/dist/index.js', 'idb-keyval.js', 'src/thirdparty/'),
+    copyLicence.bind(copyLicence, 'node_modules/idb-keyval/LICENCE', 'idb-keyval'),
     // bootstrap
     copyFiles.bind(copyFiles, ['node_modules/bootstrap/dist/js/bootstrap.min.js',
         'node_modules/bootstrap/dist/js/bootstrap.min.js.map',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "phoenix",
-    "version": "3.2.16-0",
+    "version": "3.2.17-0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "phoenix",
-            "version": "3.2.16-0",
+            "version": "3.2.17-0",
             "dependencies": {
                 "@bugsnag/js": "^7.18.0",
                 "@floating-ui/dom": "^0.5.4",
@@ -21,6 +21,7 @@
                 "cross-env": "^7.0.3",
                 "devicon": "^2.15.1",
                 "file-saver": "^2.0.5",
+                "idb-keyval": "^6.2.1",
                 "jshint": "^2.13.5",
                 "jszip": "^3.8.0",
                 "less": "^4.1.3",
@@ -10773,6 +10774,11 @@
             "engines": {
                 "node": ">=0.8.0"
             }
+        },
+        "node_modules/idb-keyval": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.1.tgz",
+            "integrity": "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg=="
         },
         "node_modules/ignore": {
             "version": "5.2.4",
@@ -26720,6 +26726,11 @@
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.4.tgz",
             "integrity": "sha1-6V8uQdsHNfwhZS94J6XuMuY8g6g=",
             "dev": true
+        },
+        "idb-keyval": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.1.tgz",
+            "integrity": "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg=="
         },
         "ignore": {
             "version": "5.2.4",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
         "cross-env": "^7.0.3",
         "devicon": "^2.15.1",
         "file-saver": "^2.0.5",
+        "idb-keyval": "^6.2.1",
         "jshint": "^2.13.5",
         "jszip": "^3.8.0",
         "less": "^4.1.3",

--- a/src/index.html
+++ b/src/index.html
@@ -467,10 +467,22 @@
             function _requireDone() {
                 loadJS('verify-dependencies-loaded.js', null, document.body);
             }
-            PhStore.storageReadyPromise
-                .finally(()=>{
-                    loadJS('thirdparty/requirejs/require.js', _requireDone, document.body, "main");
-                });
+            if(window.PhStore){
+                window.PhStore.storageReadyPromise
+                    .finally(()=>{
+                        loadJS('thirdparty/requirejs/require.js', _requireDone, document.body, "main");
+                    });
+            } else {
+                const interval = setInterval(()=>{
+                    if(PhStore){
+                        clearInterval(interval);
+                        PhStore.storageReadyPromise
+                            .finally(()=>{
+                                loadJS('thirdparty/requirejs/require.js', _requireDone, document.body, "main");
+                            });
+                    }
+                }, 50);
+            }
         }
     </script>
 

--- a/src/index.html
+++ b/src/index.html
@@ -467,7 +467,10 @@
             function _requireDone() {
                 loadJS('verify-dependencies-loaded.js', null, document.body);
             }
-            loadJS('thirdparty/requirejs/require.js', _requireDone, document.body, "main");
+            PhStore.storageReadyPromise
+                .finally(()=>{
+                    loadJS('thirdparty/requirejs/require.js', _requireDone, document.body, "main");
+                });
         }
     </script>
 
@@ -487,7 +490,7 @@
     <script src="phoenix/virtual-server-loader.js" type="module" defer></script>
 <!--    node loader should come only after fs libs are loaded as we init fs libs with node fs urls-->
     <script src="node-loader.js" defer></script>
-    <script src="storage.js" defer></script>
+    <script src="storage.js" type="module"></script>
     <!-- end javascript module scripts-->
 
     <!-- CSS/LESS -->

--- a/src/thirdparty/licences/idb-keyval.markdown
+++ b/src/thirdparty/licences/idb-keyval.markdown
@@ -1,0 +1,13 @@
+Copyright 2016, Jake Archibald
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -474,6 +474,33 @@
           window.location.href = `${currentUrl.origin}${currentUrl.pathname}?${queryString}`;
         });
       }
+      var loadJS = function(url, implementationCode, location, dataMainValue){
+        //url is URL of external file, implementationCode is the code
+        //to be called from the file, location is the location to
+        //insert the <script> element
+
+        const scriptTag = document.createElement('script');
+        if(dataMainValue){
+          scriptTag.setAttribute('data-main', dataMainValue);
+        }
+        scriptTag.onload = implementationCode;
+        scriptTag.onreadystatechange = implementationCode;
+        scriptTag.src = url;
+
+        location.appendChild(scriptTag);
+      };
+      function _requireDone() {
+        // do nothing
+      }
+      const interval = setInterval(()=>{
+        if(PhStore){
+          clearInterval(interval);
+          PhStore.storageReadyPromise
+                  .finally(()=>{
+                    loadJS('../src/thirdparty/requirejs/require.js', _requireDone, document.body, "SpecRunner");
+                  });
+        }
+      }, 100);
     }
 
   </script>
@@ -536,7 +563,5 @@
     <div id="mock-main-view" style="position:absolute; height:1000px; width:1000px; left:-10000px; top:-10000px;"></div>
     <div id="toast-notification-container">
     </div>
-    <!-- All other scripts are loaded through require. -->
-    <script src="../src/thirdparty/requirejs/require.js" data-main="SpecRunner"></script>
 </body>
 </html>

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -302,7 +302,7 @@
   <script src="../src/phoenix/shell.js" type="module"></script>
   <script src="virtual-server-loader.js" type="module"></script>
   <script src="../src/node-loader.js"></script>
-  <script src="../src/storage.js"></script>
+  <script src="../src/storage.js" type="module"></script>
 
   <link href="../src/thirdparty/bootstrap/bootstrap.min.css" rel="stylesheet">
   <link href="../src/thirdparty/bootstrap/bootstrap-grid.min.css" rel="stylesheet">


### PR DESCRIPTION
Browsers can only store up to 5 MiB of local storage, so we have to move to indexed DB for PhStore in browser - https://developer.mozilla.org/en-US/docs/Web/API/Storage_API/Storage_quotas_and_eviction_criteria#web_storage