### PR TITLE
fix: live preview should allow tab popout on window.open or href click

### DIFF
--- a/src/extensions/default/Phoenix-live-preview/main.js
+++ b/src/extensions/default/Phoenix-live-preview/main.js
@@ -68,7 +68,7 @@ define(function (require, exports, module) {
     <iframe id="panel-live-preview-frame" title="Live Preview" style="border: none"
              width="100%" height="100%" seamless="true"
              src='about:blank'
-             sandbox="allow-same-origin allow-scripts allow-forms allow-modals allow-pointer-lock">
+             sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-scripts allow-forms allow-modals allow-pointer-lock">
     </iframe>
     `;
 

--- a/src/extensions/default/Phoenix-live-preview/panel.html
+++ b/src/extensions/default/Phoenix-live-preview/panel.html
@@ -19,7 +19,7 @@
         <div style="width: 3px;"></div>
         <iframe id="panel-live-preview-frame" title="Live Preview" style="border: none"
                 width="100%" height="100%" seamless="true" srcdoc='<img width="50px" src="styles/images/Spinner-1s-200px.svg">'
-                sandbox="allow-same-origin allow-scripts allow-forms allow-modals allow-pointer-lock">
+                sandbox="allow-same-origin allow-popups-to-escape-sandbox allow-popups allow-scripts allow-forms allow-modals allow-pointer-lock">
         </iframe>
     </div>
 </div>

--- a/src/live-preview-loader.html
+++ b/src/live-preview-loader.html
@@ -296,7 +296,7 @@
     <iframe id="previewFrame"
             title="live preview"
             src="about:blank"
-            sandbox="allow-same-origin allow-scripts allow-popups allow-forms allow-modals allow-pointer-lock">
+            sandbox="allow-same-origin allow-scripts allow-popups allow-popups-to-escape-sandbox allow-forms allow-modals allow-pointer-lock">
     </iframe>
 </body>
 </html>


### PR DESCRIPTION
Since its an HTML development tool, it will confuse users if we disable window.open/ anchor tag hrefs not opening up new windows. So we enable that.

The security posture wont change due to this as 1, since the iframe is sandboxed, the popout that escaped the sandox will no loger be able to communicate with phcode, and hence isolated.

Another thing to note is that, for virtual serving urls, the popout will result in a 404 as the virtual server is sandboxed within a tab/phcode. But this is the case even before this change. Normal click-navigations will not be affected, just `open link in new tab` workflows with virtual server target urls will fail.