### PR TITLE
feat: non-live preview of non project files

### DIFF
--- a/src-node/index.js
+++ b/src-node/index.js
@@ -217,8 +217,18 @@ const server = http.createServer((req, res) => {
         // Remove '/Static<rand>' from the beginning of the URL and construct file path
         const url = new URL(req.url, `http://${req.headers.host}`);
         const cleanPath = url.pathname.replace(PHOENIX_STATIC_SERVER_URL, '');
-        const filePath = path.join(__dirname, 'www', cleanPath);
+        if(cleanPath.startsWith("/externalProject")) {
+            // Special Live Preview for External Project Files
+            // ------------------------------------------------
+            // Overview:
+            // - This feature allows for the preview of files that are not part of the current project.
+            //   It's specifically for files that users open in the editor but which are outside the scope
+            //   of the project being worked on. Useful when users want to quickly view or edit files that are not
+            //   part of the project without integrating them into the project's environment.
+            return LivePreview.serverExternalProjectResource(req, res);
+        }
 
+        const filePath = path.join(__dirname, 'www', cleanPath);
         fs.readFile(filePath, (err, data) => {
             if (err) {
                 if (err.code === 'ENOENT' || err.code === 'EISDIR') {

--- a/src-node/live-preview.js
+++ b/src-node/live-preview.js
@@ -98,13 +98,9 @@ function messageAllWebSockets(socketList, data) {
     }
 }
 
-/**
- * @param {IncomingMessage} req
- * @param {ServerResponse} res
- */
-function serverRequestListener(req, res) {
+function _serveData(getContentAPIToUse, req, res) {
     const url = new URL(req.url, `http://${req.headers.host}`);
-    liveServerConnector.execPeer('getContent', url.href)
+    liveServerConnector.execPeer(getContentAPIToUse, url.href)
         .then(data=>{
             if(data.is404){
                 res.writeHead(404, { 'Content-Type': 'text/plain' });
@@ -132,10 +128,27 @@ function serverRequestListener(req, res) {
                 res.end('');
             }
         })
-        .catch(()=>{
+        .catch((err)=>{
+            console.error(err);
             res.writeHead(500, { 'Content-Type': 'text/plain' });
             res.end('500: Internal Server Error');
         });
+}
+
+/**
+ * @param {IncomingMessage} req
+ * @param {ServerResponse} res
+ */
+function serverRequestListener(req, res) {
+    _serveData('getContent', req, res);
+}
+
+/**
+ * @param {IncomingMessage} req
+ * @param {ServerResponse} res
+ */
+function serverExternalProjectResource(req, res) {
+    _serveData('getExternalContent', req, res);
 }
 
 async function startStaticServer({projectRoot, preferredPort}) {
@@ -238,4 +251,5 @@ exports.CreateLivePreviewWSServer = CreateLivePreviewWSServer;
 exports.navMessageProjectOpened = navMessageProjectOpened;
 exports.navRedirectAllTabs = navRedirectAllTabs;
 exports.startStaticServer = startStaticServer;
+exports.serverExternalProjectResource = serverExternalProjectResource;
 exports.messageToLivePreviewTabs = messageToLivePreviewTabs;

--- a/src-node/lmdb.js
+++ b/src-node/lmdb.js
@@ -22,11 +22,11 @@ async function openDB(lmdbDir) {
     dumpFileLocation = path.join(lmdbDir, "storageDBDump.json");
 }
 
-function flushDB() {
+async function flushDB() {
     if(!storageDB){
         throw new Error("LMDB Storage operation called before openDB call");
     }
-    return storageDB.flushed; // wait for disk write complete
+    await storageDB.flushed; // wait for disk write complete
 }
 
 

--- a/src-node/www/externalProject/reamde.md
+++ b/src-node/www/externalProject/reamde.md
@@ -1,0 +1,3 @@
+This is a reserved folder for live preview of external project resources.
+Do not create any files in this folder.
+This is not actually server, but a place holder.

--- a/src/LiveDevelopment/BrowserScripts/pageLoaderWorker.js
+++ b/src/LiveDevelopment/BrowserScripts/pageLoaderWorker.js
@@ -106,12 +106,13 @@ let messageQueue = [];
 function _sendMessage(message) {
     if(_livePreviewWebSocket && _livePreviewWebSocketOpen) {
         _livePreviewWebSocket.send(mergeMetadataAndArrayBuffer(message));
-        return;
     } else if(_livePreviewNavigationChannel){
         _livePreviewNavigationChannel.postMessage(message);
+    } else {
+        console.warn("No Channels available for live preview worker messaging," +
+            " queueing request, waiting for channel..");
+        messageQueue.push(message);
     }
-    console.warn("No Channels available for live preview worker messaging, queueing request, waiting for channel..");
-    messageQueue.push(message);
 }
 
 function flushPendingMessages() {

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -318,7 +318,7 @@ define(function (require, exports, module) {
         if (doc.isUntitled()) {
             return fullPath.substring(fullPath.lastIndexOf("/") + 1);
         }
-        return ProjectManager.makeProjectRelativeIfPossible(fullPath);
+        return Phoenix.app.getDisplayPath(ProjectManager.makeProjectRelativeIfPossible(fullPath));
 
     }
 
@@ -334,7 +334,8 @@ define(function (require, exports, module) {
             if (newDocument) {
                 _currentTitlePath = _shortTitleForDocument(newDocument);
             } else {
-                _currentTitlePath = ProjectManager.makeProjectRelativeIfPossible(newFile.fullPath);
+                const filePath = ProjectManager.makeProjectRelativeIfPossible(newFile.fullPath);
+                _currentTitlePath = Phoenix.app.getDisplayPath(filePath);
             }
         } else {
             _currentTitlePath = null;

--- a/src/extensionsIntegrated/Phoenix-live-preview/NodeStaticServer.js
+++ b/src/extensionsIntegrated/Phoenix-live-preview/NodeStaticServer.js
@@ -452,6 +452,7 @@ define(function (require, exports, module) {
                 const fullPath = currentFile.fullPath;
                 if(utils.isMarkdownFile(fullPath)) {
                     resolve(_getMarkdown(fullPath));
+                    return;
                 }
                 if(utils.isHTMLFile(fullPath)) {
                     const pageText = _getRedirectionPage(getNoPreviewURL(
@@ -608,6 +609,7 @@ define(function (require, exports, module) {
                         URL: getNoPreviewURL(),
                         isNoPreview: true
                     });
+                    return;
                 }
                 const projectRoot = ProjectManager.getProjectRoot().fullPath;
                 let fullPath = currentFile.fullPath;
@@ -620,6 +622,7 @@ define(function (require, exports, module) {
                         isMarkdownFile: utils.isMarkdownFile(fullPath),
                         isHTMLFile: utils.isHTMLFile(fullPath)
                     });
+                    return;
                 }
                 let httpFilePath = null;
                 if(fullPath.startsWith("http://") || fullPath.startsWith("https://")){

--- a/src/extensionsIntegrated/Phoenix-live-preview/main.js
+++ b/src/extensionsIntegrated/Phoenix-live-preview/main.js
@@ -337,14 +337,11 @@ define(function (require, exports, module) {
         // preview breaks sporadically. to alleviate this, we create a new iframe every time.
         if(!urlPinned) {
             currentLivePreviewURL = newSrc;
-            currentPreviewFile = previewDetails.filePath;
+            currentPreviewFile = previewDetails.fullPath;
         }
-        let title= currentPreviewFile;
-        if(currentPreviewFile && currentPreviewFile.startsWith("/tauri")){
-            // this is an absolute path, and we should only show platform paths to user
-            title = Phoenix.fs.getTauriPlatformPath(currentPreviewFile);
-        }
-        _setTitle(title);
+        let relativeOrFullPath= ProjectManager.makeProjectRelativeIfPossible(currentPreviewFile);
+        relativeOrFullPath = Phoenix.app.getDisplayPath(relativeOrFullPath);
+        _setTitle(relativeOrFullPath);
         if(panel.isVisible()) {
             let newIframe = $(LIVE_PREVIEW_IFRAME_HTML);
             newIframe.insertAfter($iframe);

--- a/src/extensionsIntegrated/Phoenix-live-preview/main.js
+++ b/src/extensionsIntegrated/Phoenix-live-preview/main.js
@@ -339,7 +339,12 @@ define(function (require, exports, module) {
             currentLivePreviewURL = newSrc;
             currentPreviewFile = previewDetails.filePath;
         }
-        _setTitle(currentPreviewFile);
+        let title= currentPreviewFile;
+        if(currentPreviewFile && currentPreviewFile.startsWith("/tauri")){
+            // this is an absolute path, and we should only show platform paths to user
+            title = Phoenix.fs.getTauriPlatformPath(currentPreviewFile);
+        }
+        _setTitle(title);
         if(panel.isVisible()) {
             let newIframe = $(LIVE_PREVIEW_IFRAME_HTML);
             newIframe.insertAfter($iframe);

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -901,6 +901,8 @@ define({
     "DESCRIPTION_LIVEDEV_ENABLE_REVERSE_INSPECT": "false to disable live preview reverse inspect",
     "DESCRIPTION_LIVEDEV_NO_PREVIEW": "Nothing to preview!",
     "DESCRIPTION_LIVEDEV_NO_PREVIEW_DETAILS": "Please select an HTML file to preview",
+    "DESCRIPTION_LIVEDEV_PREVIEW_RESTRICTED": "Preview Unavailable!",
+    "DESCRIPTION_LIVEDEV_PREVIEW_RESTRICTED_DETAILS": "This HTML file is not part of the current project. For security reasons, only project files can be live-previewed. To preview this file, open its containing folder as a separate project.",
     "DESCRIPTION_LIVEDEV_MAIN_HEADING": "Uh Oh! <br>Your current browser doesn't support live preview.",
     "DESCRIPTION_LIVEDEV_MAIN_SPAN": "Get the best live preview experience by downloading our native apps for Windows, Mac, and Linux from <a href=\"https://phcode.io\" style=\"color: white\">phcode.io</a>.<br>",
     "DESCRIPTION_LIVEDEV_SECURITY_POPOUT_MESSAGE": "You are about to open a file for live preview. Please proceed only if you trust the source of this project. Click 'Trust Project' to continue, or close this window if you do not trust the source.",

--- a/src/phoenix/shell.js
+++ b/src/phoenix/shell.js
@@ -113,9 +113,22 @@ Phoenix.app = {
             return Phoenix.fs.getTauriPlatformPath(fullVFSPath);
         }
         if (fullVFSPath.startsWith(Phoenix.VFS.getMountDir())) {
-            return fullVFSPath.replace(Phoenix.VFS.getMountDir(), ""); // we don't show anything if it's stored on user's hard drive for better ui.
+            return fullVFSPath.replace(Phoenix.VFS.getMountDir(), "");
         }
         return window.Strings.STORED_IN_YOUR_BROWSER;
+    },
+    getDisplayPath: function (fullOrRelativeVFSPath) {
+        // reruns a path that can be shown to the user to make some sense of the virtual file path.
+        // The returned path is platform path for tauri,
+        // a relative path of the form (folder/file.txt) starting with opened folder name for fs access- /mnt/paths
+        // or virtual path if we cant figure out a tauri/fs access path
+        if (fullOrRelativeVFSPath.startsWith(Phoenix.VFS.getTauriDir())) {
+            return Phoenix.fs.getTauriPlatformPath(fullOrRelativeVFSPath);
+        }
+        if (fullOrRelativeVFSPath.startsWith(Phoenix.VFS.getMountDir())) {
+            return fullOrRelativeVFSPath.replace(Phoenix.VFS.getMountDir(), "");
+        }
+        return fullOrRelativeVFSPath;
     },
     setWindowTitle: async function (title) {
         window.document.title = title;


### PR DESCRIPTION
# Special Live Preview for External Project Files
Overview:
- This feature allows for the preview of files that are not part of the current project.
  It's specifically for files that users open in the editor but which are outside the scope
  of the project being worked on. Useful when users want to quickly view or edit files that are not
  part of the project without integrating them into the project's environment.

##   Domain Separation:
- The previews for these external files are loaded from a static server URL, not the usual live preview
  server URL.
- This separation ensures that the active live preview environment does not have access to resources
  from external projects.

##   Security Measures:
- For security reasons, only the content of the currently viewed file is served in this special
  live preview mode.
- HTML files are specifically not served in the live preview of external project files.
  This decision is a precaution against disk file traversal attacks. For example, if a malicious HTML
  file from a user's documents folder were allowed in the live preview, it could potentially upload
  sensitive contents from the appdata folder to a remote server. By restricting the serving of HTML
  files and isolating the external file preview environment, the system enhances security while still
  providing the flexibility to view external files to a limited extend.