### PR TITLE
chore: reverse highlight should also be disabled when live preview highlight feature deisabled

### DIFF
--- a/src/LiveDevelopment/MultiBrowserImpl/protocol/LiveDevProtocol.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/protocol/LiveDevProtocol.js
@@ -47,6 +47,7 @@ define(function (require, exports, module) {
         RemoteFunctions       = require("text!LiveDevelopment/BrowserScripts/RemoteFunctions.js"),
         EditorManager         = require("editor/EditorManager"),
         LiveDevMultiBrowser   = require("LiveDevelopment/LiveDevMultiBrowser"),
+        PreferencesManager  = require("preferences/PreferencesManager"),
         HTMLInstrumentation   = require("LiveDevelopment/MultiBrowserImpl/language/HTMLInstrumentation"),
         StringUtils = require("utils/StringUtils"),
         FileViewController    = require("project/FileViewController");
@@ -94,6 +95,11 @@ define(function (require, exports, module) {
     }
 
     function _tagSelectedInLivePreview(tagId) {
+        const highlightPref = PreferencesManager.getViewState("livedev.highlight");
+        if(!highlightPref){
+            // live preview highlight and reverse highlight feature is disabled
+            return;
+        }
         const liveDoc = LiveDevMultiBrowser.getCurrentLiveDoc(),
             editor = EditorManager.getActiveEditor();
         const liveDocPath = liveDoc ? liveDoc.doc.file.fullPath : null,

--- a/src/phoenix/shell.js
+++ b/src/phoenix/shell.js
@@ -118,6 +118,9 @@ Phoenix.app = {
         return window.Strings.STORED_IN_YOUR_BROWSER;
     },
     getDisplayPath: function (fullOrRelativeVFSPath) {
+        if(!fullOrRelativeVFSPath){
+            return "";
+        }
         // reruns a path that can be shown to the user to make some sense of the virtual file path.
         // The returned path is platform path for tauri,
         // a relative path of the form (folder/file.txt) starting with opened folder name for fs access- /mnt/paths


### PR DESCRIPTION
chore: reverse highlight should also be disabled when live preview highlight feature deisabled
![reverse highlight disable](https://github.com/phcode-dev/phoenix/assets/5336369/be5ed1de-a1fb-4c2c-8aac-c0005a0b35fd)
