### PR TITLE
feat: click binoculor icon/locate in file tree for non project files now opens file in os explorer

### DIFF
--- a/src/project/ProjectModel.js
+++ b/src/project/ProjectModel.js
@@ -685,12 +685,14 @@ define(function (require, exports, module) {
         path = _getPathFromFSObject(path);
 
         if (!this.isWithinProject(path)) {
-            return d.resolve().promise();
+            Phoenix.app.openPathInFileBrowser(path)
+                .then(d.resolve)
+                .catch(d.reject);
+            return d.promise();
         }
 
-        var parentDirectory = FileUtils.getDirectoryPath(path),
-            self = this;
-        this.setDirectoryOpen(parentDirectory, true).then(function () {
+        const self = this;
+        this.setDirectoryOpen(FileUtils.getDirectoryPath(path), true).then(function () {
             if (_pathIsFile(path)) {
                 self.setSelected(path);
             }

--- a/test/spec/ProjectModel-test.js
+++ b/test/spec/ProjectModel-test.js
@@ -1254,19 +1254,6 @@ define(function (require, exports, module) {
                 expect(vm._treeData.get("open")).toBeUndefined();
             });
 
-            it("should do nothing for a path that is outside of the project", async function () {
-                await awaitsForDone(model.showInTree("/bar/baz.js"));
-                expect(vm._treeData.get("baz.js")).toBeUndefined();
-                expect(model._selections.selected).toBeUndefined();
-            });
-
-            it("should do nothing for a path that is outside of the project on Windows", async function () {
-                model.projectRoot = "c:/foo/";
-                await awaitsForDone(model.showInTree("c:/bar/baz.js"));
-                expect(vm._treeData.get("baz.js")).toBeUndefined();
-                expect(model._selections.selected).toBeUndefined();
-            });
-
             it("should select a file at the root", async function () {
                 await awaitsForDone(model.showInTree("/foo/toplevel.txt"));
                 expect(vm._treeData.getIn(["toplevel.txt", "selected"])).toBe(true);


### PR DESCRIPTION
Earlier, for external project files, this used to do nothing, and the user would be a bit confused on where the file is located or if they actually clicked on the icon as nothing happened. Address the UX.