### PR TITLE
feat: desktop open with from file explorer working for files and folders

### DIFF
--- a/test/spec/Tauri-platform-test.js
+++ b/test/spec/Tauri-platform-test.js
@@ -105,7 +105,7 @@ define(function (require, exports, module) {
                     let newURL = currentURL.href;
                     Phoenix.app.openURLInPhoenixWindow(newURL)
                         .then(tauriWindow =>{
-                            expect(tauriWindow.label.startsWith("phcode-")).toBeTrue();
+                            expect(tauriWindow.label.startsWith("extn-")).toBeTrue();
                             tauriWindow.listen('TAURI_API_WORKING', function () {
                                 resolve(tauriWindow);
                             });


### PR DESCRIPTION
### Summary
This pull request introduces enhancements to our Tauri application to ensure it operates as a single instance. Additionally, it implements functionality to handle files and folders opened from the OS file explorer, improving user experience across Windows, macOS, and Linux platforms.

### Details
The proposed changes leverage the Tauri single instance plugin- see taur changes here: https://github.com/phcode-dev/phoenix-desktop/pull/184 . This approach guarantees that only one instance of our application runs at any given time. If a user attempts to open a new instance (e.g., by double-clicking a file associated with our app in the file explorer), the new instance will pass its command line arguments (CLI args) to the existing instance and then exit.

#### Key Functionalities:
1. **Single Instance Check**: On launch, the application checks if another instance with the same executable path or Tauri app ID is already running. If found, the new instance will emit the CLI args to the existing instance and then gracefully exit.

2. The Primary instance- Of the many editor windows that can be open in the single instance, one window will be elected primary by convention. The primary will act on behalf of phcode editor CLI execs. The convention eliminates IPC handshakes or any leader elections. The convention is as follows:
    1. The initial window has window label `main`.  The main window if present will always be primary leader.
    2. If the user has closed the `main` window, then other phoenix editor windows will have label like `phcode-1` to `phcode-30`. Only a maximum of 30 editor windows can be open at a time. The leader is the window with the lowest label. Eg, if `phcode-8` and `phcode-22` are the only windows around, then `phcode-8` will be the leader.

4. **Handling CLI Args in Existing Instance**: The existing instance, upon receiving the CLI args, will behave as follows:
   - If the CLI arg is a file (indicative of a user double-clicking a file in the file explorer), the application will open this file in an existing window.
   - If the CLI arg is a folder, the application will open a new window to handle the folder.

### Cross-Platform Compatibility
These enhancements have been tested and confirmed to work seamlessly on Windows, macOS, and Linux, ensuring a consistent and user-friendly experience across all platforms.

### Conclusion
This update significantly improves the application's integration with the OS, making it more intuitive and efficient for users who interact with files and folders directly from their file explorers.