### PR TITLE
fix: non english keyboard shortcut change from physical to logical keys

### DIFF
--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -247,10 +247,13 @@
         {
             "key": "Ctrl-Shift--",
             "displayKey": "Ctrl-Shift-−"
+        },
+        {
+            "key": "Ctrl-Shift-_"
         }
     ],
     "view.restoreFontSize":  [
-        "Ctrl-Shift-9"
+        "Ctrl-Shift-("
     ],
     "view.scrollLineUp":  [
         {
@@ -299,13 +302,7 @@
         "Ctrl-J"
     ],
     "navigate.gotoFirstProblem":  [
-        {
-            "key": "F8"
-        },
-        {
-            "key": "Cmd-'",
-            "platform": "mac"
-        }
+        "Ctrl-'"
     ],
     "navigate.nextDocListOrder":  [
         {

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -439,53 +439,17 @@ define(function (require, exports, module) {
      **/
     function _mapKeycodeToKey(event) {
         // key code mapping https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_code_values
-        const code = event.code;
+        const key = event.key;
         let codes = {
-            "Tab": "Tab",
-            "Space": "Space",
-            "Backspace": "Backspace",
-            "Insert": "Insert",
-            "Delete": "Delete",
             "ArrowUp": "Up",
             "ArrowDown": "Down",
             "ArrowLeft": "Left",
-            "ArrowRight": "Right",
-            "Semicolon": ";",
-            "Equal": "=",
-            "Add": "+", // Eg. Numpad Add button NumpadAdd
-            "Comma": ",",
-            "Minus": "-",
-            "Period": ".",
-            "Decimal": ".", // NumpadDecimal
-            "Slash": "/",
-            "Divide": "/", //NumpadDivide
-            "Quote": "'",
-            "Backquote": "`",
-            "BracketLeft": "[",
-            "BracketRight": "]",
-            "Backslash": "\\"
+            "ArrowRight": "Right"
         };
-        let strippedCode;
-        // event.code should be there in all browsers post 2014. But some older browsers don't, so the check `code &&`
-        if(code && code.startsWith("Key")){
-            strippedCode = code.replace("Key", "");
-            return codes[strippedCode] || strippedCode;
+        if(codes[key]){
+            return codes[key];
         }
-        if(code && code.startsWith("Digit")){
-            strippedCode = code.replace("Digit", "");
-            return codes[strippedCode] || strippedCode;
-        }
-        if(code && code.startsWith("Numpad")){
-            // this can either be a simple numpad digit like 'Numpad0'(we should return 0)
-            // or 'NumpadAdd'(for which we should return the mapped + button)
-            strippedCode = code.replace("Numpad", "");
-            return codes[strippedCode] || strippedCode;
-        }
-        if(codes[code]){
-            return codes[code];
-        }
-        // This is pretty much all the keys in a keyboard we usually encounter. If still no match, return key as is
-        return event.key;
+        return key;
     }
 
     /**

--- a/src/extensionsIntegrated/NoDistractions/main.js
+++ b/src/extensionsIntegrated/NoDistractions/main.js
@@ -47,8 +47,8 @@ define(function (require, exports, module) {
         toggleFullScreenKeyMac = "Cmd-F11",
         togglePanelsKey           = "Ctrl-Shift-1",
         togglePanelsKeyMac        = "Cmd-Shift-1",
-        togglePanelsKey_EN        = "Ctrl-Shift-`",
-        togglePanelsKeyMac_EN     = "Cmd-Shift-`";
+        togglePanelsKey_EN        = "Ctrl-Shift-~",
+        togglePanelsKeyMac_EN     = "Cmd-Shift-~";
 
     //locals
     let _previouslyOpenPanelIDs = [],

--- a/test/spec/KeyBindingManager-test.js
+++ b/test/spec/KeyBindingManager-test.js
@@ -48,7 +48,7 @@ define(function (require, exports, module) {
             "Ctrl-Shift-L": "edit.splitSelIntoLines",
             "Alt-Shift-Down": "edit.addCursorToNextLine",
             "Alt-Shift-Up": "edit.addCursorToPrevLine",
-            "F8": "navigate.gotoFirstProblem",
+            "Ctrl-'": "navigate.gotoFirstProblem",
             "Ctrl-1": "file.newFile",
             "Ctrl-Alt-H": "view.toggleSidebar",
             "Ctrl-Shift-O": "navigate.quickOpen",
@@ -112,8 +112,7 @@ define(function (require, exports, module) {
             displayKey = KeyBindingManager._getDisplayKey(key);
             if (platform === "mac") {
                 explicitPlatform = undefined;
-                if (commandID === "edit.selectLine" || commandID === "view.toggleSidebar" ||
-                        commandID === "navigate.gotoFirstProblem") {
+                if (commandID === "edit.selectLine" || commandID === "view.toggleSidebar") {
                     explicitPlatform = "mac";
                 }
             }
@@ -810,6 +809,7 @@ define(function (require, exports, module) {
                 return {
                     ctrlKey: true,
                     altKey: true,
+                    key: "1",
                     keyCode: "1".charCodeAt(0),
                     code: "Digit1",
                     immediatePropagationStopped: false,
@@ -954,6 +954,7 @@ define(function (require, exports, module) {
                 return {
                     ctrlKey: true,
                     keyCode: "A".charCodeAt(0),
+                    key: "A",
                     code: "KeyA",
                     immediatePropagationStopped: false,
                     propagationStopped: false,


### PR DESCRIPTION
Fixes: https://github.com/phcode-dev/phoenix/issues/1078

We were using physical keys which are mostly suited for gaming with international keyboards using the `wasd` keys.
Chnaged to use logical keys. 

This was not ain issue in brackets as brackets used `event.keyCode` which was deprectaed by w3c and was inconsistant when we moved to modern browsers from brackets shell. We earlier moved to physical key apis as the recommended replacement by w3c along with logical `key` api. Now moved to logical.