### PR TITLE
feat: keyboard navigation of top menu (left and right arrow)

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -425,18 +425,6 @@ define(function (require, exports, module) {
             $body.addClass("in-appshell");
         }
 
-        // Use HTML Menus
-        // (issue #5310) workaround for bootstrap dropdown: prevent the menu item to grab
-        // the focus -- override jquery focus implementation for top-level menu items
-        (function () {
-            const defaultFocus = $.fn.focus;
-            $.fn.focus = function () {
-                if (!this.hasClass("dropdown-toggle")) {
-                    return defaultFocus.apply(this, arguments);
-                }
-            };
-        }());
-
         $('#toolbar-extension-manager').prop('title', Strings.EXTENSION_MANAGER_TITLE);
         $('#update-notification').prop('title', Strings.UPDATE_NOTIFICATION_TOOLTIP);
 

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -54,6 +54,44 @@ define(function (require, exports, module) {
     const EVENT_KEY_BINDING_ADDED = "keyBindingAdded",
         EVENT_KEY_BINDING_REMOVED = "keyBindingRemoved";
 
+    const KEY = {
+        ENTER: "Enter",
+        ESCAPE: "Escape",
+        ARROW_LEFT: "ArrowLeft",
+        ARROW_RIGHT: "ArrowRight",
+        ARROW_UP: "ArrowUp",
+        ARROW_DOWN: "ArrowDown",
+        SPACE: " ",
+        TAB: "Tab",
+        BACKSPACE: "Backspace",
+        DELETE: "Delete",
+        HOME: "Home",
+        END: "End",
+        PAGE_UP: "PageUp",
+        PAGE_DOWN: "PageDown",
+        SHIFT: "Shift",
+        CONTROL: "Control",
+        ALT: "Alt",
+        META: "Meta", // Command key on Mac, Windows key on Windows
+        F1: "F1",
+        F2: "F2",
+        F3: "F3",
+        F4: "F4",
+        F5: "F5",
+        F6: "F6",
+        F7: "F7",
+        F8: "F8",
+        F9: "F9",
+        F10: "F10",
+        F11: "F11",
+        F12: "F12",
+        INSERT: "Insert",
+        CONTEXT_MENU: "ContextMenu", // Usually the menu key or right-click keyboard button
+        NUM_LOCK: "NumLock",
+        SCROLL_LOCK: "ScrollLock",
+        CAPS_LOCK: "CapsLock"
+    };
+
     /**
      * @private
      * Maps normalized shortcut descriptor to key binding info.
@@ -444,7 +482,8 @@ define(function (require, exports, module) {
             "ArrowUp": "Up",
             "ArrowDown": "Down",
             "ArrowLeft": "Left",
-            "ArrowRight": "Right"
+            "ArrowRight": "Right",
+            " ": "Space"
         };
         if(codes[key]){
             return codes[key];
@@ -958,7 +997,8 @@ define(function (require, exports, module) {
      * as usual.
      *
      * Multiple keydown hooks can be registered, and are executed in order,
-     * most-recently-added first.
+     * most-recently-added first. A keydown hook will only be added once if the same
+     * hook is already added before.
      *
      * (We have to have a special API for this because (1) handlers are normally
      * called in least-recently-added order, and we want most-recently-added;
@@ -970,6 +1010,10 @@ define(function (require, exports, module) {
      * @param {function(Event): boolean} hook The global hook to add.
      */
     function addGlobalKeydownHook(hook) {
+        let index = _globalKeydownHooks.indexOf(hook);
+        if (index !== -1) {
+            return;
+        }
         _globalKeydownHooks.push(hook);
     }
 
@@ -1475,6 +1519,8 @@ define(function (require, exports, module) {
     exports.addGlobalKeydownHook = addGlobalKeydownHook;
     exports.removeGlobalKeydownHook = removeGlobalKeydownHook;
 
+    // public constants
+    exports.KEY = KEY;
     // public events
     exports.EVENT_KEY_BINDING_ADDED = EVENT_KEY_BINDING_ADDED;
     exports.EVENT_KEY_BINDING_REMOVED = EVENT_KEY_BINDING_REMOVED;

--- a/src/extensionsIntegrated/RecentProjects/main.js
+++ b/src/extensionsIntegrated/RecentProjects/main.js
@@ -343,6 +343,7 @@ define(function (require, exports, module) {
         MainViewManager.focusActivePane();
 
         $(window).off("keydown", keydownHook);
+        searchStr = "";
     }
 
     function openProjectWithPath(fullPath) {

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -804,6 +804,20 @@ a:focus {
 
 }
 
+#titlebar li {
+    .dropdown-toggle:hover{
+        background-color: transparent;
+        border-color: transparent;
+    }
+}
+
+#titlebar li .selected, #titlebar li .selected:hover{
+    background-color: @bc-bg-highlight;
+    .dark & {
+        background-color: @dark-bc-bg-highlight;
+    }
+}
+
 /* Status bar language picker's DropdownButton */
 .dropdownbutton-popup.dropdown-status-bar {
     -webkit-transform-origin: 0 100%;

--- a/src/view/MainViewManager.js
+++ b/src/view/MainViewManager.js
@@ -319,7 +319,8 @@ define(function (require, exports, module) {
      * Focuses the current pane. If the current pane has a current view, then the pane will focus the view.
      */
     function focusActivePane() {
-        _getPane(ACTIVE_PANE).focus();
+        const activePane = _getPane(ACTIVE_PANE);
+        activePane && activePane.focus();
     }
 
     /**

--- a/src/widgets/PopUpManager.js
+++ b/src/widgets/PopUpManager.js
@@ -29,6 +29,7 @@ define(function (require, exports, module) {
         EventDispatcher = require("utils/EventDispatcher"),
         WorkspaceManager = require("view/WorkspaceManager"),
         CommandManager  = require("command/CommandManager"),
+        MainViewManager     = require("view/MainViewManager"),
         KeyEvent        = require("utils/KeyEvent");
 
     let _popUps = [];
@@ -105,13 +106,10 @@ define(function (require, exports, module) {
 
                     removePopUp($popUp);
 
-                    // TODO: right now Menus and Context Menus do not take focus away from
-                    // the editor. We need to have a focus manager to correctly manage focus
+                    // We need to have a focus manager to correctly manage focus
                     // between editors and other UI elements.
-                    // For now we don't set focus here and assume individual popups
-                    // adjust focus if necessary
-                    // See story in Trello card #404
-                    //EditorManager.focusEditor();
+                    // For now we set focus here
+                    MainViewManager.focusActivePane();
                 }
 
                 break;


### PR DESCRIPTION
![menu-key-nav](https://github.com/phcode-dev/phoenix/assets/5336369/99323215-6c67-4827-95b0-88a46348d541)

## Also fixes
1. `Ctrl/Cmd-Space` doesnt trigger code hints. This is a regression that happened after we moved KeyBindingManager to use `event.key`.
2. A bug in project dropdown where the keyboard search filter doesnt get reset on popup close.