### PR TITLE
feat: all new keyboard navigation workflows

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -65,6 +65,8 @@ define(function (require, exports, module) {
     require("worker/WorkerComm");
     require("utils/ZipUtils");
     require("NodeConnector");
+    require("command/KeyboardOverlayMode");
+    require("editor/EditorManager");
 
     // Load dependent modules
     const AppInit             = require("utils/AppInit"),

--- a/src/command/KeyboardOverlayMode.js
+++ b/src/command/KeyboardOverlayMode.js
@@ -1,0 +1,106 @@
+/*
+ * GNU AGPL-3.0 License
+ *
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
+ * Original work Copyright (c) 2013 - 2021 Adobe Systems Incorporated. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
+ *
+ */
+
+/*global Phoenix*/
+
+/**
+ * Initializes the default brackets menu items.
+ */
+define(function (require, exports, module) {
+    const EditorManager       = require("editor/EditorManager"),
+        AppInit             = require("utils/AppInit"),
+        MainViewManager      = require("view/MainViewManager"),
+        Menus = require("command/Menus"),
+        Keys                = require("command/Keys");
+
+    const CONTROL_NAV_OVERLAY_ID = "ctrl-nav-overlay";
+    let overlay;
+
+    let lastEditorWithFocus, overlayMode = false;
+
+    function startOverlayMode(targetId) {
+        // Find the target div and the overlay div
+        if(!targetId){
+            targetId = MainViewManager.getActivePaneId() || "first-pane";
+        }
+        const target = document.getElementById(targetId);
+
+        lastEditorWithFocus = EditorManager.getActiveEditor();
+        if (target && overlay) {
+            // Get the position and dimensions of the target div
+            const rect = target.getBoundingClientRect();
+            // Set the overlay div's styles to match the target's dimensions and position
+            overlay.style.left = rect.left + 'px';
+            overlay.style.top = rect.top + 'px';
+            overlay.style.width = rect.width + 'px';
+            overlay.style.height = rect.height + 'px';
+            overlay.classList.remove('forced-hidden'); // Remove the class that hides the overlay
+            overlay.classList.add('hide-cursor'); // Remove the class that hides the overlay
+            overlay.focus();
+            overlayMode = true;
+            document.addEventListener('click', exitOverlayMode, true);
+        }
+    }
+
+    function exitOverlayMode() {
+        const overlay = document.getElementById(CONTROL_NAV_OVERLAY_ID);
+        overlay.classList.add('forced-hidden'); // Remove the class that hides the overlay
+        overlayMode = false;
+        if(lastEditorWithFocus){
+            lastEditorWithFocus.focus();
+        }
+        document.removeEventListener('click', exitOverlayMode, true);
+    }
+
+    function processOverlayKeyboardEvent(event) {
+        let processed = false;
+        switch (event.key) {
+        case Keys.KEY.ARROW_UP:
+            exitOverlayMode();
+            Menus.openMenu();
+            processed = true;
+            break;
+        case Keys.KEY.ESCAPE:
+        default:
+            exitOverlayMode();
+            processed = true;
+            break;
+        }
+        if(processed){
+            event.stopPropagation();
+            event.preventDefault();
+        }
+        return processed;
+    }
+
+    function isInOverlayMode() {
+        return overlayMode;
+    }
+
+    AppInit.htmlReady(function () {
+        overlay = document.getElementById(CONTROL_NAV_OVERLAY_ID);
+    });
+
+    exports.processOverlayKeyboardEvent = processOverlayKeyboardEvent;
+    exports.startOverlayMode = startOverlayMode;
+    exports.exitOverlayMode = exitOverlayMode;
+    exports.isInOverlayMode = isInOverlayMode;
+});

--- a/src/command/Keys.js
+++ b/src/command/Keys.js
@@ -1,0 +1,67 @@
+/*
+ * GNU AGPL-3.0 License
+ *
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
+ * Original work Copyright (c) 2013 - 2021 Adobe Systems Incorporated. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
+ *
+ */
+
+/*global Phoenix*/
+
+/**
+ * Initializes the default brackets menu items.
+ */
+define(function (require, exports, module) {
+    const KEY = {
+        ENTER: "Enter",
+        RETURN: "Return",
+        ESCAPE: "Escape",
+        ARROW_LEFT: "ArrowLeft",
+        ARROW_RIGHT: "ArrowRight",
+        ARROW_UP: "ArrowUp",
+        ARROW_DOWN: "ArrowDown",
+        SPACE: " ",
+        TAB: "Tab",
+        BACKSPACE: "Backspace",
+        DELETE: "Delete",
+        HOME: "Home",
+        END: "End",
+        PAGE_UP: "PageUp",
+        PAGE_DOWN: "PageDown",
+        SHIFT: "Shift",
+        CONTROL: "Control",
+        ALT: "Alt",
+        META: "Meta", // Command key on Mac, Windows key on Windows
+        F1: "F1",
+        F2: "F2",
+        F3: "F3",
+        F4: "F4",
+        F5: "F5",
+        F6: "F6",
+        F7: "F7",
+        F8: "F8",
+        F9: "F9",
+        F10: "F10",
+        F11: "F11",
+        F12: "F12",
+        INSERT: "Insert",
+        CONTEXT_MENU: "ContextMenu", // Usually the menu key or right-click keyboard button
+        NUM_LOCK: "NumLock",
+        SCROLL_LOCK: "ScrollLock",
+        CAPS_LOCK: "CapsLock"
+    };
+    exports.KEY = KEY;
+});

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -29,6 +29,7 @@ define(function (require, exports, module) {
     let Commands            = require("command/Commands"),
         EventDispatcher     = require("utils/EventDispatcher"),
         KeyBindingManager   = require("command/KeyBindingManager"),
+        Keys       = require("command/Keys"),
         StringUtils         = require("utils/StringUtils"),
         CommandManager      = require("command/CommandManager"),
         PopUpManager        = require("widgets/PopUpManager"),
@@ -41,7 +42,7 @@ define(function (require, exports, module) {
     // make sure the global brackets letiable is loaded
     require("utils/Global");
 
-    const KEY = KeyBindingManager.KEY;
+    const KEY = Keys.KEY;
     /**
      * Brackets Application Menu Constants
      * @enum {string}
@@ -1010,6 +1011,22 @@ define(function (require, exports, module) {
         }
     }
 
+    let lastOpenedMenuID = 'file-menu';
+    function openMenu(id) {
+        if(!id){
+            id = lastOpenedMenuID;
+        }
+        if (!menuMap[id]) {
+            console.error("openMenu- no such menu: " + id);
+            return null;
+        }
+        $(`#${getDropdownToggleMenuID(id)}`).click();
+    }
+
+    function getDropdownToggleMenuID(id) {
+        return `${id}-dropdown-toggle`;
+    }
+
     /**
      * Adds a top-level menu to the application menu bar which may be native or HTML-based.
      *
@@ -1045,7 +1062,7 @@ define(function (require, exports, module) {
         menuMap[id] = menu;
 
 
-        let $toggle = $(`<a id="${id}-dropdown-toggle" href='#' class='dropdown-toggle' data-toggle='dropdown'>${name}</a>`),
+        let $toggle = $(`<a id="${getDropdownToggleMenuID(id)}" href='#' class='dropdown-toggle' data-toggle='dropdown'>${name}</a>`),
             $popUp = $("<ul class='dropdown-menu'></ul>"),
             $dropdown = $("<li class='dropdown' id='" + id + "'></li>"),
             $newMenu = $dropdown.append($toggle).append($popUp);
@@ -1093,8 +1110,10 @@ define(function (require, exports, module) {
         let currentIndex = $dropdownToggles.index($menuDropdownToggle);
         currentIndex = event.key === KEY.ARROW_LEFT ? currentIndex - 1 : currentIndex + 1;
         const nextIndex = currentIndex % $dropdownToggles.length;
-        $dropdownToggles.eq(nextIndex).parent().addClass('open');
-        $dropdownToggles.eq(nextIndex).focus();
+        const $nextDropdownToggle = $dropdownToggles.eq(nextIndex);
+        $nextDropdownToggle.parent().addClass('open');
+        $nextDropdownToggle.focus();
+        lastOpenedMenuID = $nextDropdownToggle.parent()[0].id;
         mainMenu && mainMenu.closeSubMenu();
     }
 
@@ -1501,6 +1520,7 @@ define(function (require, exports, module) {
     exports.getContextMenu = getContextMenu;
     exports.addMenu = addMenu;
     exports.removeMenu = removeMenu;
+    exports.openMenu = openMenu;
     exports.registerContextMenu = registerContextMenu;
     exports.closeAll = closeAll;
     exports.Menu = Menu;

--- a/src/index.html
+++ b/src/index.html
@@ -691,6 +691,15 @@
 <!-- Notification bar -->
 <div id="toast-notification-container">
 </div>
+
+<div id="ctrl-nav-overlay" class="forced-hidden">
+    <div class="arrowDivs">
+        <i class="fa-solid fa-arrows-up-down-left-right"></i>
+    </div>
+    <div class="instruction-text">
+        Use arrows to navigate, or type to select UI elements.
+    </div>
+</div>
 <!-- HTML content is dynamically loaded and rendered by brackets.js after _loadPhoenixAfterSplashScreen.
      Any modules that depend on or modify HTML during load should
      require the "utils/AppInit" module and install a callback for

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -72,6 +72,49 @@ html, body {
     }
 }
 
+#ctrl-nav-overlay {
+    position: absolute;
+    display: flex; /* Enable flexbox */
+    flex-direction: column; /* Stack children vertically */
+    justify-content: center; /* Center children vertically */
+    align-items: center; /* Center children horizontally */
+    width: 100%; /* Full width of the container */
+    height: 100vh; /* Full height of the viewport */
+    top: 0; /* Align to top edge */
+    left: 0; /* Align to left edge */
+    color: #FFF; /* Text and icon color, white for contrast */
+    text-align: center; /* Align text centrally */
+    padding: 20px; /* Padding around the content */
+    box-sizing: border-box; /* Include padding in width/height calculations */
+    z-index: @z-index-brackets-topmost-overlay;
+}
+
+.arrowDivs {
+    /* Flex container for the icon - though not necessary if only one icon */
+    display: flex;
+    justify-content: center; /* Center the icon horizontally */
+    align-items: center; /* Center the icon vertically */
+}
+
+/* Style for the Font Awesome icon */
+.arrowDivs > .fa-solid {
+    font-size: xxx-large;
+    margin-bottom: 20px; /* Space between the icon and the text */
+}
+
+/* Style for the instruction text */
+.instruction-text {
+    font-size: 14px; /* Font size for the instruction text */
+    max-width: 80%; /* Max width of the text to maintain readability */
+}
+
+.hide-cursor {
+    cursor: none !important;
+    .CodeMirror .CodeMirror-sizer {
+        cursor: none !important;
+    }
+}
+
 .editor-text-fragment-hover{
     text-decoration-style: solid;
     text-decoration-line: underline;

--- a/src/styles/brackets_theme_default.less
+++ b/src/styles/brackets_theme_default.less
@@ -159,7 +159,7 @@
  */
 
 .dark {
-    .editor-holder {
+    #editor-holder, .editor-holder {
         @background: #1d1f21;
         @foreground: #ddd;
         .CodeMirror .CodeMirror-selected {

--- a/src/styles/brackets_variables.less
+++ b/src/styles/brackets_variables.less
@@ -68,3 +68,4 @@
 @z-index-brackets-context-menu-base:    1000;
 @z-index-brackets-stylesheet-menu:      1000;
 @z-index-brackets-inline-editor-error:  1000;
+@z-index-brackets-topmost-overlay:  10000;

--- a/src/view/WorkspaceManager.js
+++ b/src/view/WorkspaceManager.js
@@ -33,8 +33,9 @@
 define(function (require, exports, module) {
 
 
-    var AppInit                 = require("utils/AppInit"),
+    const AppInit                 = require("utils/AppInit"),
         EventDispatcher         = require("utils/EventDispatcher"),
+        KeyBindingManager = require("command/KeyBindingManager"),
         Resizer                 = require("utils/Resizer"),
         PluginPanelView         = require("view/PluginPanelView"),
         PanelView               = require("view/PanelView"),
@@ -456,7 +457,7 @@ define(function (require, exports, module) {
 
     // pressing escape when focused on editor will toggle the last opened bottom panel
     function _handleKeydown(event) {
-        if(event.keyCode !== KeyEvent.DOM_VK_ESCAPE){
+        if(event.keyCode !== KeyEvent.DOM_VK_ESCAPE || KeyBindingManager.isInOverlayMode()){
             return;
         }
 


### PR DESCRIPTION
1. Double click on ctr/command key to start the keyboard workflows
2. hide mouse cursor when the user is typing something in editor, on mouse move, it will be shown again.
![image](https://github.com/phcode-dev/phoenix/assets/5336369/82cd2f5b-9134-40b4-b1da-5e2c0151e0f7)
