### PR TITLE
feat: task spinner ux improvement and integ tests

### DIFF
--- a/src/editor/EditorStatusBar.js
+++ b/src/editor/EditorStatusBar.js
@@ -31,7 +31,7 @@ define(function (require, exports, module) {
     const _                    = require("thirdparty/lodash"),
         AnimationUtils       = require("utils/AnimationUtils"),
         AppInit              = require("utils/AppInit"),
-        DropdownButton       = require("widgets/DropdownButton").DropdownButton,
+        DropdownButton       = require("widgets/DropdownButton"),
         EditorManager        = require("editor/EditorManager"),
         MainViewManager      = require("view/MainViewManager"),
         Editor               = require("editor/Editor").Editor,
@@ -375,7 +375,7 @@ define(function (require, exports, module) {
         $indentWidthInput   = $("#indent-width-input");
         $statusOverwrite    = $("#status-overwrite");
 
-        languageSelect      = new DropdownButton("", [], function (item, index) {
+        languageSelect      = new DropdownButton.DropdownButton("", [], function (item, index) {
             var document = EditorManager.getActiveEditor().document,
                 defaultLang = LanguageManager.getLanguageForPath(document.file.fullPath, true);
 
@@ -402,7 +402,7 @@ define(function (require, exports, module) {
         languageSelect.$button.attr("title", Strings.STATUSBAR_LANG_TOOLTIP);
 
 
-        encodingSelect = new DropdownButton("", [], function (item, index) {
+        encodingSelect = new DropdownButton.DropdownButton("", [], function (item, index) {
             var document = EditorManager.getActiveEditor().document;
             var html = _.escape(item);
 
@@ -425,7 +425,7 @@ define(function (require, exports, module) {
             $("#status-tasks .spinner").addClass("hide-spinner");
         }
 
-        tasksSelect = new DropdownButton(Strings.STATUSBAR_TASKS, [Strings.STATUSBAR_TASKS_HIDE_SPINNER], function (item, index) {
+        tasksSelect = new DropdownButton.DropdownButton(Strings.STATUSBAR_TASKS, [Strings.STATUSBAR_TASKS_HIDE_SPINNER], function (item, index) {
             if (item === Strings.STATUSBAR_TASKS_HIDE_SPINNER) {
                 hideSpinner = PreferencesManager.getViewState("StatusBar.HideSpinner");
                 if(hideSpinner){
@@ -445,14 +445,17 @@ define(function (require, exports, module) {
             if(selection === Strings.STATUSBAR_TASKS_HIDE_SPINNER){
                 hideSpinner = !PreferencesManager.getViewState("StatusBar.HideSpinner");
                 PreferencesManager.setViewState("StatusBar.HideSpinner", hideSpinner);
-                if(!hideSpinner){
-                    $("#status-tasks .spinner").removeClass("hide-spinner");
-                } else {
+                if(hideSpinner){
                     $("#status-tasks .spinner").addClass("hide-spinner");
+                } else {
+                    $("#status-tasks .spinner").removeClass("hide-spinner");
                 }
                 return;
             }
             return TaskManager._onSelect(e, selection);
+        });
+        tasksSelect.on(DropdownButton.EVENT_DROPDOWN_SHOWN, (evt)=>{
+            return TaskManager._onDropdownShown(evt);
         });
 
         // indentation event handlers

--- a/src/editor/EditorStatusBar.js
+++ b/src/editor/EditorStatusBar.js
@@ -422,12 +422,13 @@ define(function (require, exports, module) {
         encodingSelect.$button.attr("title", Strings.STATUSBAR_ENCODING_TOOLTIP);
         let hideSpinner = PreferencesManager.getViewState("StatusBar.HideSpinner");
         if(hideSpinner){
-            $("#status-tasks .spinner").addClass("forced-hidden");
+            $("#status-tasks .spinner").addClass("hide-spinner");
         }
 
         tasksSelect = new DropdownButton(Strings.STATUSBAR_TASKS, [Strings.STATUSBAR_TASKS_HIDE_SPINNER], function (item, index) {
             if (item === Strings.STATUSBAR_TASKS_HIDE_SPINNER) {
-                if($("#status-tasks .spinner").hasClass("forced-hidden")){
+                hideSpinner = PreferencesManager.getViewState("StatusBar.HideSpinner");
+                if(hideSpinner){
                     return  "<span class='checked-spinner'></span>" + item;
                 }
                 return item;
@@ -445,9 +446,9 @@ define(function (require, exports, module) {
                 hideSpinner = !PreferencesManager.getViewState("StatusBar.HideSpinner");
                 PreferencesManager.setViewState("StatusBar.HideSpinner", hideSpinner);
                 if(!hideSpinner){
-                    $("#status-tasks .spinner").removeClass("forced-hidden");
+                    $("#status-tasks .spinner").removeClass("hide-spinner");
                 } else {
-                    $("#status-tasks .spinner").addClass("forced-hidden");
+                    $("#status-tasks .spinner").addClass("hide-spinner");
                 }
                 return;
             }

--- a/src/features/TaskManager.js
+++ b/src/features/TaskManager.js
@@ -55,20 +55,12 @@ define(function (require, exports, module) {
         // the persist option is now used only for errors and success tasks that has not been removed from the task
         // manager list(which usually happens if there is some user action needed). Even then on click the spinner will
         // be hidden again.
-        if(currentSpinnerType === SPINNER_FAIL){
-            // error spinner has the highest priority and is persisted until someone click on the spinner.
-            return;
-        }
         if(spinnerType === SPINNER_FAIL) {
             clearTimeout(spinnerHideTimer);
             $spinner.removeClass("forced-hidden");
             $spinner.removeClass(SPINNER_SUCCESS);
             $spinner.addClass(SPINNER_FAIL);
             currentSpinnerType = SPINNER_FAIL;
-            return;
-        }
-        if(currentSpinnerType === SPINNER_SUCCESS){
-            // success spinner has the second highest priority and is persisted until someone click on the spinner.
             return;
         }
         if(spinnerType === SPINNER_SUCCESS) {
@@ -101,7 +93,7 @@ define(function (require, exports, module) {
      * determines what the spinner icon to show(green-for success), red-fail, blue normal based on the active
      * tasks in list and renders. IF the active tasks has already  been notified, it wont notify again.
      */
-    function renderSpinnerIcon() {
+    function renderSpinnerIcon(newTaskAdded) {
         let unackSuccessTaskFound = false;
         if(currentSpinnerType && currentSpinnerType !== SPINNER_NORMAL) {
             // there is a success/fail spinner visible, clean it. For the normal spinner, it will be
@@ -121,8 +113,12 @@ define(function (require, exports, module) {
             _showSpinnerIcon(SPINNER_SUCCESS);
             return;
         }
+
         // for normal spinner, we dont show anything as its only shown briefly till SPINNER_HIDE_TIME
-        // which was already handled
+        // which was already handled, except when newTaskAdded
+        if(newTaskAdded) {
+            _showSpinnerIcon(SPINNER_NORMAL);
+        }
     }
 
     function _onDropdownShown() {
@@ -451,7 +447,7 @@ define(function (require, exports, module) {
             task._completedStatus = STATUS_FAIL;
             _renderProgressbar(task);
             task._spinnerIconAck= false;
-            _showSpinnerIcon(SPINNER_FAIL);
+            renderSpinnerIcon();
         }
         function isFailed(){
             return task._completedStatus === STATUS_FAIL;
@@ -460,7 +456,7 @@ define(function (require, exports, module) {
             task._completedStatus = STATUS_SUCCESS;
             _renderProgressbar(task);
             task._spinnerIconAck= false;
-            _showSpinnerIcon(SPINNER_SUCCESS);
+            renderSpinnerIcon();
         }
         function isSucceeded(){
             return task._completedStatus === STATUS_SUCCESS;
@@ -522,14 +518,14 @@ define(function (require, exports, module) {
         taskList[task._id] = task;
         EventDispatcher.makeEventDispatcher(task);
         _showOrHideStatusBarIfNeeded();
-        _showSpinnerIcon(SPINNER_NORMAL);
+        renderSpinnerIcon(true);
         return task;
     }
 
     function _setLegacyExtensionBusy(busy) {
         legacyExtensionBusy = busy;
         if(busy){
-            _showSpinnerIcon(SPINNER_NORMAL);
+            renderSpinnerIcon(true);
         } else {
             renderSpinnerIcon();
         }

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -446,6 +446,10 @@ a, img {
     .dark & {
         color: @dark-bc-text;
     }
+
+    .hide-spinner {
+        display: none !important;
+    }
 }
 
 .task-status-popup-item {
@@ -512,7 +516,10 @@ a, img {
     }
 
     .progress-bar-foreground-failure {
-        background: @accent-error;
+        background: @bc-error;
+        .dark & {
+            background: @accent-error;
+        }
         height: 100%;
     }
 
@@ -2528,6 +2535,53 @@ textarea.exclusions-editor {
 
 
 /* Spinner */
+
+.progress-bar-foreground-success {
+    background: @accent-success;
+    height: 100%;
+}
+
+.spinner.spinner-failure {
+    border-left: 3px solid @bc-error;
+    border-right: 3px solid @bc-error;
+
+    .dark & {
+        border-left: 3px solid @accent-error;
+        border-right: 3px solid @accent-error;
+    }
+
+    &:before,
+    &:after {
+        border-left: 3px solid @bc-error;
+        border-right: 3px solid @bc-error;
+
+        .dark & {
+            border-left: 3px solid @accent-error;
+            border-right: 3px solid @accent-error;
+        }
+    }
+}
+
+.spinner.spinner-success {
+    border-left: 3px solid @accent-success;
+    border-right: 3px solid @accent-success;
+
+    .dark & {
+        border-left: 3px solid @accent-success;
+        border-right: 3px solid @accent-success;
+    }
+
+    &:before,
+    &:after {
+        border-left: 3px solid @accent-success;
+        border-right: 3px solid @accent-success;
+
+        .dark & {
+            border-left: 3px solid @accent-success;
+            border-right: 3px solid @accent-success;
+        }
+    }
+}
 
 .spinner {
     display: inline-block;

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -2535,6 +2535,47 @@ textarea.exclusions-editor {
 
 
 /* Spinner */
+.spinner.spinner-failure {
+    border-left: 3px solid @bc-error;
+    border-right: 3px solid @bc-error;
+
+    .dark & {
+        border-left: 3px solid @accent-error;
+        border-right: 3px solid @accent-error;
+    }
+
+    &:before,
+    &:after {
+        border-left: 3px solid @bc-error;
+        border-right: 3px solid @bc-error;
+
+        .dark & {
+            border-left: 3px solid @accent-error;
+            border-right: 3px solid @accent-error;
+        }
+    }
+}
+
+.spinner.spinner-success {
+    border-left: 3px solid @accent-success;
+    border-right: 3px solid @accent-success;
+
+    .dark & {
+        border-left: 3px solid @accent-success;
+        border-right: 3px solid @accent-success;
+    }
+
+    &:before,
+    &:after {
+        border-left: 3px solid @accent-success;
+        border-right: 3px solid @accent-success;
+
+        .dark & {
+            border-left: 3px solid @accent-success;
+            border-right: 3px solid @accent-success;
+        }
+    }
+}
 
 .progress-bar-foreground-success {
     background: @accent-success;

--- a/src/tauri-updater.html
+++ b/src/tauri-updater.html
@@ -43,8 +43,23 @@
         }
 
         async function updateLinux() {
-            status = UPDATE_STATUS.FAILED;
-            sendUpdateEvent(UPDATE_EVENT.STATUS, UPDATE_STATUS.FAILED);
+            try {
+                const command = new __TAURI__.shell.Command('run-update-linux-command',
+                    ['-e', 'wget -qO- https://updates.phcode.io/linux/installer.sh | bash -s -- --upgrade'])
+                const result = await command.execute();
+                if(result.code !== 0){
+                    status = UPDATE_STATUS.FAILED;
+                    sendUpdateEvent(UPDATE_EVENT.LOG_ERROR, result.stderr);
+                    sendUpdateEvent(UPDATE_EVENT.STATUS, UPDATE_STATUS.FAILED);
+                    return;
+                }
+                status = UPDATE_STATUS.INSTALLED;
+                sendUpdateEvent(UPDATE_EVENT.STATUS, UPDATE_STATUS.INSTALLED);
+            } catch (e) {
+                status = UPDATE_STATUS.FAILED;
+                sendUpdateEvent(UPDATE_EVENT.LOG_ERROR, e.stack);
+                sendUpdateEvent(UPDATE_EVENT.STATUS, UPDATE_STATUS.FAILED);
+            }
         }
 
         async function updateWindows() {

--- a/test/spec/TaskManager-integ-test.js
+++ b/test/spec/TaskManager-integ-test.js
@@ -427,5 +427,18 @@ define(function (require, exports, module) {
             task.close();
             expect(testWindow.$("#status-tasks .spinner").is(":visible")).toBeFalse();
         });
+
+        it(`Should task be able to change spinner type`, async function(){
+            const task = TaskManager.addNewTask("title", "message");
+            expect(testWindow.$("#status-tasks .spinner").is(":visible")).toBeTrue();
+            task.setFailed();
+            expect(testWindow.$("#status-tasks .spinner").hasClass("spinner-failure")).toBeTrue();
+            task.setSucceded();
+            expect(testWindow.$("#status-tasks .spinner").hasClass("spinner-success")).toBeTrue();
+            task.setProgressPercent(10);
+            expect(testWindow.$("#status-tasks .spinner").hasClass("spinner-failure")).toBeFalse();
+            expect(testWindow.$("#status-tasks .spinner").hasClass("spinner-success")).toBeFalse();
+            task.close();
+        });
     });
 });


### PR DESCRIPTION
To make the task spinner less distracting, the following changes were made:
1. The spinner will only be shown for 3 seconds when a task is created.
2. The spinner will be shown coninuously in green color if there is a success notification that the user should see.
3. the pinner will spin in red on any task failure untill user cicks the tasks list, or the faulre is resoved automatically.
4. When the task closes itself, the spinner will adjust to the most appropriate color based on success/fail tasks pending in the list.

### fail spinner
![image](https://github.com/phcode-dev/phoenix/assets/5336369/f9fec141-2df1-4d17-9525-1abb60367fe6)
![image](https://github.com/phcode-dev/phoenix/assets/5336369/e849f37f-3aa2-401e-ab5e-fdc10e65888b)

### success spinner
![image](https://github.com/phcode-dev/phoenix/assets/5336369/9125e66e-e2b3-4d0e-9870-5cad40768080)
![image](https://github.com/phcode-dev/phoenix/assets/5336369/c8d81f13-29d7-4906-aff2-8749f08b2b9f)

## Also adds linux upgrade scripts
To verify after scripts deployment
