### PR TITLE
chore: multi window sync for phstore

### DIFF
--- a/src/extensionsIntegrated/RecentProjects/main.js
+++ b/src/extensionsIntegrated/RecentProjects/main.js
@@ -539,6 +539,8 @@ define(function (require, exports, module) {
     AppInit.appReady(function () {
         ProjectManager.on("projectOpen", add);
         ProjectManager.on("beforeProjectClose", add);
+        // add the current project at startup.
+        add();
     });
 
     AppInit.htmlReady(function () {

--- a/test/spec/TaskManager-integ-test.js
+++ b/test/spec/TaskManager-integ-test.js
@@ -178,9 +178,10 @@ define(function (require, exports, module) {
             expect(testWindow.$(".dropdown-status-bar").is(":visible")).toBeFalse();
         });
 
-        function getProgressPercent() {
-            return Math.round((testWindow.$(".dropdown-status-bar .progress").width() /
+        function expectProgressPercentToBeAround(progress) {
+            const progressShown = Math.floor((testWindow.$(".dropdown-status-bar .progress").width() /
                 testWindow.$(".dropdown-status-bar .progress").parent().width()) * 100);
+            expect(progress >= (progressShown-1) && progress <= (progressShown+1)).toBeTrue();
         }
 
         it("Should be able to add with progress percent", async function () {
@@ -190,7 +191,7 @@ define(function (require, exports, module) {
             });
             testWindow.$("#status-tasks .btn-status-bar").click();
             expect(testWindow.$(".dropdown-status-bar").is(":visible")).toBeTrue();
-            expect(getProgressPercent()).toBe(progressPercent);
+            expectProgressPercentToBeAround(progressPercent);
             expect(testWindow.$(".dropdown-status-bar .progress").hasClass('progress-bar-foreground')).toBeTrue();
             task.close();
             expect(testWindow.$(".dropdown-status-bar").is(":visible")).toBeFalse();
@@ -202,12 +203,12 @@ define(function (require, exports, module) {
             expect(testWindow.$(".dropdown-status-bar").is(":visible")).toBeTrue();
             expect(testWindow.$(".dropdown-status-bar .progress").hasClass('progress-bar-foreground-pulse')).toBeTrue();
             task.setProgressPercent(0);
-            expect(getProgressPercent()).toBe(100);
+            expectProgressPercentToBeAround(100);
             expect(testWindow.$(".dropdown-status-bar .progress").hasClass('progress-bar-foreground-pulse')).toBeTrue();
             task.setProgressPercent(10);
-            expect(getProgressPercent()).toBe(10);
+            expectProgressPercentToBeAround(10);
             task.setProgressPercent(70);
-            expect(getProgressPercent()).toBe(70);
+            expectProgressPercentToBeAround(70);
             expect(testWindow.$(".dropdown-status-bar .progress").hasClass('progress-bar-foreground')).toBeTrue();
             task.close();
             expect(testWindow.$(".dropdown-status-bar").is(":visible")).toBeFalse();
@@ -219,7 +220,7 @@ define(function (require, exports, module) {
             testWindow.$("#status-tasks .btn-status-bar").click();
             expect(testWindow.$(".dropdown-status-bar").is(":visible")).toBeTrue();
 
-            expect(getProgressPercent()).toBe(70);
+            expectProgressPercentToBeAround(70);
             expect(testWindow.$(".dropdown-status-bar .progress").hasClass('progress-bar-foreground')).toBeTrue();
             task.close();
             expect(testWindow.$(".dropdown-status-bar").is(":visible")).toBeFalse();
@@ -230,7 +231,7 @@ define(function (require, exports, module) {
             task.setSucceded();
             testWindow.$("#status-tasks .btn-status-bar").click();
             expect(testWindow.$(".dropdown-status-bar").is(":visible")).toBeTrue();
-            expect(getProgressPercent()).toBe(100);
+            expectProgressPercentToBeAround(100);
             expect(testWindow.$(".dropdown-status-bar .progress").hasClass('progress-bar-foreground-success')).toBeTrue();
             task.close();
             expect(testWindow.$(".dropdown-status-bar").is(":visible")).toBeFalse();
@@ -241,7 +242,7 @@ define(function (require, exports, module) {
             task.setFailed();
             testWindow.$("#status-tasks .btn-status-bar").click();
             expect(testWindow.$(".dropdown-status-bar").is(":visible")).toBeTrue();
-            expect(getProgressPercent()).toBe(100);
+            expectProgressPercentToBeAround(100);
             expect(testWindow.$(".dropdown-status-bar .progress").hasClass('progress-bar-foreground-failure')).toBeTrue();
             task.close();
             expect(testWindow.$(".dropdown-status-bar").is(":visible")).toBeFalse();
@@ -252,12 +253,12 @@ define(function (require, exports, module) {
             task.setFailed();
             testWindow.$("#status-tasks .btn-status-bar").click();
             expect(testWindow.$(".dropdown-status-bar").is(":visible")).toBeTrue();
-            expect(getProgressPercent()).toBe(100);
+            expectProgressPercentToBeAround(100);
             expect(testWindow.$(".dropdown-status-bar .progress").hasClass('progress-bar-foreground-failure')).toBeTrue();
 
             // now try to set progress to reset the failure
             task.setProgressPercent(70);
-            expect(getProgressPercent()).toBe(70);
+            expectProgressPercentToBeAround(70);
             expect(testWindow.$(".dropdown-status-bar .progress").hasClass('progress-bar-foreground')).toBeTrue();
 
             task.close();


### PR DESCRIPTION
This pull request addresses data consistency issues in Tauri applications with multiple windows. Previously, each window committed its storage changes to disk on exit or every 30 seconds, leading to potential stale data when a new window is created and the new window will read stale dump file.

The solution introduces a local memory cache in Tauri's Rust backend. This cache consolidates storage changes from all windows, providing immediate access to the latest data before disk commit. It ensures all windows work with the most current storage state, bypassing the delay of dump file creation in multi window mode. This works as our app in a ingle instance - multiple window app.

Changes:

- Added a local memory cache in Rust to aggregate storage updates from multiple windows.
- Updated storage access to use this cache, ensuring up-to-date data retrieval.
- at boot, a window will take the dump file that may be stale, and then merges the data from the in memory cache to recreate the global view without waiting for a disc dump.