### PR TITLE
chore: remove github project option from desktop builds till git integration

### DIFF
--- a/src/assets/new-project/assets/js/code-editor.js
+++ b/src/assets/new-project/assets/js/code-editor.js
@@ -213,6 +213,10 @@ function initCodeEditor() {
             _openURLInTauri(document.getElementById(iconID).getAttribute('href'));
         };
     }
+    if(window.top.__TAURI__) {
+        // in desktop, we don't show github project option till we have git extension integrated.
+        document.getElementById("newGitHubProject").classList.add("forced-hidden");
+    }
     document.getElementById("newGitHubProject").onclick = function() {
         Metrics.countEvent(Metrics.EVENT_TYPE.NEW_PROJECT, "main.Click", "github-project");
         window.location.href = 'new-project-github.html';


### PR DESCRIPTION
The github project option in desktop will overload our poor servers, and its unnecessary as desktop builds can clone themselves. So disabing this feature in desktop builds till we have native git integration.

## in desktop
![image](https://github.com/phcode-dev/phoenix/assets/5336369/f882d833-0f60-45be-9882-0b0a653a189c)

## in web
![image](https://github.com/phcode-dev/phoenix/assets/5336369/fe0bd805-576d-436b-8696-60b92be879f6)
