### PR TITLE
chore: migrate legacy state and change bin icon for remove from recent projects 

### DIFF
--- a/src/assets/new-project/assets/css/style.css
+++ b/src/assets/new-project/assets/css/style.css
@@ -57,6 +57,14 @@ img {
     -ms-user-select: none;
 }
 
+.recent-project-remove {
+    font-size: small;
+    color: #8A8A8A;
+}
+.recent-project-remove:hover {
+    color: white;
+}
+
 .side-nav {
     background: #5D5F60;
     height: 100vh;

--- a/src/assets/new-project/assets/js/code-editor.js
+++ b/src/assets/new-project/assets/js/code-editor.js
@@ -41,19 +41,9 @@ function _createRecentProjectCard(fullPath, displayLocation, nodeId, tabIndex) {
             <div class="project-name">
                 ${newProjectExtension.path.basename(fullPath)}
             </div>
-            <button class="remove-btn" onclick="removeProject('${fullPath}');_recentProjectMetric('remove');"
-            style="${removeBtnDisableStyle}">
-                <svg width="16" height="16" viewBox="0 0 14 14" fill="none"
-                     xmlns="http://www.w3.org/2000/svg">
-                    <path d="M1.75 3.5H2.91667H12.25" stroke="#D0D0D0" stroke-linecap="round"
-                          stroke-linejoin="round"/>
-                    <path d="M4.6665 3.50008V2.33341C4.6665 2.024 4.78942 1.72725 5.00821 1.50846C5.22701 1.28966 5.52375 1.16675 5.83317 1.16675H8.1665C8.47592 1.16675 8.77267 1.28966 8.99146 1.50846C9.21026 1.72725 9.33317 2.024 9.33317 2.33341V3.50008M11.0832 3.50008V11.6667C11.0832 11.9762 10.9603 12.2729 10.7415 12.4917C10.5227 12.7105 10.2259 12.8334 9.91651 12.8334H4.08317C3.77375 12.8334 3.47701 12.7105 3.25821 12.4917C3.03942 12.2729 2.9165 11.9762 2.9165 11.6667V3.50008H11.0832Z"
-                          stroke="#D0D0D0" stroke-linecap="round" stroke-linejoin="round"/>
-                    <path d="M5.8335 6.41675V9.91675" stroke="#D0D0D0" stroke-linecap="round"
-                          stroke-linejoin="round"/>
-                    <path d="M8.1665 6.41675V9.91675" stroke="#D0D0D0" stroke-linecap="round"
-                          stroke-linejoin="round"/>
-                </svg>
+            <button class="remove-btn recent-project-remove" onclick="removeProject('${fullPath}');_recentProjectMetric('remove');"
+            style="${removeBtnDisableStyle};" title="${Strings.REMOVE_FROM_RECENT_PROJECTS}">
+                <i class="fa-solid fa-xmark"></i>
             </button>
         </a>
         <div style="overflow: hidden;">

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -851,6 +851,7 @@ define({
 
     // extensions/default/RecentProjects
     "CMD_TOGGLE_RECENT_PROJECTS": "Recent Projects",
+    "REMOVE_FROM_RECENT_PROJECTS": "Remove from Recent Projects",
 
     // extensions/default/MDNDocs
     "DOCS_MORE_LINK": "Read more",

--- a/src/preferences/PreferencesImpl.js
+++ b/src/preferences/PreferencesImpl.js
@@ -30,7 +30,7 @@ define(function (require, exports, module) {
 
     const PreferencesBase = require("./PreferencesBase"),
         Async           = require("utils/Async"),
-        FileSystem      = require("filesystem/FileSystem"),
+        StateManager            = require("preferences/StateManager"),
 
         // The SETTINGS_FILENAME is used with a preceding "." within user projects
         SETTINGS_FILENAME = "phcode.json",
@@ -85,6 +85,7 @@ define(function (require, exports, module) {
     var userScopeLoading = manager.addScope("user", userScope);
 
     _addScopePromises.push(userScopeLoading);
+    _addScopePromises.push(StateManager._migrateLegacyStateFile());
 
     // Set up the .phcode.json file handling
     userScopeLoading

--- a/src/preferences/StateManager.js
+++ b/src/preferences/StateManager.js
@@ -247,7 +247,7 @@ define(function (require, exports, module) {
      * @private
      */
     function _migrateLegacyStateFile() {
-        if(Phoenix.firstBoot){
+        if(Phoenix.firstBoot || Phoenix.isTestWindow){
             // nothing to migrate, fresh install
             setVal(LEGACY_STATE_MANAGER_MIGRATED, true);
             return new $.Deferred().resolve().promise();

--- a/src/preferences/StateManager.js
+++ b/src/preferences/StateManager.js
@@ -20,6 +20,7 @@
  */
 
 /*unittests: Preferences Manager */
+/*global fs*/
 
 /**
  * StateManager
@@ -28,7 +29,11 @@
 define(function (require, exports, module) {
     const _ = require("thirdparty/lodash"),
         EventDispatcher = require("utils/EventDispatcher"),
+        Metrics = require("utils/Metrics"),
         ProjectManager = require("project/ProjectManager");
+
+    const LEGACY_STATE_MANAGER_MIGRATED = "ph_state_manager_migrated";
+    const LEGACY_STATE_FILE_PATH = "/fs/app/state.json";
 
     const PROJECT_CONTEXT = "project";
     const GLOBAL_CONTEXT = "global";
@@ -235,6 +240,68 @@ define(function (require, exports, module) {
         return createExtensionStateManager(prefix);
     }
 
+    /**
+     * We used file based state.json in the earlier state manager impl. no  we moved to phstore. So we have to move
+     * earlier users to phstore to prevent losing their files. This code can be deleted anytime after 4 months
+     * from this commit.
+     * @private
+     */
+    function _migrateLegacyStateFile() {
+        if(Phoenix.firstBoot){
+            // nothing to migrate, fresh install
+            setVal(LEGACY_STATE_MANAGER_MIGRATED, true);
+            return new $.Deferred().resolve().promise();
+        }
+        if(getVal(LEGACY_STATE_MANAGER_MIGRATED)){
+            return new $.Deferred().resolve().promise();
+        }
+        const _migrated = new $.Deferred();
+        console.log("Migrating legacy state file", LEGACY_STATE_FILE_PATH);
+        fs.readFile(LEGACY_STATE_FILE_PATH, "utf8", function (err, data) {
+            setVal(LEGACY_STATE_MANAGER_MIGRATED, true);
+            if (err) {
+                // if error, ignore and continue. state file not found(unlikely to be here)
+                _migrated.resolve();
+                return;
+            }
+            try{
+                const keysToMigrate = [
+                    "afterFirstLaunch",
+                    "sidebar",
+                    "workingSetSortMethod",
+                    "healthDataUsage",
+                    "main-toolbar",
+                    "recentProjects",
+                    "healthDataNotificationShown",
+                    "searchHistory",
+                    "problems-panel"
+                ];
+                const oldState = JSON.parse(data);
+                for(let key of keysToMigrate) {
+                    if(oldState[key]){
+                        console.log("Migrated Legacy state: ", key, oldState[key]);
+                        setVal(key, oldState[key]);
+                    }
+                }
+                fs.unlink(LEGACY_STATE_FILE_PATH, (unlinkErr)=>{
+                    if(unlinkErr){
+                        console.error(`Error deleting legacy state file ${LEGACY_STATE_FILE_PATH}`, unlinkErr);
+                    }
+                });
+            } catch (e) {
+                console.error("Error migrating legacy state file", LEGACY_STATE_FILE_PATH);
+            }
+            Metrics.countEvent(Metrics.EVENT_TYPE.PLATFORM, "legacyState", "migrated");
+            _migrated.resolve();
+            console.log("Legacy state migration completed");
+        });
+        return _migrated.promise();
+    }
+
+    // private API
+    exports._migrateLegacyStateFile = _migrateLegacyStateFile;
+
+    // public api
     exports.get     = getVal;
     exports.set     = setVal;
     exports.definePreference = definePreferenceInternal;


### PR DESCRIPTION
# Change bin icon to close icon to prevent UI confusion
Bin icon generally means delete and is not the correct one to remove folder from list without deleting the folder.
![Screenshot from 2024-02-26 10-05-00](https://github.com/phcode-dev/phoenix/assets/5336369/d545e82f-c6c9-45ca-8d9f-2cd12ffbb96c)
Earlier:
![image](https://github.com/phcode-dev/phoenix/assets/5336369/a0d57593-20e8-48dd-b6a9-0635acca8036)

# Migrate from legacy state manager to phstore
In browser, we still have users in the old state manager, so if we just switch to phstore, they will loose their recent projects(which can seem like a data loss for browser only projects, thought the underlying virtual fs folders are not deleted.), 

We don't restore everything from previous state manager as it may lead to corruption if there is some custom state injected by extensions, just enough to not lose project data.