### PR TITLE
fix: force find in node_modules should work

### DIFF
--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1980,26 +1980,31 @@ define(function (require, exports, module) {
      * @param {boolean=} includeWorkingSet If true, include files in the working set
      *          that are not under the project root (*except* for untitled documents).
      * @param {boolean=} sort If true, The files will be sorted by their paths
+     * @param {Object} options optional path within project to narrow down the search
+     * @param {File} options.scope optional path within project to narrow down the search
      *
      * @return {$.Promise} Promise that is resolved with an Array of File objects.
      */
-    function getAllFiles(filter, includeWorkingSet, sort) {
+    function getAllFiles(filter, includeWorkingSet, sort, options) {
         var viewFiles, deferred;
 
         // The filter and includeWorkingSet params are both optional.
         // Handle the case where filter is omitted but includeWorkingSet is
         // specified.
-        if (includeWorkingSet === undefined && typeof (filter) !== "function") {
+        if (typeof (filter) !== "function") {
+            options = sort;
+            sort = includeWorkingSet;
             includeWorkingSet = filter;
             filter = null;
         }
+        options = options || {};
 
         if (includeWorkingSet) {
             viewFiles = MainViewManager.getWorkingSet(MainViewManager.ALL_PANES);
         }
 
         deferred = new $.Deferred();
-        model.getAllFiles(filter, viewFiles, sort)
+        model.getAllFiles(filter, viewFiles, sort, {scope: options.scope})
             .done(function (fileList) {
                 deferred.resolve(fileList);
             })

--- a/src/search/FindInFiles.js
+++ b/src/search/FindInFiles.js
@@ -368,7 +368,9 @@ define(function (require, exports, module) {
         if (scope && scope.isFile) {
             return new $.Deferred().resolve(filter(scope) ? [scope] : []).promise();
         }
-        return ProjectManager.getAllFiles(filter, true, true);
+        return ProjectManager.getAllFiles(filter, true, true, {
+            scope
+        });
 
     }
 
@@ -932,7 +934,7 @@ define(function (require, exports, module) {
     var _initCache = function () {
         projectIndexingComplete = false;
         function filter(file) {
-            return _subtreeFilter(file, null) && _isReadableFileType(file.fullPath);
+            return _isReadableFileType(file.fullPath);
         }
         FindUtils.setInstantSearchDisabled(true);
 

--- a/test/spec/FindInFiles-integ-test.js
+++ b/test/spec/FindInFiles-integ-test.js
@@ -259,6 +259,56 @@ define(function (require, exports, module) {
                 expect(fileResults.matches.length).toBe(3);
             });
 
+            it("should find all occurrences in node_modules folder", async function () {
+                var dirEntry = FileSystem.getDirectoryForPath(testPath + "/node_modules/");
+                await openSearchBar(dirEntry);
+                await executeSearch("foo");
+
+                var fileResults = FindInFiles.searchModel.results[testPath + "/bar.txt"];
+                expect(fileResults).toBeFalsy();
+
+                fileResults = FindInFiles.searchModel.results[testPath + "/foo.html"];
+                expect(fileResults).toBeFalsy();
+
+                fileResults = FindInFiles.searchModel.results[testPath + "/foo.js"];
+                expect(fileResults).toBeFalsy();
+
+                fileResults = FindInFiles.searchModel.results[testPath + "/css/foo.css"];
+                expect(fileResults).toBeFalsy();
+
+                fileResults = FindInFiles.searchModel.results[testPath + "/node_modules/node_modules/test2.js"];
+                expect(fileResults).toBeFalsy();
+
+                fileResults = FindInFiles.searchModel.results[testPath + "/node_modules/test.js"];
+                expect(fileResults).toBeTruthy();
+                expect(fileResults.matches.length).toBe(1);
+            });
+
+            it("should find all occurrences in nested node_modules folder", async function () {
+                var dirEntry = FileSystem.getDirectoryForPath(testPath + "/node_modules/node_modules/");
+                await openSearchBar(dirEntry);
+                await executeSearch("foo");
+
+                var fileResults = FindInFiles.searchModel.results[testPath + "/bar.txt"];
+                expect(fileResults).toBeFalsy();
+
+                fileResults = FindInFiles.searchModel.results[testPath + "/foo.html"];
+                expect(fileResults).toBeFalsy();
+
+                fileResults = FindInFiles.searchModel.results[testPath + "/foo.js"];
+                expect(fileResults).toBeFalsy();
+
+                fileResults = FindInFiles.searchModel.results[testPath + "/css/foo.css"];
+                expect(fileResults).toBeFalsy();
+
+                fileResults = FindInFiles.searchModel.results[testPath + "/node_modules/test.js"];
+                expect(fileResults).toBeFalsy();
+
+                fileResults = FindInFiles.searchModel.results[testPath + "/node_modules/node_modules/test2.js"];
+                expect(fileResults).toBeTruthy();
+                expect(fileResults.matches.length).toBe(1);
+            });
+
             it("should find all occurences in single file", async function () {
                 var fileEntry = FileSystem.getFileForPath(testPath + "/foo.js");
                 await openSearchBar(fileEntry);

--- a/test/spec/FindReplace-test-files/node_modules/node_modules/test2.js
+++ b/test/spec/FindReplace-test-files/node_modules/node_modules/test2.js
@@ -1,0 +1,1 @@
+// will not be searched if the parent node module folder is being searched foo

--- a/test/spec/FindReplace-test-files/node_modules/test.js
+++ b/test/spec/FindReplace-test-files/node_modules/test.js
@@ -1,0 +1,1 @@
+// only_search_if_forced foo


### PR DESCRIPTION
Selecting the node_modules folder and selecting `find in` should override the node module or other filters and trigger a find in the folder. Useful when you want to search within a specific package in the node_modules folder

![image](https://github.com/phcode-dev/phoenix/assets/5336369/ee0322c4-7e8e-48d5-beae-c5b679494709)
