### PR TITLE
fix: frequent 403 for node download in desktop tests and toast notification better visual hyperlink colors

### DIFF
--- a/.github/workflows/desktop-linux-prod-test-pull.yml
+++ b/.github/workflows/desktop-linux-prod-test-pull.yml
@@ -35,6 +35,8 @@ jobs:
           npm run release:prod
 
       - name: Download phoenix desktop and build test runner
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd ..
           git clone https://github.com/phcode-dev/phoenix-desktop.git

--- a/.github/workflows/desktop-linux-test-pull.yml
+++ b/.github/workflows/desktop-linux-test-pull.yml
@@ -34,6 +34,8 @@ jobs:
           npm run release:dev
 
       - name: Download phoenix desktop and build test runner
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd ..
           git clone https://github.com/phcode-dev/phoenix-desktop.git

--- a/.github/workflows/desktop-mac-m1-test-pull.yml
+++ b/.github/workflows/desktop-mac-m1-test-pull.yml
@@ -27,8 +27,6 @@ jobs:
           npm run release:dev
 
       - name: Download phoenix desktop and build test runner
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd ..
           git clone https://github.com/phcode-dev/phoenix-desktop.git

--- a/.github/workflows/desktop-mac-m1-test-pull.yml
+++ b/.github/workflows/desktop-mac-m1-test-pull.yml
@@ -27,6 +27,8 @@ jobs:
           npm run release:dev
 
       - name: Download phoenix desktop and build test runner
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd ..
           git clone https://github.com/phcode-dev/phoenix-desktop.git

--- a/.github/workflows/desktop-mac-test-pull.yml
+++ b/.github/workflows/desktop-mac-test-pull.yml
@@ -27,6 +27,8 @@ jobs:
           npm run release:dev
 
       - name: Download phoenix desktop and build test runner
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd ..
           git clone https://github.com/phcode-dev/phoenix-desktop.git

--- a/.github/workflows/desktop-windows-test-pull.yml
+++ b/.github/workflows/desktop-windows-test-pull.yml
@@ -27,6 +27,8 @@ jobs:
           npm run release:dev
 
       - name: Download phoenix desktop and build test runner
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd ..
           git clone https://github.com/phcode-dev/phoenix-desktop.git

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -2968,18 +2968,38 @@ label input {
 
 .notification-popup-container.style-danger {
     background: var(--bc-toast-danger-bg-color);
+    a {
+        color: white;
+        cursor: pointer;
+    }
 }
 .notification-popup-container.style-error {
     background: var(--bc-toast-error-bg-color);
+    a {
+        color: white;
+        cursor: pointer;
+    }
 }
 .notification-popup-container.style-info {
     background: var(--bc-toast-info-bg-color);
+    a {
+        color: blue;
+        cursor: pointer;
+    }
 }
 .notification-popup-container.style-success {
     background: var(--bc-toast-success-bg-color);
+    a {
+        color: darkblue;
+        cursor: pointer;
+    }
 }
 .notification-popup-container.style-warning {
     background: var(--bc-toast-warning-bg-color);
+    a {
+        color: white;
+        cursor: pointer;
+    }
 }
 
 .notification-popup-container.animateOpen {


### PR DESCRIPTION
## two fixes in this pr
### notification colors
The colors of toast notification has been improved for error, info, etc.. see info style color scheme in below pic.
![image](https://github.com/phcode-dev/phoenix/assets/5336369/ac119cfa-d09b-40d6-b4a0-3116a30e7089)

### build failures
fix mac frequent node download failures by using GitHub auth downloads.
