### PR TITLE
fix: mac updates will be extracted nad deleted on appquit to prevent multiple app listing in open with

### DIFF
--- a/src/extensionsIntegrated/appUpdater/main.js
+++ b/src/extensionsIntegrated/appUpdater/main.js
@@ -407,6 +407,10 @@ define(function (require, exports, module) {
         if(!installerLocation){
             return;
         }
+        // at this time, the node process have exited and we need to force use tauri apis. This would
+        // normally happen as node responds as terminated, but for updates, this is at quit time and we
+        // cant wait any longer.
+        window.fs.forceUseNodeWSEndpoint(false);
         console.log("Installing update from: ", installerLocation);
         return new Promise(resolve=>{
             // this should never reject as it happens in app quit. rejecting wont affect quit, but its unnecessary.

--- a/src/extensionsIntegrated/appUpdater/main.js
+++ b/src/extensionsIntegrated/appUpdater/main.js
@@ -336,7 +336,6 @@ define(function (require, exports, module) {
     }
 
     async function _extractMacInstaller() {
-        // todo delete .app files already in the install folder
         const appdataDir = window._tauriBootVars.appLocalDir;
         let extractPlatformPath = path.join(appdataDir, 'installer', "extracted");
         // extract the .app file
@@ -378,7 +377,7 @@ define(function (require, exports, module) {
     }
 
     async function doMacUpdate() {
-        await _extractMacInstaller(installerLocation);
+        await _extractMacInstaller();
         const currentAppPath = await getCurrentMacAppPath();
         if(!currentAppPath || !installerLocation || !currentAppPath.endsWith(".app") ||
             !installerLocation.endsWith(".app")){

--- a/src/extensionsIntegrated/appUpdater/main.js
+++ b/src/extensionsIntegrated/appUpdater/main.js
@@ -27,6 +27,7 @@ define(function (require, exports, module) {
     const AppInit = require("utils/AppInit"),
         Metrics = require("utils/Metrics"),
         FileSystem    = require("filesystem/FileSystem"),
+        FileUtils   = require("file/FileUtils"),
         Commands = require("command/Commands"),
         CommandManager  = require("command/CommandManager"),
         Menus = require("command/Menus"),
@@ -358,10 +359,11 @@ define(function (require, exports, module) {
         const extractedVirtualPath = window.fs.getTauriVirtualPath(extractPlatformPath);
         let directory = FileSystem.getDirectoryForPath(extractedVirtualPath);
         const {entries} = await directory.getContentsAsync();
-        if(entries.length !== 1){
+        if(entries.length !== 1 || !entries[0].fullPath.includes(".app")){
             throw new Error("Could not resolve .app to update from extracted folder" + extractedVirtualPath);
         }
-        installerLocation = window.fs.getTauriPlatformPath(entries[0].fullPath);
+        installerLocation = FileUtils.stripTrailingSlash(
+            window.fs.getTauriPlatformPath(entries[0].fullPath));
     }
 
     function _cleanExtractedFolderSilent() {

--- a/src/node-loader.js
+++ b/src/node-loader.js
@@ -718,6 +718,7 @@ function nodeLoader() {
                 };
 
                 window.PhNodeEngine.terminateNode = function () {
+                    fs.forceUseNodeWSEndpoint(false);
                     if(!window.isNodeTerminated) {
                         execNode(NODE_COMMANDS.TERMINATE);
                     }

--- a/src/node-loader.js
+++ b/src/node-loader.js
@@ -718,7 +718,6 @@ function nodeLoader() {
                 };
 
                 window.PhNodeEngine.terminateNode = function () {
-                    fs.forceUseNodeWSEndpoint(false);
                     if(!window.isNodeTerminated) {
                         execNode(NODE_COMMANDS.TERMINATE);
                     }


### PR DESCRIPTION
See phoenix code `3.3.4` in applicastions folder and `3.3.6` in `<appdata>/installer/extracted/Phoenix Code.app` folder both being listed in open with in mac. This was happening as we downloaded and extracted the update while `3.3.4` was running into the appdata folder, and Mac will detect `3.3.6` and will start to list the app in the `open with menu` even though its not yet installed.
![image](https://github.com/phcode-dev/phoenix/assets/5336369/3fda0a1e-8f3f-41f6-b565-83404bca29b1)
