### PR TITLE
fix: remove word rap default as it makes large line files load stuck …

### DIFF
--- a/src/editor/EditorHelper/EditorPreferences.js
+++ b/src/editor/EditorHelper/EditorPreferences.js
@@ -147,7 +147,7 @@ define(function (require, exports, module) {
     PreferencesManager.definePreference(USE_TAB_CHAR,       "boolean", false, {
         description: Strings.DESCRIPTION_USE_TAB_CHAR
     });
-    PreferencesManager.definePreference(WORD_WRAP,          "boolean", true, {
+    PreferencesManager.definePreference(WORD_WRAP,          "boolean", false, {
         description: Strings.DESCRIPTION_WORD_WRAP
     });
 


### PR DESCRIPTION
Brackets had default to word wrap- false. But phcode changed it to true without realizing that it heavily affected file load performance on files with large lines(Eg. Min css/min.js). Reverting back to word wrap false for performance.

All VSCode and Webstorm also defaults to word wrap false.