### PR TITLE
Feat: visual command navigation palette on ctrl-p and triple ctrl key

### DIFF
--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -1094,12 +1094,12 @@ define(function (require, exports, module) {
         Control: true,
         Meta: true
     };
-    function _detectDoubleCtrlKeyPress(event) {
+    function _detectTripleCtrlKeyPress(event) {
         if (ctrlKeyCodes[event.code] && ctrlKeyCodes[event.key] && !event.shiftKey && !event.altKey) {
             const currentTime = new Date().getTime(); // Get the current time
             pressCount++;
             if (currentTime - lastKeyPressTime <= doublePressInterval) {
-                if(pressCount === 2) {
+                if(pressCount === 3) {
                     KeyboardOverlayMode.startOverlayMode();
                     event.stopPropagation();
                     event.preventDefault();
@@ -1166,7 +1166,7 @@ define(function (require, exports, module) {
         if(KeyboardOverlayMode.isInOverlayMode()){
             return KeyboardOverlayMode.processOverlayKeyboardEvent(event);
         }
-        if(_detectDoubleCtrlKeyPress(event)){
+        if(_detectTripleCtrlKeyPress(event)){
             return true;
         }
         const shortcut = _translateKeyboardEvent(event);

--- a/src/command/KeyboardOverlayMode.js
+++ b/src/command/KeyboardOverlayMode.js
@@ -43,7 +43,7 @@ define(function (require, exports, module) {
 
     function showOverlay(targetId) {
         // Find the target div and the overlay div
-        Metrics.countEvent(Metrics.EVENT_TYPE.KEYBOARD, "ctrlx2", "showOverlay");
+        Metrics.countEvent(Metrics.EVENT_TYPE.KEYBOARD, "ctrlx3", "showOverlay");
         if(!targetId){
             console.error("No target ID for selecting overlay. Ignoring");
             return;
@@ -182,7 +182,11 @@ define(function (require, exports, module) {
     });
 
     AppInit.appReady(function () {
-        CommandManager.register(Strings.CMD_KEYBOARD_NAV_OVERLAY,    Commands.CMD_KEYBOARD_NAV_UI_OVERLAY, startOverlayMode);
+        CommandManager.register(Strings.CMD_KEYBOARD_NAV_OVERLAY,
+            Commands.CMD_KEYBOARD_NAV_UI_OVERLAY, startOverlayMode);
+        const viewMenu = Menus.getMenu(Menus.AppMenuBar.VIEW_MENU);
+        viewMenu.addMenuItem(Commands.CMD_KEYBOARD_NAV_UI_OVERLAY, 'Ctrl-P',
+            Menus.AFTER, Commands.VIEW_TOGGLE_INSPECTION);
     });
 
     exports.processOverlayKeyboardEvent = processOverlayKeyboardEvent;

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -497,7 +497,7 @@ define({
     "CMD_WORKING_SORT_TOGGLE_AUTO": "Automatic Sort",
     "CMD_THEMES": "Themes\u2026",
     "CMD_TOGGLE_SEARCH_AUTOHIDE": "Automatically close search",
-    "CMD_KEYBOARD_NAV_OVERLAY": "UI Navigation Mode",
+    "CMD_KEYBOARD_NAV_OVERLAY": "Visual Command Palette",
 
     // Navigate menu commands
     "NAVIGATE_MENU": "Navigate",

--- a/test/spec/Keyboard-nav-integ-test.js
+++ b/test/spec/Keyboard-nav-integ-test.js
@@ -64,7 +64,8 @@ define(function (require, exports, module) {
             await SpecRunnerUtils.closeTestWindow();
         }, 30000);
 
-        function doubleControlEvent() {
+        function tripleControlEvent() {
+            keyboardType(Keys.KEY.CONTROL);
             keyboardType(Keys.KEY.CONTROL);
             keyboardType(Keys.KEY.CONTROL);
         }
@@ -103,10 +104,10 @@ define(function (require, exports, module) {
             }, "overlay to be shown");
         }
 
-        it("Should show overlay on double control and exit on escape", async function () {
+        it("Should show overlay on triple control and exit on escape", async function () {
             MainViewManager.setLayoutScheme(1, 1);
             await openAnyFile();
-            doubleControlEvent();
+            tripleControlEvent();
             await awaitsFor(()=>{
                 return testWindow.$('#ctrl-nav-overlay').is(":visible");
             }, "overlay to be shown");


### PR DESCRIPTION
1. To prevent accidental activation as from user feedback, changed ui nav shortcut to triple ctrl/cmd key press instead of double.
2. Added shortcut `Ctel-P` to ui visual nav as this will be our visual command palette workflow.