### PR TITLE
feat: open live preview in chrome, edge, safari and firefox buttons

### DIFF
--- a/gulpfile.js/thirdparty-lib-copy.js
+++ b/gulpfile.js/thirdparty-lib-copy.js
@@ -173,6 +173,12 @@ let copyThirdPartyLibs = series(
         'src/thirdparty/devicon/'),
     copyFiles.bind(copyFiles, ['node_modules/devicon/fonts/*.*'],
         'src/thirdparty/devicon/fonts/'),
+    copyFiles.bind(copyFiles, ['node_modules/devicon/icons/chrome/chrome-original.svg'],
+        'src/thirdparty/devicon/icons/chrome/'),
+    copyFiles.bind(copyFiles, ['node_modules/devicon/icons/safari/safari-original.svg'],
+        'src/thirdparty/devicon/icons/safari/'),
+    copyFiles.bind(copyFiles, ['node_modules/devicon/icons/firefox/firefox-original.svg'],
+        'src/thirdparty/devicon/icons/firefox/'),
     copyLicence.bind(copyLicence, 'node_modules/devicon/LICENSE', 'devicon'),
     // file-icons https://www.npmjs.com/package/@uiw/file-icons - MIT License
     copyFiles.bind(copyFiles, ['node_modules/@uiw/file-icons/fonts/ffont.css'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "phoenix",
-    "version": "3.4.8-0",
+    "version": "3.6.1-0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "phoenix",
-            "version": "3.4.8-0",
+            "version": "3.6.1-0",
             "dependencies": {
                 "@bugsnag/js": "^7.18.0",
                 "@floating-ui/dom": "^0.5.4",

--- a/src-node/package-lock.json
+++ b/src-node/package-lock.json
@@ -13,6 +13,7 @@
                 "lmdb": "^2.9.2",
                 "mime-types": "^2.1.35",
                 "npm": "10.1.0",
+                "open": "^10.1.0",
                 "ws": "^8.13.0"
             },
             "engines": {
@@ -204,6 +205,20 @@
                 "node": ">=8"
             }
         },
+        "node_modules/bundle-name": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+            "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+            "dependencies": {
+                "run-applescript": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/chokidar": {
             "version": "3.5.3",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -228,6 +243,43 @@
             },
             "optionalDependencies": {
                 "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/default-browser": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+            "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+            "dependencies": {
+                "bundle-name": "^4.1.0",
+                "default-browser-id": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/default-browser-id": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+            "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/define-lazy-prop": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+            "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/detect-libc": {
@@ -292,6 +344,20 @@
                 "node": ">=8"
             }
         },
+        "node_modules/is-docker": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -311,12 +377,43 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-inside-container": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+            "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+            "dependencies": {
+                "is-docker": "^3.0.0"
+            },
+            "bin": {
+                "is-inside-container": "cli.js"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "engines": {
                 "node": ">=0.12.0"
+            }
+        },
+        "node_modules/is-wsl": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+            "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+            "dependencies": {
+                "is-inside-container": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/lmdb": {
@@ -3487,6 +3584,23 @@
             "inBundle": true,
             "license": "ISC"
         },
+        "node_modules/open": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
+            "integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
+            "dependencies": {
+                "default-browser": "^5.2.1",
+                "define-lazy-prop": "^3.0.0",
+                "is-inside-container": "^1.0.0",
+                "is-wsl": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/ordered-binary": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.5.1.tgz",
@@ -3512,6 +3626,17 @@
             },
             "engines": {
                 "node": ">=8.10.0"
+            }
+        },
+        "node_modules/run-applescript": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
+            "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/to-regex-range": {

--- a/src-node/package.json
+++ b/src-node/package.json
@@ -20,6 +20,7 @@
     "IMPORTANT!!": "Adding things here will bloat up the package size",
     "dependencies": {
         "@phcode/fs": "^3.0.0",
+        "open": "^10.1.0",
         "npm": "10.1.0",
         "ws": "^8.13.0",
         "lmdb": "^2.9.2",

--- a/src/extensionsIntegrated/Phoenix-live-preview/live-preview.css
+++ b/src/extensionsIntegrated/Phoenix-live-preview/live-preview.css
@@ -2,6 +2,18 @@
     --toolbar-height: 30px;
 }
 
+.live-preview-browser-btn {
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 1s, visibility 0s linear 1s; /* Fade-out effect */
+}
+
+#live-preview-plugin-toolbar:hover .live-preview-browser-btn {
+    opacity: 1;
+    visibility: visible;
+    transition: unset;
+}
+
 #panel-live-preview {
     position: relative;
     width: 100%;
@@ -13,7 +25,7 @@
 }
 
 #panel-live-preview-title {
-    max-width: 50%;
+    max-width: 50%%;
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;

--- a/src/extensionsIntegrated/Phoenix-live-preview/panel.html
+++ b/src/extensionsIntegrated/Phoenix-live-preview/panel.html
@@ -1,12 +1,28 @@
 <div id="panel-live-preview">
     <div id="live-preview-plugin-toolbar" class="plugin-toolbar" title="Live Preview" style="display: flex; align-items: center; flex-direction: row;">
-        <div style="position: absolute; left: 0px;">
+        <div style="width: 33%;display: flex;">
             <button id="reloadLivePreviewButton" title="{{clickToReload}}" class="btn-alt-quiet toolbar-button reload-icon"></button>
             <button id="highlightLPButton" title="{{toggleLiveHighlight}}" class="btn-alt-quiet toolbar-button pointer-fill-icon"></button>
         </div>
-        <button id="pinURLButton" title="{{clickToPinUnpin}}" class="btn-alt-quiet toolbar-button unpin-icon"></button>
-        <span id="panel-live-preview-title">{{livePreview}}</span>
-        <button id="livePreviewPopoutButton" title="{{clickToPopout}}" class="btn-alt-quiet toolbar-button open-icon"></button>
+        <div style="width: fit-content;display: flex;justify-content: center; align-items: center;">
+            <button id="pinURLButton" title="{{clickToPinUnpin}}" class="btn-alt-quiet toolbar-button unpin-icon"></button>
+            <span id="panel-live-preview-title">{{livePreview}}</span>
+            <button id="livePreviewPopoutButton" title="{{clickToPopout}}" class="btn-alt-quiet toolbar-button open-icon"></button>
+        </div>
+        <div style="width: 33%;display: flex;align-items: center;">
+            <button id="chromeButton" title="{{openInChrome}}" class="btn-alt-quiet toolbar-button live-preview-browser-btn forced-hidden">
+                <img src="thirdparty/devicon/icons/chrome/chrome-original.svg" />
+            </button>
+            <button id="safariButton" title="{{openInSafari}}" class="btn-alt-quiet toolbar-button live-preview-browser-btn forced-hidden">
+                <img src="thirdparty/devicon/icons/safari/safari-original.svg" />
+            </button>
+            <button id="edgeButton" title="{{openInEdge}}" class="btn-alt-quiet toolbar-button live-preview-browser-btn forced-hidden">
+                <img src="styles/images/edge-logo.svg" />
+            </button>
+            <button id="firefoxButton" title="{{openInFirefox}}" class="btn-alt-quiet toolbar-button live-preview-browser-btn forced-hidden">
+                <img src="thirdparty/devicon/icons/firefox/firefox-original.svg" />
+            </button>
+        </div>
         <iframe id="live-preview-server-iframe"
                 title="live preview server"
                 src="about:blank"

--- a/src/extensionsIntegrated/Phoenix-live-preview/panel.html
+++ b/src/extensionsIntegrated/Phoenix-live-preview/panel.html
@@ -10,11 +10,11 @@
             <button id="livePreviewPopoutButton" title="{{clickToPopout}}" class="btn-alt-quiet toolbar-button open-icon"></button>
         </div>
         <div style="width: 33%;display: flex;align-items: center;">
-            <button id="chromeButton" title="{{openInChrome}}" class="btn-alt-quiet toolbar-button live-preview-browser-btn forced-hidden">
-                <img src="thirdparty/devicon/icons/chrome/chrome-original.svg" />
-            </button>
             <button id="safariButton" title="{{openInSafari}}" class="btn-alt-quiet toolbar-button live-preview-browser-btn forced-hidden">
                 <img src="thirdparty/devicon/icons/safari/safari-original.svg" />
+            </button>
+            <button id="chromeButton" title="{{openInChrome}}" class="btn-alt-quiet toolbar-button live-preview-browser-btn forced-hidden">
+                <img src="thirdparty/devicon/icons/chrome/chrome-original.svg" />
             </button>
             <button id="edgeButton" title="{{openInEdge}}" class="btn-alt-quiet toolbar-button live-preview-browser-btn forced-hidden">
                 <img src="styles/images/edge-logo.svg" />

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -144,6 +144,12 @@ define({
     "LIVE_DEV_CLICK_TO_RELOAD_PAGE": "Reload Page",
     "LIVE_DEV_TOGGLE_LIVE_HIGHLIGHT": "Toggle Live Preview Highlights",
     "LIVE_DEV_CLICK_POPOUT": "Popout Live Preview To New Window",
+    "LIVE_DEV_OPEN_CHROME": "Open In Chrome\u2026",
+    "LIVE_DEV_OPEN_SAFARI": "Open In Safari\u2026",
+    "LIVE_DEV_OPEN_EDGE": "Open In Edge\u2026",
+    "LIVE_DEV_OPEN_FIREFOX": "Open In Firefox\u2026",
+    "LIVE_DEV_OPEN_ERROR_TITLE": "Error Opening Live Preview in {0}",
+    "LIVE_DEV_OPEN_ERROR_MESSAGE": "Make sure that {0} browser is installed and try again.",
     "LIVE_DEV_CLICK_TO_PIN_UNPIN": "Pin on Unpin Preview Page",
     "LIVE_DEV_STATUS_TIP_SYNC_ERROR": "Live Preview (not updating due to syntax error)",
 

--- a/src/utils/NodeUtils.js
+++ b/src/utils/NodeUtils.js
@@ -71,6 +71,13 @@ define(function (require, exports, module) {
         return utilsConnector.execPeer("getLinuxOSFlavorName");
     }
 
+    async function openUrlInBrowser(url, browserName) {
+        if(!Phoenix.browser.isTauri) {
+            throw new Error("openUrlInBrowser not available in browser");
+        }
+        return utilsConnector.execPeer("openUrlInBrowser", {url, browserName});
+    }
+
     if(NodeConnector.isNodeAvailable()) {
         // todo we need to update the strings if a user extension adds its translations. Since we dont support
         // node extensions for now, should consider when we support node extensions.
@@ -81,6 +88,7 @@ define(function (require, exports, module) {
     exports.updateNodeLocaleStrings = updateNodeLocaleStrings;
     exports.getPhoenixBinaryVersion = getPhoenixBinaryVersion;
     exports.getLinuxOSFlavorName = getLinuxOSFlavorName;
+    exports.openUrlInBrowser = openUrlInBrowser;
     exports.isNodeReady = NodeConnector.isNodeReady;
 
     window.NodeUtils = exports;


### PR DESCRIPTION
In desktop browsers, hovering over the live preview title bar will reveal the `open live preview in chrome, edge, safari and firefox buttons`
![image](https://github.com/phcode-dev/phoenix/assets/5336369/7c149735-0c44-4a57-bdba-6b306b8070bf)

[Screencast from 01-04-24 04:15:48 PM IST.webm](https://github.com/phcode-dev/phoenix/assets/5336369/49830b88-192c-411c-a2db-bd44daefbdd9)

Fixes https://github.com/phcode-dev/phoenix/issues/1449