### PR TITLE
feat: vertical ruler in editor, supports multiple vertical rulers

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -59,6 +59,7 @@ define(function (require, exports, module) {
     require("thirdparty/CodeMirror/addon/search/searchcursor");
     require("thirdparty/CodeMirror/addon/selection/active-line");
     require("thirdparty/CodeMirror/addon/selection/mark-selection");
+    require("thirdparty/CodeMirror/addon/display/rulers");
     require("thirdparty/CodeMirror/keymap/sublime");
 
     require("utils/EventDispatcher");

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -125,6 +125,7 @@ define(function (require, exports, module) {
     exports.TOGGLE_LINE_NUMBERS         = "view.toggleLineNumbers";     // EditorOptionHandlers.js      _getToggler()
     exports.TOGGLE_ACTIVE_LINE          = "view.toggleActiveLine";      // EditorOptionHandlers.js      _getToggler()
     exports.TOGGLE_WORD_WRAP            = "view.toggleWordWrap";        // EditorOptionHandlers.js      _getToggler()
+    exports.TOGGLE_RULERS               = "view.toggleRulers";          // EditorOptionHandlers.js
     exports.TOGGLE_SEARCH_AUTOHIDE      = "view.toggleSearchAutoHide";  // EditorOptionHandlers.js      _getToggler()
 
     exports.CMD_OPEN                        = "cmd.open";

--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -211,6 +211,7 @@ define(function (require, exports, module) {
         menu.addMenuItem(Commands.TOGGLE_ACTIVE_LINE);
         menu.addMenuItem(Commands.TOGGLE_LINE_NUMBERS);
         menu.addMenuItem(Commands.TOGGLE_WORD_WRAP);
+        menu.addMenuItem(Commands.TOGGLE_RULERS);
         menu.addMenuDivider();
         menu.addMenuItem(Commands.FILE_LIVE_HIGHLIGHT);
         menu.addMenuDivider();

--- a/src/editor/EditorOptionHandlers.js
+++ b/src/editor/EditorOptionHandlers.js
@@ -22,33 +22,44 @@
 define(function (require, exports, module) {
 
 
-    var AppInit             = require("utils/AppInit"),
+    const AppInit             = require("utils/AppInit"),
         Editor              = require("editor/Editor").Editor,
         Commands            = require("command/Commands"),
         CommandManager      = require("command/CommandManager"),
         PreferencesManager  = require("preferences/PreferencesManager"),
         Strings             = require("strings"),
+        EditorManager       = require("editor/EditorManager"),
+        MainViewManager     = require("view/MainViewManager"),
+        WorkspaceManager    = require("view/WorkspaceManager"),
         _                   = require("thirdparty/lodash");
 
     // Constants for the preferences referred to in this file
-    var SHOW_LINE_NUMBERS = "showLineNumbers",
+    const SHOW_LINE_NUMBERS = "showLineNumbers",
         STYLE_ACTIVE_LINE = "styleActiveLine",
         WORD_WRAP         = "wordWrap",
         CLOSE_BRACKETS    = "closeBrackets",
         AUTO_HIDE_SEARCH  = "autoHideSearch";
 
-
+    const PREFERENCES_EDITOR_RULERS = "editor.rulers",
+        PREFERENCES_EDITOR_RULERS_ENABLED = "editor.rulersEnabled";
+    PreferencesManager.definePreference(PREFERENCES_EDITOR_RULERS_ENABLED, "boolean", true, {
+        description: Strings.DESCRIPTION_RULERS_ENABLED
+    });
+    PreferencesManager.definePreference(PREFERENCES_EDITOR_RULERS, "array", [100], {
+        description: Strings.DESCRIPTION_RULERS_COLUMNS
+    });
     /**
      * @private
      *
      * Maps from preference names to the command names needed to update the checked status.
      */
-    var _optionMapping = {};
+    let _optionMapping = {};
     _optionMapping[SHOW_LINE_NUMBERS] = Commands.TOGGLE_LINE_NUMBERS;
     _optionMapping[STYLE_ACTIVE_LINE] = Commands.TOGGLE_ACTIVE_LINE;
     _optionMapping[WORD_WRAP] = Commands.TOGGLE_WORD_WRAP;
     _optionMapping[CLOSE_BRACKETS] = Commands.TOGGLE_CLOSE_BRACKETS;
     _optionMapping[AUTO_HIDE_SEARCH] = Commands.TOGGLE_SEARCH_AUTOHIDE;
+    _optionMapping[PREFERENCES_EDITOR_RULERS_ENABLED] = Commands.TOGGLE_RULERS;
 
 
 
@@ -86,6 +97,69 @@ define(function (require, exports, module) {
         };
     }
 
+    const rulerEvents = {
+        "activeEditorChange": true,
+        "change": true,
+        "workingSetMove": true,
+        "paneLayoutChange": true,
+        "workspaceUpdateLayout": true
+    };
+
+    // rulers code adapted from guidelines extension by
+    // "Jake Knerr <jake@yellowhangar.com> (https://github.com/jakeknerr)"
+    function _createGuidelines(event) {
+        const rulerColumns = PreferencesManager.get(PREFERENCES_EDITOR_RULERS) || [];
+        const rulersEnabled = PreferencesManager.get(PREFERENCES_EDITOR_RULERS_ENABLED);
+        if( !rulersEnabled || !rulerEvents[event.type] || !rulerColumns.length){
+            return;
+        }
+        // initially I thought I could add the guideline to each pane alone and
+        // not editor instances, however this doesn't work because then the
+        // guideline does not scroll; must add a guideline to each editor
+        // instance
+
+        // loop through each scroller; get the height of each scroller so that
+        // the guideline can be sized to at least fill the viewport
+        const scrollers = $("div.CodeMirror-scroll");
+        scrollers.each(function() {
+            const scroller = $(this);
+            const minHeight = scroller.height();
+
+            // add the guideline to the sizer; this will also add guidelines to
+            // inline editors
+            const jSizer = scroller.find("> div.CodeMirror-sizer");
+
+            // reuse guidelines if possible
+            let guideline = jSizer.find("> div.guideline");
+            if (!guideline || guideline.length < 1) {
+                // add the guideline; notice that you must include a <pre> tag
+                // because when line numbers are disabled, brackets introduces a
+                // style .show-line-padding that will indent <pre> tags based on
+                // the theme;
+                jSizer.append(
+                    '<div class="guideline" tabindex="-1">' +
+                    '<pre class></pre>' +
+                    '</div>'
+                );
+                guideline = jSizer.find("> div.guideline");
+            }
+            // apply the user selected line color and column
+            const preTag = guideline.find('> pre');
+            preTag.css('-webkit-mask-position', rulerColumns[0] + 'ch 0');
+
+            // set the minimum height to the scroller height
+            guideline.css("min-height", minHeight + "px");
+
+        });
+    }
+
+    CommandManager.register(Strings.CMD_TOGGLE_LINE_NUMBERS, Commands.TOGGLE_LINE_NUMBERS, _getToggler(SHOW_LINE_NUMBERS));
+    CommandManager.register(Strings.CMD_TOGGLE_ACTIVE_LINE, Commands.TOGGLE_ACTIVE_LINE, _getToggler(STYLE_ACTIVE_LINE));
+    CommandManager.register(Strings.CMD_TOGGLE_WORD_WRAP, Commands.TOGGLE_WORD_WRAP, _getToggler(WORD_WRAP));
+    CommandManager.register(Strings.CMD_TOGGLE_CLOSE_BRACKETS, Commands.TOGGLE_CLOSE_BRACKETS, _getToggler(CLOSE_BRACKETS));
+    CommandManager.register(Strings.CMD_TOGGLE_SEARCH_AUTOHIDE, Commands.TOGGLE_SEARCH_AUTOHIDE, _getToggler(AUTO_HIDE_SEARCH));
+    CommandManager.register(Strings.CMD_TOGGLE_RULERS, Commands.TOGGLE_RULERS, _getToggler(PREFERENCES_EDITOR_RULERS_ENABLED));
+
     function _init() {
         _.each(_optionMapping, function (commandName, prefName) {
             CommandManager.get(commandName).setChecked(PreferencesManager.get(prefName));
@@ -94,13 +168,35 @@ define(function (require, exports, module) {
         if (!Editor.getShowLineNumbers()) {
             Editor._toggleLinePadding(true);
         }
-    }
 
-    CommandManager.register(Strings.CMD_TOGGLE_LINE_NUMBERS, Commands.TOGGLE_LINE_NUMBERS, _getToggler(SHOW_LINE_NUMBERS));
-    CommandManager.register(Strings.CMD_TOGGLE_ACTIVE_LINE, Commands.TOGGLE_ACTIVE_LINE, _getToggler(STYLE_ACTIVE_LINE));
-    CommandManager.register(Strings.CMD_TOGGLE_WORD_WRAP, Commands.TOGGLE_WORD_WRAP, _getToggler(WORD_WRAP));
-    CommandManager.register(Strings.CMD_TOGGLE_CLOSE_BRACKETS, Commands.TOGGLE_CLOSE_BRACKETS, _getToggler(CLOSE_BRACKETS));
-    CommandManager.register(Strings.CMD_TOGGLE_SEARCH_AUTOHIDE, Commands.TOGGLE_SEARCH_AUTOHIDE, _getToggler(AUTO_HIDE_SEARCH));
+        // fires for inline editor creation;
+        EditorManager.on('activeEditorChange', _createGuidelines);
+        // theme changes, font changes, folding, line-numbers; should catch settings
+        // that change the gutter width
+        PreferencesManager.on("change", (event)=>{
+            $("div.guideline").remove();
+            _createGuidelines(event);
+        });
+
+        // fires when panes are created; works even when the pane isn't focused;
+        // will not fire for inline editors; will add the guideline when a pane
+        // is created but not focused; the primary pane will not dispatch this event
+        // when it is created;
+        // MainViewManager.on('paneCreate', eventHandler);
+
+        // handles the situation when a file is moved to a new pane but not focused
+        MainViewManager.on('workingSetMove', _createGuidelines);
+
+        // catches layout when pane orientation changes; layout event doesn't fire for
+        // this oddly
+        MainViewManager.on("paneLayoutChange", _createGuidelines);
+
+        // doesn't fire for inline editor, new files, or as the scrollable content
+        // changes, orientation changes; surprisingly not that useful; however,
+        // will catch resizes that make the guideline extend out of the viewable
+        // region and trigger scrolling
+        WorkspaceManager.on("workspaceUpdateLayout", _createGuidelines);
+    }
 
     AppInit.htmlReady(_init);
 });

--- a/src/editor/EditorOptionHandlers.js
+++ b/src/editor/EditorOptionHandlers.js
@@ -162,6 +162,7 @@ define(function (require, exports, module) {
         });
         PreferencesManager.on("change", PREFERENCES_EDITOR_RULERS_ENABLED, _resetRulers);
         PreferencesManager.on("change", PREFERENCES_EDITOR_RULERS, _resetRulers);
+        PreferencesManager.on("change", PREFERENCES_EDITOR_RULER_COLORS, _resetRulers);
         ThemeManager.on(ThemeManager.EVENT_THEME_CHANGE, _handleThemeChange);
         _resetRulers();
     }

--- a/src/editor/EditorOptionHandlers.js
+++ b/src/editor/EditorOptionHandlers.js
@@ -40,12 +40,16 @@ define(function (require, exports, module) {
         AUTO_HIDE_SEARCH  = "autoHideSearch";
 
     const PREFERENCES_EDITOR_RULERS = "editor.rulers",
+        PREFERENCES_EDITOR_RULER_COLORS = "editor.rulerColors",
         PREFERENCES_EDITOR_RULERS_ENABLED = "editor.rulersEnabled";
     PreferencesManager.definePreference(PREFERENCES_EDITOR_RULERS_ENABLED, "boolean", true, {
         description: Strings.DESCRIPTION_RULERS_ENABLED
     });
     PreferencesManager.definePreference(PREFERENCES_EDITOR_RULERS, "array", [120], {
         description: Strings.DESCRIPTION_RULERS_COLUMNS
+    });
+    PreferencesManager.definePreference(PREFERENCES_EDITOR_RULER_COLORS, "array", [], {
+        description: Strings.DESCRIPTION_RULERS_COLORS
     });
 
     let _currentTheme;
@@ -100,19 +104,23 @@ define(function (require, exports, module) {
 
     function _createRulers(editor) {
         const rulerColumns = PreferencesManager.get(PREFERENCES_EDITOR_RULERS) || [];
+        const rulerColors = PreferencesManager.get(PREFERENCES_EDITOR_RULER_COLORS) || [];
         const rulersEnabled = PreferencesManager.get(PREFERENCES_EDITOR_RULERS_ENABLED);
         if( !rulersEnabled || !rulerColumns.length || !editor){
             return;
         }
+
         if(!_currentTheme){
             _currentTheme = ThemeManager.getCurrentTheme();
         }
+        const defaultColor = (_currentTheme && _currentTheme.dark) ? "#4b4b4b" : "#d0d0d0";
+
         if(!editor._codeMirror.getOption("rulers")){
             let rulerOptions = [];
-            for(const element of rulerColumns) {
+            for(let i=0; i<rulerColumns.length; i++) {
                 rulerOptions.push({
-                    color: _currentTheme.dark ? "#4b4b4b" : "#d0d0d0",
-                    column: element,
+                    color: rulerColors[i] ? rulerColors[i]: defaultColor,
+                    column: rulerColumns[i],
                     lineStyle: "solid !important"
                 });
             }

--- a/src/editor/EditorOptionHandlers.js
+++ b/src/editor/EditorOptionHandlers.js
@@ -45,7 +45,7 @@ define(function (require, exports, module) {
     PreferencesManager.definePreference(PREFERENCES_EDITOR_RULERS_ENABLED, "boolean", true, {
         description: Strings.DESCRIPTION_RULERS_ENABLED
     });
-    PreferencesManager.definePreference(PREFERENCES_EDITOR_RULERS, "array", [100], {
+    PreferencesManager.definePreference(PREFERENCES_EDITOR_RULERS, "array", [120], {
         description: Strings.DESCRIPTION_RULERS_COLUMNS
     });
     /**
@@ -120,37 +120,40 @@ define(function (require, exports, module) {
 
         // loop through each scroller; get the height of each scroller so that
         // the guideline can be sized to at least fill the viewport
+        // we support multiple rulers in the same document
         const scrollers = $("div.CodeMirror-scroll");
-        scrollers.each(function() {
-            const scroller = $(this);
-            const minHeight = scroller.height();
+        for(let nulerNumber=0; nulerNumber<rulerColumns.length; nulerNumber++) {
+            scrollers.each(function() {
+                const scroller = $(this);
+                const minHeight = scroller.height();
 
-            // add the guideline to the sizer; this will also add guidelines to
-            // inline editors
-            const jSizer = scroller.find("> div.CodeMirror-sizer");
+                // add the guideline to the sizer; this will also add guidelines to
+                // inline editors
+                const jSizer = scroller.find("> div.CodeMirror-sizer");
 
-            // reuse guidelines if possible
-            let guideline = jSizer.find("> div.guideline");
-            if (!guideline || guideline.length < 1) {
-                // add the guideline; notice that you must include a <pre> tag
-                // because when line numbers are disabled, brackets introduces a
-                // style .show-line-padding that will indent <pre> tags based on
-                // the theme;
-                jSizer.append(
-                    '<div class="guideline" tabindex="-1">' +
-                    '<pre class></pre>' +
-                    '</div>'
-                );
-                guideline = jSizer.find("> div.guideline");
-            }
-            // apply the user selected line color and column
-            const preTag = guideline.find('> pre');
-            preTag.css('-webkit-mask-position', rulerColumns[0] + 'ch 0');
+                // reuse guidelines if possible
+                let guideline = jSizer.find(`> div.guideline.${nulerNumber}`);
+                if (!guideline || guideline.length < 1) {
+                    // add the guideline; notice that you must include a <pre> tag
+                    // because when line numbers are disabled, brackets introduces a
+                    // style .show-line-padding that will indent <pre> tags based on
+                    // the theme;
+                    jSizer.append(
+                        `<div class="guideline ${nulerNumber}" tabindex="-1">` +
+                        '<pre class></pre>' +
+                        '</div>'
+                    );
+                    guideline = jSizer.find(`> div.guideline.${nulerNumber}`);
+                }
+                // apply the user selected line color and column
+                const preTag = guideline.find('> pre');
+                preTag.css('-webkit-mask-position', rulerColumns[nulerNumber] + 'ch 0');
 
-            // set the minimum height to the scroller height
-            guideline.css("min-height", minHeight + "px");
+                // set the minimum height to the scroller height
+                guideline.css("min-height", minHeight + "px");
 
-        });
+            });
+        }
     }
 
     CommandManager.register(Strings.CMD_TOGGLE_LINE_NUMBERS, Commands.TOGGLE_LINE_NUMBERS, _getToggler(SHOW_LINE_NUMBERS));

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -932,6 +932,7 @@ define({
     "DESCRIPTION_SHOW_CURSOR_WHEN_SELECTING": "Keeps the blinking cursor visible when you have a text selection",
     "DESCRIPTION_SHOW_LINE_NUMBERS": "true to show line numbers in a “gutter” to the left of the code",
     "DESCRIPTION_RULERS_COLUMNS": "An array of column numbers to draw vertical rulers in the editor. Eg: [80, 100]",
+    "DESCRIPTION_RULERS_COLORS": "An array of ruler colors corresponding to the rulers option in the editor. Eg: [\"#3d3d3d\", \"red\"]",
     "DESCRIPTION_RULERS_ENABLED": "true to enable editor rulers, else false",
     "DESCRIPTION_SMART_INDENT": "Automatically indent when creating a new block",
     "DESCRIPTION_SOFT_TABS": "false to turn off soft tabs behavior",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -503,6 +503,7 @@ define({
     "CMD_WORKING_SORT_TOGGLE_AUTO": "Automatic Sort",
     "CMD_THEMES": "Themes\u2026",
     "CMD_TOGGLE_SEARCH_AUTOHIDE": "Automatically close search",
+    "CMD_TOGGLE_RULERS": "Rulers",
     "CMD_KEYBOARD_NAV_OVERLAY": "Visual Command Palette",
 
     // Navigate menu commands
@@ -930,6 +931,8 @@ define({
     "DESCRIPTION_SHOW_CODE_HINTS": "false to disable all code hints",
     "DESCRIPTION_SHOW_CURSOR_WHEN_SELECTING": "Keeps the blinking cursor visible when you have a text selection",
     "DESCRIPTION_SHOW_LINE_NUMBERS": "true to show line numbers in a “gutter” to the left of the code",
+    "DESCRIPTION_RULERS_COLUMNS": "An array of column numbers to draw vertical rulers in the editor. Eg: [80, 100]",
+    "DESCRIPTION_RULERS_ENABLED": "true to enable editor rulers, else false",
     "DESCRIPTION_SMART_INDENT": "Automatically indent when creating a new block",
     "DESCRIPTION_SOFT_TABS": "false to turn off soft tabs behavior",
     "DESCRIPTION_SORT_DIRECTORIES_FIRST": "true to sort the directories first in the project tree",

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -861,6 +861,10 @@ a, img {
         }
     }
 
+    .CodeMirror-ruler{
+        z-index: 1;
+    }
+
     .active-pane {
 
         .pane-header {
@@ -871,29 +875,6 @@ a, img {
                 color: @dark-bc-menu-text;
             }
         }
-    }
-
-    .guideline {
-        width: 100%;
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        z-index: 2;
-        pointer-events: none;
-        margin-right: 0;
-        padding-right: 0;
-    }
-
-    .guideline > pre {
-        height: calc(100% - 15px);
-        background-color: #d0d0d0;
-        .dark & {
-            background-color: #4b4b4b;
-        }
-        -webkit-mask-origin: content;
-        -webkit-mask-image: url("data:image/svg+xml;utf8,<svg class='test' xmlns='http://www.w3.org/2000/svg' width='1' height='1'><rect width='1' height='1'/></svg>");
-        -webkit-mask-position: 80ch 0;
-        -webkit-mask-repeat: repeat-y;
     }
 }
 

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -872,6 +872,29 @@ a, img {
             }
         }
     }
+
+    .guideline {
+        width: 100%;
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        z-index: 2;
+        pointer-events: none;
+        margin-right: 0;
+        padding-right: 0;
+    }
+
+    .guideline > pre {
+        height: calc(100% - 15px);
+        background-color: #d0d0d0;
+        .dark & {
+            background-color: #4b4b4b;
+        }
+        -webkit-mask-origin: content;
+        -webkit-mask-image: url("data:image/svg+xml;utf8,<svg class='test' xmlns='http://www.w3.org/2000/svg' width='1' height='1'><rect width='1' height='1'/></svg>");
+        -webkit-mask-position: 80ch 0;
+        -webkit-mask-repeat: repeat-y;
+    }
 }
 
 // moved this out of #editor-holder because we need to lower the specificity so theme authors can override the background color

--- a/test/spec/EditorOptionHandlers-integ-test.js
+++ b/test/spec/EditorOptionHandlers-integ-test.js
@@ -30,6 +30,7 @@ define(function (require, exports, module) {
         EditorManager,       // loaded from brackets.test
         DocumentManager,     // loaded from brackets.test
         FileViewController,
+        PreferencesManager,
         SpecRunnerUtils     = require("spec/SpecRunnerUtils");
 
 
@@ -57,6 +58,7 @@ define(function (require, exports, module) {
             EditorManager       = testWindow.brackets.test.EditorManager;
             DocumentManager     = testWindow.brackets.test.DocumentManager;
             FileViewController  = testWindow.brackets.test.FileViewController;
+            PreferencesManager  = testWindow.brackets.test.PreferencesManager;
 
             await SpecRunnerUtils.loadProjectInTestWindow(testPath);
         }, 30000);
@@ -269,6 +271,62 @@ define(function (require, exports, module) {
 
                 var editor = EditorManager.getCurrentFullEditor();
                 checkActiveLine(editor, 3, true);
+            });
+        });
+
+        describe("Toggle Rulers", function () {
+            function _checkDefaultRuler(editor) {
+                const rulers = editor._codeMirror.getOption("rulers");
+                expect(rulers.length).toBe(1);
+                expect(rulers[0].column).toBe(120);
+            }
+            it("should show ruler in editor by default", async function () {
+                await openEditor(HTML_FILE);
+                _checkDefaultRuler(EditorManager.getCurrentFullEditor());
+            });
+
+            it("should show ruler in inline editor by default", async function () {
+                await openInlineEditor();
+                _checkDefaultRuler(EditorManager.getCurrentFullEditor().getInlineWidgets()[0].editor);
+            });
+
+            it("should be able to toggle ruler preference", async function () {
+                await openEditor(HTML_FILE);
+                const editor = EditorManager.getCurrentFullEditor();
+                _checkDefaultRuler(editor);
+                PreferencesManager.set("editor.rulersEnabled", false);
+                expect(editor._codeMirror.getOption("rulers")).toBeNull();
+                PreferencesManager.set("editor.rulersEnabled", true);
+                _checkDefaultRuler(editor);
+            });
+
+            it("should be able to set multiple rulers without color", async function () {
+                await openEditor(HTML_FILE);
+                const editor = EditorManager.getCurrentFullEditor();
+                _checkDefaultRuler(editor);
+                PreferencesManager.set("editor.rulers", [10, 30, 50]);
+                let rulers = editor._codeMirror.getOption("rulers");
+                expect(rulers.length).toBe(3);
+                expect(rulers[0].column).toBe(10);
+                expect(rulers[1].column).toBe(30);
+                expect(rulers[2].column).toBe(50);
+                PreferencesManager.set("editor.rulers", [120]);
+                _checkDefaultRuler(editor);
+            });
+
+            it("should be able to set multiple rulers with color", async function () {
+                await openEditor(HTML_FILE);
+                const editor = EditorManager.getCurrentFullEditor();
+                _checkDefaultRuler(editor);
+                PreferencesManager.set("editor.rulers", [10, 30, 50]);
+                PreferencesManager.set("editor.rulerColors", ["red", "", "#458"]);
+                let rulers = editor._codeMirror.getOption("rulers");
+                expect(rulers.length).toBe(3);
+                expect(rulers[0].color).toBe("red");
+                expect(rulers[1].color).toBeDefined();
+                expect(rulers[2].color).toBe("#458");
+                PreferencesManager.set("editor.rulers", [120]);
+                _checkDefaultRuler(editor);
             });
         });
 


### PR DESCRIPTION
Addresses part of https://github.com/phcode-dev/phoenix/issues/1237
## preferences
```json
        // An array of ruler colors corresponding to the rulers option in the editor. Eg: ["#3d3d3d", "red"]
	"editor.rulerColors": [],
	// An array of column numbers to draw vertical rulers in the editor. Eg: [80, 100]
	"editor.rulers": [],
	// true to enable editor rulers, else false
	"editor.rulersEnabled": true,
```
## Dark theme ruler
![image](https://github.com/phcode-dev/phoenix/assets/5336369/bf246ec1-9a0e-4926-a0a1-c0741306bdc0)
## light theme ruler
![image](https://github.com/phcode-dev/phoenix/assets/5336369/c0f1222d-535d-4b1e-a584-5ccb2c2ac442)
## enable or disable rulers
![image](https://github.com/phcode-dev/phoenix/assets/5336369/42f3f25c-d79c-4b21-afa9-bc28b7731f86)
## multiple ruler support with prreferences
![image](https://github.com/phcode-dev/phoenix/assets/5336369/feb2bd90-59df-413b-b47c-cf403dd4f645)
## multiple ruler color support
![image](https://github.com/phcode-dev/phoenix/assets/5336369/7b3d0f95-b113-4e63-838d-801b063dbca6)

