### PR TITLE
feat: live preview reverse CSS highlights and ux improvement

### DIFF
--- a/src/LiveDevelopment/BrowserScripts/LiveDevProtocolRemote.js
+++ b/src/LiveDevelopment/BrowserScripts/LiveDevProtocolRemote.js
@@ -361,6 +361,27 @@
         ProtocolManager.enable();
     });
 
+    function _getAllInheritedSelectorsInOrder(element) {
+        let selectorsFound= new Map();
+        const selectorsList = [];
+        while (element) {
+            if(element.id){
+                selectorsList.push(`#${element.id}`);
+            }
+            if (element.classList) {
+                element.classList.forEach(cls => {
+                    if(!selectorsFound.get(cls)){
+                        selectorsFound.set(cls, true);
+                        selectorsList.push(`.${cls}`);
+                    }
+                });
+            }
+            element = element.parentElement; // Move up to the next parent element
+        }
+        return selectorsList;
+    }
+
+
     /**
     * Sends the message containing tagID which is being clicked
     * to the editor in order to change the cursor position to
@@ -381,7 +402,10 @@
         if (element && element.hasAttribute('data-brackets-id')) {
             MessageBroker.send({
                 "tagId": element.getAttribute('data-brackets-id'),
+                "nodeID": element.id,
+                "nodeClassList": element.classList,
                 "nodeName": element.nodeName,
+                "allSelectors": _getAllInheritedSelectorsInOrder(element),
                 "contentEditable": element.contentEditable === 'true',
                 "clicked": true
             });

--- a/src/LiveDevelopment/MultiBrowserImpl/protocol/LiveDevProtocol.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/protocol/LiveDevProtocol.js
@@ -110,9 +110,18 @@ define(function (require, exports, module) {
     }
 
     const cssLangIDS = ["css", "scss", "sass", "less"];
+    const lessLangIDS = ["scss", "sass", "less"];
+    function _isLessOrSCSS(editor) {
+        if(!editor){
+            return false;
+        }
+        const language = LanguageManager.getLanguageForPath(editor.document.file.fullPath);
+        return language && lessLangIDS.includes(language.getId());
+    }
+
     function _searchAndCursorIfCSS(editor, allSelectors, nodeName) {
         const codeMirror =  editor._codeMirror;
-        const language = LanguageManager.getLanguageForExtension(editor.document.extension);
+        const language = LanguageManager.getLanguageForPath(editor.document.file.fullPath);
         if(!language || !cssLangIDS.includes(language.getId())){
             return;
         }
@@ -167,9 +176,10 @@ define(function (require, exports, module) {
         if(liveDocPath === activeFullEditorPath) {
             // if the active pane is the html being live previewed, select that.
             selectInHTMLEditor(activeFullEditor);
-        } else if(liveDoc.isRelated(activeEditorPath)) {
+        } else if(liveDoc.isRelated(activeEditorPath) || _isLessOrSCSS(activeEditor)) {
             // the active editor takes the priority in the workflow. If a css related file is active,
-            // then we dont need to open the html live doc.
+            // then we dont need to open the html live doc. For less files, we dont check if its related as
+            // its not directly linked usually and needs a compile step. so we just do a fuzzy search.
             activeEditor.focus();
             _searchAndCursorIfCSS(activeEditor, allSelectors, nodeName);
             // in this case, see if we need to do any css reverse highlight magic here

--- a/src/extensionsIntegrated/Phoenix-live-preview/BrowserStaticServer.js
+++ b/src/extensionsIntegrated/Phoenix-live-preview/BrowserStaticServer.js
@@ -165,7 +165,8 @@ define(function (require, exports, module) {
                     } else {
                         const currentLivePreviewDetails = LiveDevelopment.getLivePreviewDetails();
                         if(currentLivePreviewDetails && currentLivePreviewDetails.liveDocument
-                            &&currentLivePreviewDetails.liveDocument.isRelated(fullPath)){
+                            && currentLivePreviewDetails.liveDocument.isRelated
+                            && currentLivePreviewDetails.liveDocument.isRelated(fullPath)){
                             fullPath = currentLivePreviewDetails.liveDocument.doc.file.fullPath;
                             const filePath = path.relative(projectRoot, fullPath);
                             let URL = `${projectRootUrl}${filePath}`;

--- a/src/extensionsIntegrated/Phoenix-live-preview/NodeStaticServer.js
+++ b/src/extensionsIntegrated/Phoenix-live-preview/NodeStaticServer.js
@@ -660,7 +660,8 @@ define(function (require, exports, module) {
                 } else {
                     const currentLivePreviewDetails = LiveDevelopment.getLivePreviewDetails();
                     if(currentLivePreviewDetails && currentLivePreviewDetails.liveDocument
-                        &&currentLivePreviewDetails.liveDocument.isRelated(fullPath)){
+                        && currentLivePreviewDetails.liveDocument.isRelated
+                        && currentLivePreviewDetails.liveDocument.isRelated(fullPath)){
                         fullPath = currentLivePreviewDetails.liveDocument.doc.file.fullPath;
                         const relativeFilePath = httpFilePath || path.relative(projectRoot, fullPath);
                         let URL = httpFilePath || decodeURI(_staticServerInstance.pathToUrl(fullPath));

--- a/src/extensionsIntegrated/Phoenix-live-preview/live-preview.css
+++ b/src/extensionsIntegrated/Phoenix-live-preview/live-preview.css
@@ -25,10 +25,11 @@
 }
 
 #panel-live-preview-title {
-    max-width: 50%%;
+    max-width: 80%;
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
+    cursor: pointer;
 }
 
 .frame-container {

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -140,6 +140,7 @@ define({
     "LIVE_DEV_STATUS_TIP_PROGRESS2": "Live Preview: Initializing\u2026",
     "LIVE_DEV_STATUS_TIP_CONNECTED": "Live Preview Server Active",
     "LIVE_DEV_STATUS_TIP_OUT_OF_SYNC": "Live Preview",
+    "LIVE_DEV_TOOLTIP_SHOW_IN_EDITOR": "{0} - Show in Editor\u2026",
     "LIVE_DEV_SELECT_FILE_TO_PREVIEW": "Select File To Live Preview",
     "LIVE_DEV_CLICK_TO_RELOAD_PAGE": "Reload Page",
     "LIVE_DEV_TOGGLE_LIVE_HIGHLIGHT": "Toggle Live Preview Highlights",

--- a/src/view/MainViewManager.js
+++ b/src/view/MainViewManager.js
@@ -429,6 +429,31 @@ define(function (require, exports, module) {
     }
 
     /**
+     * Retrieves the currently viewed editor of the specified paneId
+     * @param {?string} paneId - the id of the pane in which to retrieve the currently viewed editor
+     * @return {?Editor} currently editor, or null if there isn't one or there's no such pane
+     */
+    function getCurrentlyViewedEditor(paneId) {
+        const pane = _getPane(paneId);
+        return pane ? pane.getCurrentlyViewedEditor() : null;
+    }
+
+    /**
+     * Get an array of editors open in panes with their pane ids. Can return empty if no editor open.
+     * @return {[{editor: Editor, paneId:string}]}
+     */
+    function getAllViewedEditors() {
+        const editorList = [];
+        for(let paneId of getPaneIdList()){
+            const editor = getCurrentlyViewedEditor(paneId);
+            if(editor){
+                editorList.push({editor, paneId});
+            }
+        }
+        return editorList;
+    }
+
+    /**
      * Retrieves the currently viewed path of the pane specified by paneId
      * @param {?string} paneId - the id of the pane in which to retrieve the currently viewed path
      * @return {?string} the path of the currently viewed file or null if there isn't one
@@ -624,7 +649,7 @@ define(function (require, exports, module) {
      * @return {Array.<{pane:string, index:number}>} an array of paneId/index records
      */
     function findInAllWorkingSets(fullPath) {
-        var index,
+        let index,
             result = [];
 
         _.forEach(_panes, function (pane) {
@@ -635,6 +660,24 @@ define(function (require, exports, module) {
         });
 
         return result;
+    }
+
+    /**
+     * Returns the paneId and editor(if present) of the given file on any open and viewable pane. If same file
+     * is open in multiple panes, all matching panes will be returned. If not found in any panes, [] will be returned.
+     * @param {string} fullPath
+     * @return {[{paneId:string, editor:?Editor}]} paneId - array of id of the panes in which the file is open.
+     */
+    function findInOpenPane(fullPath) {
+        const paneList = [];
+        for(let paneId of getPaneIdList()){
+            const file = getCurrentlyViewedFile(paneId);
+            const editor = getCurrentlyViewedEditor(paneId);
+            if(file && file.fullPath === fullPath){
+                paneList.push({paneId, editor});
+            }
+        }
+        return paneList;
     }
 
     /**
@@ -1747,6 +1790,7 @@ define(function (require, exports, module) {
     exports.findInWorkingSetByAddedOrder  = findInWorkingSetByAddedOrder;
     exports.findInWorkingSetByMRUOrder    = findInWorkingSetByMRUOrder;
     exports.findInAllWorkingSets          = findInAllWorkingSets;
+    exports.findInOpenPane                = findInOpenPane;
     exports.findInGlobalMRUList           = _findFileInMRUList;
 
     // Traversal
@@ -1774,6 +1818,8 @@ define(function (require, exports, module) {
     // Convenience
     exports.getCurrentlyViewedFile        = getCurrentlyViewedFile;
     exports.getCurrentlyViewedPath        = getCurrentlyViewedPath;
+    exports.getCurrentlyViewedEditor      = getCurrentlyViewedEditor;
+    exports.getAllViewedEditors           = getAllViewedEditors;
 
     // Constants
     exports.ALL_PANES                     = ALL_PANES;

--- a/src/view/Pane.js
+++ b/src/view/Pane.js
@@ -154,6 +154,7 @@ define(function (require, exports, module) {
         EventDispatcher     = require("utils/EventDispatcher"),
         FileSystem          = require("filesystem/FileSystem"),
         InMemoryFile        = require("document/InMemoryFile"),
+        Editor              = require("editor/Editor").Editor,
         ViewStateManager    = require("view/ViewStateManager"),
         MainViewManager     = require("view/MainViewManager"),
         PreferencesManager  = require("preferences/PreferencesManager"),
@@ -1264,6 +1265,14 @@ define(function (require, exports, module) {
      */
     Pane.prototype.getCurrentlyViewedFile = function () {
         return this._currentView ? this._currentView.getFile() : null;
+    };
+
+    /**
+     * Retrieves the File object of the current view
+     * @return {?File} the File object of the current view or null if there isn't one
+     */
+    Pane.prototype.getCurrentlyViewedEditor = function () {
+        return this._currentView instanceof Editor ? this._currentView : null;
     };
 
     /**

--- a/test/spec/LiveDevelopment-MultiBrowser-test-files/cssLive.css
+++ b/test/spec/LiveDevelopment-MultiBrowser-test-files/cssLive.css
@@ -1,0 +1,12 @@
+@import url('import1.css');
+
+.testClass {
+	color: #000;
+}
+
+#testId{
+}
+
+.testClass2{}
+
+span{}

--- a/test/spec/LiveDevelopment-MultiBrowser-test-files/cssLive1.less
+++ b/test/spec/LiveDevelopment-MultiBrowser-test-files/cssLive1.less
@@ -1,0 +1,12 @@
+@import url('import1.css');
+
+.testClass {
+	color: #000;
+}
+
+#testId{
+}
+
+.testClass2{}
+
+span{}

--- a/test/spec/LiveDevelopment-MultiBrowser-test-files/cssLive1.sass
+++ b/test/spec/LiveDevelopment-MultiBrowser-test-files/cssLive1.sass
@@ -1,0 +1,12 @@
+@import url('import1.css');
+
+.testClass {
+	color: #000;
+}
+
+#testId{
+}
+
+.testClass2{}
+
+span{}

--- a/test/spec/LiveDevelopment-MultiBrowser-test-files/cssLive1.scss
+++ b/test/spec/LiveDevelopment-MultiBrowser-test-files/cssLive1.scss
@@ -1,0 +1,12 @@
+@import url('import1.css');
+
+.testClass {
+	color: #000;
+}
+
+#testId{
+}
+
+.testClass2{}
+
+span{}

--- a/test/spec/LiveDevelopment-MultiBrowser-test-files/cssLivePreview.html
+++ b/test/spec/LiveDevelopment-MultiBrowser-test-files/cssLivePreview.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Simple Test</title>
+<link rel="stylesheet" href="simpleShared.css">
+<link rel="stylesheet" href="cssLive.css">
+<script type="text/javascript" src="simple1.js"></script>
+</head>
+
+<body>
+<div class="testClass">
+    <p id="testId" class="testClass">Brackets is awesome!</p>
+    <p id ="testId2" class="testClass2" >Red is bad. Green is good.</p>
+    <div class="notInCss">
+        not in css
+    </div>
+</div>
+<span>
+    tag style
+</span>
+</body>
+</html>

--- a/test/spec/LiveDevelopmentMultiBrowser-test.js
+++ b/test/spec/LiveDevelopmentMultiBrowser-test.js
@@ -991,6 +991,38 @@ define(function (require, exports, module) {
             await endPreviewSession();
         }, 30000);
 
+        async function _forSelection(id, editor, cursor) {
+            await awaitsFor(()=>{
+                const cursorPos = editor.getCursorPos();
+                return cursorPos && cursorPos.line === cursor.line && cursorPos.ch === cursor.ch;
+            }, "waiting for editor reverse selection on "+ id);
+        }
+
+        it("should reverse highlight on clicking related CSS on live preview", async function () {
+            await awaitsForDone(SpecRunnerUtils.openProjectFiles(["cssLivePreview.html"]),
+                "SpecRunnerUtils.openProjectFiles cssLivePreview.html");
+
+            await waitsForLiveDevelopmentToOpen();
+            await awaits(500);
+
+            // now open the css file
+            await awaitsForDone(SpecRunnerUtils.openProjectFiles(["cssLive.css"]),
+                "SpecRunnerUtils.openProjectFiles cssLive.css");
+
+            let editor = EditorManager.getActiveEditor();
+
+            await forRemoteExec(`document.getElementById("testId").click()`);
+            await _forSelection("#testId", editor, { line: 6, ch: 0, sticky: null });
+            await forRemoteExec(`document.getElementById("testId2").click()`);
+            await _forSelection("#testId2", editor, { line: 9, ch: 0, sticky: null });
+            await forRemoteExec(`document.getElementsByTagName("span")[0].click()`);
+            await _forSelection("span", editor, { line: 11, ch: 0, sticky: null });
+            await forRemoteExec(`document.getElementsByClassName("notInCss")[0].click()`);
+            await _forSelection("span", editor, { line: 2, ch: 0, sticky: null });
+
+            await endPreviewSession();
+        }, 30000);
+
         it("should reverse highlight open previewed html file if not open on clicking live preview", async function () {
             await awaitsForDone(SpecRunnerUtils.openProjectFiles(["simple1.html"]),
                 "SpecRunnerUtils.openProjectFiles simple1.html");

--- a/test/spec/LiveDevelopmentMultiBrowser-test.js
+++ b/test/spec/LiveDevelopmentMultiBrowser-test.js
@@ -1023,6 +1023,42 @@ define(function (require, exports, module) {
             await endPreviewSession();
         }, 30000);
 
+        it("should open document on clicking on html live preview if no file is present", async function () {
+            await awaitsForDone(SpecRunnerUtils.openProjectFiles(["cssLivePreview.html"]),
+                "SpecRunnerUtils.openProjectFiles cssLivePreview.html");
+
+            await waitsForLiveDevelopmentToOpen();
+
+            await awaitsForDone(CommandManager.execute(Commands.FILE_CLOSE_ALL, { _forceClose: true }),
+                "closing all file");
+
+            await forRemoteExec(`document.getElementById("testId").click()`);
+            await awaitsFor(()=>{
+                return !!EditorManager.getActiveEditor();
+            }, "Editor to be opened");
+            let editor = EditorManager.getActiveEditor();
+            expect(editor.document.file.name).toBe("cssLivePreview.html");
+            await endPreviewSession();
+        }, 30000);
+
+        it("should not open document on clicking live preview if related file is present and html not present", async function () {
+            await awaitsForDone(SpecRunnerUtils.openProjectFiles(["cssLivePreview.html"]),
+                "SpecRunnerUtils.openProjectFiles cssLivePreview.html");
+
+            await waitsForLiveDevelopmentToOpen();
+
+            await awaitsForDone(CommandManager.execute(Commands.FILE_CLOSE_ALL, { _forceClose: true }),
+                "closing all file");
+            await awaitsForDone(SpecRunnerUtils.openProjectFiles(["cssLive.css"]),
+                "SpecRunnerUtils.openProjectFiles cssLive.css");
+
+            await forRemoteExec(`document.getElementById("testId").click()`);
+            await awaits(100); // just wait for some time to verify html file is not opened
+            let editor = EditorManager.getActiveEditor();
+            expect(editor.document.file.name).toBe("cssLive.css");
+            await endPreviewSession();
+        }, 30000);
+
         it("should reverse highlight open previewed html file if not open on clicking live preview", async function () {
             await awaitsForDone(SpecRunnerUtils.openProjectFiles(["simple1.html"]),
                 "SpecRunnerUtils.openProjectFiles simple1.html");

--- a/test/spec/LiveDevelopmentMultiBrowser-test.js
+++ b/test/spec/LiveDevelopmentMultiBrowser-test.js
@@ -1008,7 +1008,7 @@ define(function (require, exports, module) {
             }, "waiting for editor reverse selection on "+ id);
         }
 
-        it("should reverse highlight on clicking related CSS on live preview", async function () {
+        async function _verifyCssReverseHighlight(fileName) {
             await awaitsForDone(SpecRunnerUtils.openProjectFiles(["cssLivePreview.html"]),
                 "SpecRunnerUtils.openProjectFiles cssLivePreview.html");
 
@@ -1016,21 +1016,49 @@ define(function (require, exports, module) {
             await awaits(500);
 
             // now open the css file
-            await awaitsForDone(SpecRunnerUtils.openProjectFiles(["cssLive.css"]),
-                "SpecRunnerUtils.openProjectFiles cssLive.css");
+            await awaitsForDone(SpecRunnerUtils.openProjectFiles([fileName]),
+                `SpecRunnerUtils.openProjectFiles ${fileName}`);
 
             let editor = EditorManager.getActiveEditor();
+            expect(editor.document.file.name).toBe(fileName);
 
             await forRemoteExec(`document.getElementById("testId").click()`);
+            editor = EditorManager.getActiveEditor();
+            expect(editor.document.file.name).toBe(fileName);
             await _forSelection("#testId", editor, { line: 6, ch: 0, sticky: null });
             await forRemoteExec(`document.getElementById("testId2").click()`);
+            editor = EditorManager.getActiveEditor();
+            expect(editor.document.file.name).toBe(fileName);
             await _forSelection("#testId2", editor, { line: 9, ch: 0, sticky: null });
             await forRemoteExec(`document.getElementsByTagName("span")[0].click()`);
+            editor = EditorManager.getActiveEditor();
+            expect(editor.document.file.name).toBe(fileName);
             await _forSelection("span", editor, { line: 11, ch: 0, sticky: null });
             await forRemoteExec(`document.getElementsByClassName("notInCss")[0].click()`);
+            editor = EditorManager.getActiveEditor();
+            expect(editor.document.file.name).toBe(fileName);
             await _forSelection("span", editor, { line: 2, ch: 0, sticky: null });
 
             await endPreviewSession();
+        }
+
+        it("should reverse highlight on related CSS on clicking live preview", async function () {
+            await _verifyCssReverseHighlight("cssLive.css");
+        }, 30000);
+
+        it("should reverse highlight on unrelated less on clicking live preview", async function () {
+            // for less files we dont do the related file check as its is not usually directly linked into the css DOM.
+            await _verifyCssReverseHighlight("cssLive1.less");
+        }, 30000);
+
+        it("should reverse highlight on unrelated scss on clicking live preview", async function () {
+            // for scss files we dont do the related file check as its is not usually directly linked into the css DOM.
+            await _verifyCssReverseHighlight("cssLive1.scss");
+        }, 30000);
+
+        it("should reverse highlight on unrelated sass on clicking live preview", async function () {
+            // for sass files we dont do the related file check as its is not usually directly linked into the css DOM.
+            await _verifyCssReverseHighlight("cssLive1.sass");
         }, 30000);
 
         it("should open document on clicking on html live preview if no file is present", async function () {

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -880,10 +880,11 @@ define(function (require, exports, module) {
     /**
      * Opens project relative file paths in the test window
      * @param {!(Array.<string>|string)} paths Project relative file path(s) to open
+     * @param {string} [paneId] - optional
      * @return {!$.Promise} A promise resolved with a mapping of project-relative path
      *  keys to a corresponding Document
      */
-    function openProjectFiles(paths) {
+    function openProjectFiles(paths, paneId) {
         var result = new $.Deferred(),
             fullpaths = makeArray(makeAbsolute(paths)),
             keys = makeArray(makeRelative(paths)),
@@ -894,7 +895,7 @@ define(function (require, exports, module) {
         Async.doSequentially(fullpaths, function (path, i) {
             var one = new $.Deferred();
 
-            FileViewController.openFileAndAddToWorkingSet(path).done(function (file) {
+            FileViewController.openFileAndAddToWorkingSet(path, paneId).done(function (file) {
                 docs[keys[i]] = DocumentManager.getOpenDocumentForPath(file.fullPath);
                 one.resolve();
             }).fail(function (err) {


### PR DESCRIPTION
Add support for selecting css selectors in code if a css file is open as active document when user click on an element in live preview. 
On clicking an html dom node when a related css file(or any less/scss/sass file) is the active document, a css style with the nodes `#id` is searched, then `.class`. IF no match is found, it will search the nodes parents selector id and classes in the css file. If none is found till the root element, it will check for tag styles.
Also Fixes: https://github.com/phcode-dev/phoenix/issues/822