### PR TITLE
chore: predictable refresh live preview on html/non html/pin files and tests

### DIFF
--- a/src/LiveDevelopment/LiveDevMultiBrowser.js
+++ b/src/LiveDevelopment/LiveDevMultiBrowser.js
@@ -54,6 +54,9 @@
  * - "navigated_away" (The browser changed to a location outside of the project)
  * - "detached_target_closed" (The tab or window was closed)
  */
+
+/*global jsPromise */
+
 define(function (require, exports, module) {
 
 
@@ -535,10 +538,10 @@ define(function (require, exports, module) {
     /**
      * Open a live preview on the current docuemnt.
      */
-    function open() {
+    async function open() {
         let doc = DocumentManager.getCurrentDocument();
         if(livePreviewUrlPinned){
-            doc = DocumentManager.getDocumentForPath(currentPreviewFilePath);
+            doc = await jsPromise(DocumentManager.getDocumentForPath(currentPreviewFilePath));
         }
 
         // wait for server (StaticServer, Base URL or file:)

--- a/src/LiveDevelopment/LiveDevMultiBrowser.js
+++ b/src/LiveDevelopment/LiveDevMultiBrowser.js
@@ -524,13 +524,7 @@ define(function (require, exports, module) {
             isViewable = _server && _server.canServe(doc.file.fullPath);
 
         if (_liveDocument && _liveDocument.doc.url !== docUrl && isViewable) {
-            // clear live doc and related docs
-            _closeDocuments();
-            // create new live doc
-            _createLiveDocumentForFrame(doc);
-            _setStatus(STATUS_RESTARTING);
-            _open(doc);
-
+            open();
         }
     }
 
@@ -551,6 +545,9 @@ define(function (require, exports, module) {
                     return;
                 }
                 _setStatus(STATUS_CONNECTING);
+                // clear live doc and related docs
+                _closeDocuments();
+                // create new live doc
                 doc && _createLiveDocumentForFrame(doc);
                 if(_server.isActive()){
                     doc && _open(doc);

--- a/src/LiveDevelopment/main.js
+++ b/src/LiveDevelopment/main.js
@@ -130,9 +130,9 @@ define(function main(require, exports, module) {
         MultiBrowserLiveDev.close();
     }
 
-    function openLivePreview() {
+    function openLivePreview(doc) {
         if (!Phoenix.isTestWindow) {
-            MultiBrowserLiveDev.open();
+            MultiBrowserLiveDev.open(doc);
         }
     }
 

--- a/src/utils/StringUtils.js
+++ b/src/utils/StringUtils.js
@@ -251,10 +251,11 @@ define(function (require, exports, module) {
      *
      * !!!Should not be used for crypto secure workflows.!!!
      *
-     * @param {number} stringLength - The length of the nonce in bytes.
+     * @param {number} stringLength - The length of the nonce in bytes. default 10.
+     * @param {string} [prefix] - optional prefix
      * @returns {string} - The randomly generated nonce.
      */
-    function randomString(stringLength) {
+    function randomString(stringLength=10, prefix="") {
         const randomBuffer = new Uint8Array(stringLength);
         crypto.getRandomValues(randomBuffer);
 
@@ -262,7 +263,7 @@ define(function (require, exports, module) {
         const charset = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
 
         // Convert the ArrayBuffer to a case-sensitive random string with numbers
-        let randomId = '';
+        let randomId = prefix || '';
         Array.from(randomBuffer).forEach(byte => {
             randomId += charset[byte % charset.length];
         });


### PR DESCRIPTION
Fixes issues:
1. pressing reload button when live previewing HTML file and current file is a css file, will open no preview page instead of just a page reload.
2. Pinned live previews and reload was not working as expected.
3. Added integ tests to cover the cases.
4. Also fixes live preview and editor becomes slow after editing html pages for a long time due to live preview documents not being closed. This leads to event handler attached on the currently edited document being not released. This leads to too mans handler calls on an edit and generally slows down the editor. Proper cleanup is now done.