### PR TITLE
fix: cannot uncomment markdown comment, fallbak to codemirror comment plugin

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -60,6 +60,7 @@ define(function (require, exports, module) {
     require("thirdparty/CodeMirror/addon/selection/active-line");
     require("thirdparty/CodeMirror/addon/selection/mark-selection");
     require("thirdparty/CodeMirror/addon/display/rulers");
+    require("thirdparty/CodeMirror/addon/comment/comment");
     require("thirdparty/CodeMirror/keymap/sublime");
 
     require("utils/EventDispatcher");

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -2220,6 +2220,18 @@ define(function (require, exports, module) {
     };
 
     /**
+     * Tries to uncomment the current selection, and if that fails, line-comments it.
+     * This is internal private api used by phoenix line toggle command
+     * @private
+     */
+    Editor.prototype._toggleComment = function () {
+        const indentLineComment = Editor.getIndentLineComment(this.document.file.fullPath);
+        this._codeMirror.toggleComment({
+            indent: indentLineComment
+        });
+    };
+
+    /**
      * Returns the list of gutters current registered on all editors.
      * @return {!Array.<{name: string, priority: number}>}
      */

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -550,7 +550,7 @@ define(function (require, exports, module) {
                 });
 
             // Uncomment - remove prefix and suffix.
-            } else {
+            } else if(prefixPos){
                 // Find if the prefix and suffix are at the ch 0 and if they are the only thing in the line.
                 // If both are found we assume that a complete line selection comment added new lines, so we remove them.
                 var line          = doc.getLine(prefixPos.line).trim(),
@@ -634,6 +634,11 @@ define(function (require, exports, module) {
         return _getBlockCommentPrefixSuffixEdit(editor, prefix, suffix, [], sel, lineSel.selectionsToTrack, command);
     }
 
+    function _languageHasCommentsDefined(editor) {
+        const language = editor.document.getLanguage();
+        return language && (language.hasLineCommentSyntax() || language.hasBlockCommentSyntax());
+    }
+
     /**
      * @private
      * Generates an array of edits for toggling line comments on the given selections.
@@ -684,6 +689,11 @@ define(function (require, exports, module) {
             return;
         }
 
+        if(!_languageHasCommentsDefined(editor)) {
+            editor._toggleComment();
+            return;
+        }
+
         editor.setSelections(editor.document.doMultipleEdits(_getLineCommentEdits(editor, editor.getSelections(), "line")));
     }
 
@@ -694,6 +704,11 @@ define(function (require, exports, module) {
     function blockComment(editor) {
         editor = editor || EditorManager.getFocusedEditor();
         if (!editor) {
+            return;
+        }
+
+        if(!_languageHasCommentsDefined(editor)) {
+            editor._toggleComment();
             return;
         }
 

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -825,5 +825,8 @@ define(function (require, exports, module) {
     exports.focusEditor                   = focusEditor;
     exports.getCurrentlyViewedPath        = getCurrentlyViewedPath;
     exports.setEditorHolder               = setEditorHolder;
-    window.ed = exports;
+
+    if(location.origin === "http://localhost:8000"){
+        window.EditorManager = exports; // this is for quick editor queries during development in browser console
+    }
 });

--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -292,15 +292,13 @@
 
     "markdown": {
         "name": "Markdown",
-        "mode": "markdown",
-        "blockComment": ["<!--", "-->"]
+        "mode": "markdown"
     },
 
     "gfm": {
         "name": "Markdown (GitHub)",
         "mode": "gfm",
-        "fileExtensions": ["md", "markdown", "mdown", "mkdn"],
-        "blockComment": ["<!--", "-->"]
+        "fileExtensions": ["md", "markdown", "mdown", "mkdn"]
     },
 
     "yaml": {

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -236,6 +236,7 @@ define(function (require, exports, module) {
     require("thirdparty/CodeMirror/addon/mode/multiplex");
     require("thirdparty/CodeMirror/addon/mode/overlay");
     require("thirdparty/CodeMirror/addon/search/searchcursor");
+    require("thirdparty/CodeMirror/addon/comment/comment");
     require("thirdparty/CodeMirror/keymap/sublime");
 
     //load Language Tools Module


### PR DESCRIPTION
fixes: https://github.com/phcode-dev/phoenix/issues/1561