### PR TITLE
fix: file tree does not refresh automatically

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -447,9 +447,11 @@ define(function (require, exports, module) {
             // This call to syncOpenDocuments() *should* be a no-op now that we have
             // file watchers, but is still here as a safety net.
             FileSyncManager.syncOpenDocuments();
-            // This call to refreshFileTree() refreshes the project tree when the window comes back into focus
-            // If any changes are made outside of Phoenix Code, they will be updated when the user returns
-            ProjectManager.refreshFileTree();
+            if(!Phoenix.browser.isTauri) { // dont do this in desktop builds as native fs watchers will take care of external changes
+                // Refresh the project tree when the window comes back into focus
+                // Changes made outside of Phoenix Code will be updated when the user returns
+                ProjectManager.refreshFileTree();
+              }
         });
 
         // Prevent unhandled middle button clicks from triggering native behavior

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -447,6 +447,9 @@ define(function (require, exports, module) {
             // This call to syncOpenDocuments() *should* be a no-op now that we have
             // file watchers, but is still here as a safety net.
             FileSyncManager.syncOpenDocuments();
+            // This call to refreshFileTree() refreshes the project tree when the window comes back into focus
+            // If any changes are made outside of Phoenix Code, they will be updated when the user returns
+            ProjectManager.refreshFileTree();
         });
 
         // Prevent unhandled middle button clicks from triggering native behavior


### PR DESCRIPTION
Bugfix - fixes issue #310 

I ran into the above issue a few weeks ago...

The current behavior is that Phoenix Code will not check for changes made on the local filesystem if that's where the project is being stored. Although there are checks to ensure that opened files are not out of sync, the `ProjectManager` module does not consistently check for new files in the local directory. 

Since changes on the local filesystem (like the example cited in #310 where a file is created via the terminal) typically occur while the user is not in the Phoenix Code window, we can check the local filesystem for changes when the user returns to the window. 

I added a call to `refreshFileTree()` when Phoenix Code comes back into focus, which has resolved the issue.

### Gifs of the change
![phoenix-filesync-demo](https://github.com/phcode-dev/phoenix/assets/40146280/bc69592c-3de7-41a8-a5e0-d2329816c338)

### Does this PR introduce a breaking change?
- No

### Tests done
Tested on Windows and macOS with Chrome and Edge. Does not cause any unit tests to fail.


