### PR TITLE
chore: should not lint minified css and js files

### DIFF
--- a/src/extensions/default/CSSCodeHints/css-lint.js
+++ b/src/extensions/default/CSSCodeHints/css-lint.js
@@ -54,11 +54,11 @@ define(function (require, exports, module) {
      * a gold star when no errors are found.
      */
     async function lintOneFile(text, fullPath) {
-        return new Promise((resolve)=>{
+        return new Promise((resolve, reject)=>{
             const languageId = LanguageManager.getLanguageForPath(fullPath).getId();
             if(!cssMode[languageId]){
                 console.error("Unknown language id to lint: ", languageId, fullPath);
-                resolve();
+                reject(new Error("Unknown CSS language to lint for "+ fullPath));
                 return;
             }
             IndexingWorker.execPeer("cssLint", {
@@ -88,7 +88,10 @@ define(function (require, exports, module) {
     for(let language of supportedLanguages){
         CodeInspection.register(language, {
             name: StringUtils.format(Strings.CSS_LINT_NAME, cssMode[language]),
-            scanFileAsync: lintOneFile
+            scanFileAsync: lintOneFile,
+            canInspect: function (fullPath) {
+                return fullPath && !fullPath.endsWith(".min.css");
+            }
         });
     }
 });

--- a/src/extensions/default/JSHint/main.js
+++ b/src/extensions/default/JSHint/main.js
@@ -234,6 +234,9 @@ define(function (require, exports, module) {
     // Register for JS files
     CodeInspection.register("javascript", {
         name: Strings.JSHINT_NAME,
-        scanFileAsync: lintOneFile
+        scanFileAsync: lintOneFile,
+        canInspect: function (fullPath) {
+            return fullPath && !fullPath.endsWith(".min.js");
+        }
     });
 });

--- a/test/spec/Extn-CSSCodeHints-integ-test.js
+++ b/test/spec/Extn-CSSCodeHints-integ-test.js
@@ -188,5 +188,14 @@ define(function (require, exports, module) {
             });
 
         });
+
+        it(`Should not lint minified css files`, async function () {
+            await awaitsForDone(SpecRunnerUtils.openProjectFiles(["css-lint-errors.min.css"]), "open test file: css-lint-errors.min.css");
+            // there is an error at 2,0 - Do not use empty rulesets (emptyRules)
+            await expectNoCSSLintQuickViewAtPos(2, 0);
+            await awaitsFor(()=>{
+                return testWindow.$("#status-inspection").attr("title") === "No linter available for CSS";
+            }, "CSS linter to not show for minified files");
+        });
     });
 });

--- a/test/spec/LanguageTools-test-files/css-language-service/css-lint-errors.min.css
+++ b/test/spec/LanguageTools-test-files/css-language-service/css-lint-errors.min.css
@@ -1,0 +1,45 @@
+@import "no-error.css";
+
+.empty-css-error {}
+
+.duplicate-properties-warning {
+    color: red;
+    color: blue;
+}
+
+.zero-units-warning {
+    width: 0px;
+}
+
+.box-model-no-warning {
+    width: 300px;
+    padding: 50px;
+    border: 5px solid black;
+}
+
+.unknown-properties-warning {
+    doesntExist: 300px;
+}
+
+.ie-hack-warning {
+    color: blue; /* For modern browsers */
+    _color: red; /* This color is only for IE 6 and below */
+}
+
+.property-ignored-due-to-display-warning {
+    display: inline-block;
+    float: right;
+}
+
+.no-warnings-on-important {
+    width: 0 !important;
+    height: 0 !important;
+}
+
+@font-face {
+    font-family: 'needa default font warning';
+}
+
+.unknown-vendor-prefix-warning {
+    -microsoft-border-radius: 5px;
+}


### PR DESCRIPTION
Also adds css fetch flooding protection.

External http/s CSS stylesheet fetches only happen once every 10 seconds to prevent loading web servers on every code hint type. Cached external links are never fetched again, but problem happens when links fetch fails, and can be immediately retried on next key press. we need to block that and do it once in 10 seconds only.