### PR TITLE
feat: copy problem button in problems panel

### DIFF
--- a/src/htmlContent/problems-panel-table.html
+++ b/src/htmlContent/problems-panel-table.html
@@ -9,12 +9,18 @@
             </td>
         </tr>
         {{#results}}
-        <tr class="{{display}}">
+        <tr class="{{display}} inspector-line">
             <td class="line-number" data-line="{{pos.line}}" data-character="{{pos.ch}}">{{friendlyLine}}</td>
             <td class="line-icon">
                 <i class="{{iconClass}}"></i>
             </td>
             <td class="line-text">{{message}}</td>
+            <td>
+                <button class="btn btn-mini table-copy-err-button" title="{{Strings.COPY_ERROR}}"
+                        data-message="{{message}}">
+                    <i class="fa-solid fa-copy"></i>
+                </button>
+            </td>
             <td class="line-snippet">{{codeSnippet}}</td>
         </tr>
         {{/results}}

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -409,6 +409,7 @@ define({
     "LINT_DISABLED": "Linting is disabled",
     "NO_LINT_AVAILABLE": "No linter available for {0}",
     "NOTHING_TO_LINT": "Nothing to lint",
+    "COPY_ERROR": "Copy Error Message",
     "LINTER_TIMED_OUT": "{0} has timed out after waiting for {1} ms",
     "LINTER_FAILED": "{0} terminated with error: {1}",
 

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -2992,6 +2992,16 @@ textarea.exclusions-editor {
     .inspector-section > td {
         padding-left: 5px;
     }
+
+    .table-copy-err-button {
+        visibility: hidden;
+        cursor: pointer;
+        margin: 0 0 0 0;
+    }
+
+    .inspector-line:hover .table-copy-err-button {
+        visibility: visible;
+    }
 }
 
 /* Line up label text and input text */


### PR DESCRIPTION
* Users can now select text in problems panel by selecting text with mouse cursor and copying.
* Also added a copy button that will be visible on hover over each problem

![image](https://github.com/phcode-dev/phoenix/assets/5336369/c50a179d-434a-4842-90c6-bfbaf0c0c513)
