### PR TITLE
chore: matching tags, refs color scheme change in dark theme

### DIFF
--- a/src/extensions/default/DarkTheme/main.less
+++ b/src/extensions/default/DarkTheme/main.less
@@ -49,11 +49,13 @@
 @accent-string-2: #ffc641;
 @accent-meta: #B39C1D;
 @matching-bracket: #2e5c00;
+@matching-tags: #0b0b0b;
+@matching-refs: #1D2951;
 
 /* Code Styling */
 
 .editor-text-fragment-matching-refs{
-    background-color: @matching-bracket;
+    background-color: @matching-refs;
 }
 
 .cm-atom, .cm-string, .cm-hr {color: #d89333;}
@@ -85,10 +87,15 @@
     }
 }
 
-.CodeMirror-matchingbracket, .CodeMirror-matchingtag {
+.CodeMirror-matchingbracket {
     /* Ensure visibility against gray inline editor background */
     background-color: @matching-bracket;
     color: @foreground !important;
+}
+
+.CodeMirror-matchingtag {
+    /* Ensure visibility against gray inline editor background */
+    background-color: @matching-tags;
 }
 
 .CodeMirror-overwrite .CodeMirror-cursor {
@@ -105,7 +112,7 @@
 
 .CodeMirror.over-gutter, .CodeMirror-activeline {
     .CodeMirror-foldgutter-open:after {
-        color: #888;
+        color: #242424;
     }
 }
 


### PR DESCRIPTION
## Matching tags
### now
![image](https://github.com/phcode-dev/phoenix/assets/5336369/5b5debcb-4ec5-4785-bd8b-c3ea586290ea)  
### before
![image](https://github.com/phcode-dev/phoenix/assets/5336369/48aab8d9-b2ab-4b97-a5cf-d8bfcdcd6e7c) 

## Matching references
### now
![image](https://github.com/phcode-dev/phoenix/assets/5336369/ec6794d0-55ae-4aad-8b0c-3e026fdb0d86)
### before
![image](https://github.com/phcode-dev/phoenix/assets/5336369/8dfe3cdc-13e2-4134-bd56-5e46bc806701)
