### PR TITLE
fix: opening text files with open with opens live preview on startup

### DIFF
--- a/src/extensionsIntegrated/Phoenix-live-preview/NodeStaticServer.js
+++ b/src/extensionsIntegrated/Phoenix-live-preview/NodeStaticServer.js
@@ -588,13 +588,22 @@ define(function (require, exports, module) {
 
     function _getExternalPreviewURL(fullPath) {
         if(utils.isHTMLFile(fullPath)) {
-            return getNoPreviewURL(Strings.DESCRIPTION_LIVEDEV_PREVIEW_RESTRICTED,
-                Strings.DESCRIPTION_LIVEDEV_PREVIEW_RESTRICTED_DETAILS);
+            return {
+                url: getNoPreviewURL(Strings.DESCRIPTION_LIVEDEV_PREVIEW_RESTRICTED,
+                    Strings.DESCRIPTION_LIVEDEV_PREVIEW_RESTRICTED_DETAILS),
+                isNoPreview: true
+            };
         }
         if(!utils.isPreviewableFile(fullPath)){
-            return getNoPreviewURL();
+            return {
+                url: getNoPreviewURL(),
+                isNoPreview: true
+            };
         }
-        return `${staticServerURL}externalProject/${path.basename(fullPath)}`;
+        return {
+            url: `${staticServerURL}externalProject/${path.basename(fullPath)}`,
+            isNoPreview: false
+        };
     }
 
     function getTabPopoutURL(url) {
@@ -635,8 +644,10 @@ define(function (require, exports, module) {
                 let fullPath = currentFile.fullPath;
                 if(!ProjectManager.isWithinProject(fullPath)){
                     // external project file. Use secure external preview link.
+                    const preview = _getExternalPreviewURL(fullPath);
                     resolve({
-                        URL: _getExternalPreviewURL(fullPath),
+                        URL: preview.url,
+                        isNoPreview: preview.isNoPreview,
                         filePath: fullPath,
                         fullPath: fullPath,
                         isMarkdownFile: utils.isMarkdownFile(fullPath),


### PR DESCRIPTION
`noPreview` flag was not set correctly for text files and other non-previewable file types when opened from the 'Open With' option in the file explorer. Previously, attempting to open these files would mistakenly trigger a `no preview` page, due to the incorrect flag handling.

- Updated the flag assignment logic to correctly identify and set the `noPreview` flag for all supported non-previewable files, regardless of their location relative to the project directory.

opening text files/other non-preview files will no longer open a `no-prview` HTML page on startup.
