### PR TITLE
fix: live code hints gets dismissed when pressing arrow keys

### DIFF
--- a/src/extensions/default/CSSCodeHints/main.js
+++ b/src/extensions/default/CSSCodeHints/main.js
@@ -442,6 +442,7 @@ define(function (require, exports, module) {
             return;
         }
         isInLiveHighlightSession = true;
+        this.editor._dontDismissPopupOnScroll();
         this.editor.restoreHistoryPoint(`${HISTORY_PREFIX}${hintSessionId}`);
         this.insertHint($highlightedEl.find(".brackets-css-hints"), true);
     };

--- a/src/extensions/default/HTMLCodeHints/main.js
+++ b/src/extensions/default/HTMLCodeHints/main.js
@@ -391,6 +391,7 @@ define(function (require, exports, module) {
             return;
         }
         isInLiveHighlightSession = true;
+        this.editor._dontDismissPopupOnScroll();
         this.editor.restoreHistoryPoint(`${HISTORY_PREFIX}${hintSessionId}`);
         this.insertHint($highlightedEl.find(".brackets-html-hints"), true);
     };


### PR DESCRIPTION
on live code hints, when the user is selecting code hints using arrow keys, the text in the editor changes.
If the text that is being changed falls beyond the editor border(Eg: end of a long line that is part occluded
by live preview panel), then cm will scroll the editor horizontally to show the changed text. On scrolling,
 all popups are usually dismissed(see scroll event handler in this file), but that should happen if we
are live code hinting. So we do this.

## the bug:

https://github.com/phcode-dev/phoenix/assets/5336369/ed6b8efc-1172-4a2a-9dd5-6fc2ff604e9d

