### PR TITLE
feat: enable save as file dialog in desktop builds

### DIFF
--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -122,11 +122,15 @@ define(function (require, exports, module) {
         menu.addMenuDivider();
         menu.addMenuItem(Commands.FILE_SAVE);
         menu.addMenuItem(Commands.FILE_SAVE_ALL);
+        if(Phoenix.isNativeApp){
+            menu.addMenuItem(Commands.FILE_SAVE_AS);
+            // save as is not yet supported in browser as in our vfs implements only open folder, so vfs needs to
+            // be changed. Also, we dont know how the ux for save as will be in virtual paths.
+        }
         menu.addMenuItem(Commands.FILE_DUPLICATE_FILE);
         menu.addMenuItem(Commands.FILE_DOWNLOAD_PROJECT, undefined, undefined, undefined, {
             hideWhenCommandDisabled: true
         });
-        // menu.addMenuItem(Commands.FILE_SAVE_AS); not yet available in phoenix
         // menu.addMenuItem(Commands.FILE_PROJECT_SETTINGS); not yet available in phoenix
         menu.addMenuDivider();
         menu.addMenuItem(Commands.FILE_EXTENSION_MANAGER);

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1073,6 +1073,10 @@ define(function (require, exports, module) {
                     setTimeout(()=>{
                         fileOpenPromise = FileViewController
                             .openAndSelectDocument(path, FileViewController.PROJECT_MANAGER);
+                        // always configure editor after file is opened
+                        fileOpenPromise.always(function () {
+                            _configureEditorAndResolve();
+                        });
                     }, 100); // this is in a timeout as the file tree may not have updated yet after save as
                     // file created, and we wait for the file watcher events to get triggered so that the file
                     // selection is updated.
@@ -1085,12 +1089,11 @@ define(function (require, exports, module) {
 
                     // Add new file to workingset, and ensure we now redraw (even if index hasn't changed)
                     fileOpenPromise = handleFileAddToWorkingSetAndOpen({fullPath: path, paneId: info.paneId, index: info.index, forceRedraw: true});
+                    // always configure editor after file is opened
+                    fileOpenPromise.always(function () {
+                        _configureEditorAndResolve();
+                    });
                 }
-
-                // always configure editor after file is opened
-                fileOpenPromise.always(function () {
-                    _configureEditorAndResolve();
-                });
             }
 
             // Same name as before - just do a regular Save

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1070,8 +1070,12 @@ define(function (require, exports, module) {
 
                 if (FileViewController.getFileSelectionFocus() === FileViewController.PROJECT_MANAGER) {
                     // If selection is in the tree, leave workingset unchanged - even if orig file is in the list
-                    fileOpenPromise = FileViewController
-                        .openAndSelectDocument(path, FileViewController.PROJECT_MANAGER);
+                    setTimeout(()=>{
+                        fileOpenPromise = FileViewController
+                            .openAndSelectDocument(path, FileViewController.PROJECT_MANAGER);
+                    }, 100); // this is in a timeout as the file tree may not have updated yet after save as
+                    // file created, and we wait for the file watcher events to get triggered so that the file
+                    // selection is updated.
                 } else {
                     // If selection is in workingset, replace orig item in place with the new file
                     var info = MainViewManager.findInAllWorkingSets(doc.file.fullPath).shift();


### PR DESCRIPTION
Fixes: https://github.com/orgs/phcode-dev/discussions/1653

Save As is now available in desktop apps:
![image](https://github.com/phcode-dev/phoenix/assets/5336369/44a974f1-8b4b-4e32-9ea2-a681dfa5e870)

 save as is not yet supported in browser as in our vfs implements only open folder, so vfs needs to
 be changed. Also, we don't know how the ux for save as will be in virtual paths.