### PR TITLE
feat: add drag and drop support in windows and mac desktop apps

### DIFF
--- a/src/desktop-metrics.html
+++ b/src/desktop-metrics.html
@@ -120,9 +120,9 @@
         }
         window.__TAURI__.event.listen("health", processRequest);
         setInterval(async ()=>{
-            // close window if the metrics hidden window is the only one around.
+            // close window if the metrics hidden window and file drop window is the only one around.
             const allTauriWindowsLabels  = await window.__TAURI__.invoke('_get_window_labels');
-            if(allTauriWindowsLabels.length === 1){
+            if(allTauriWindowsLabels.length === 2 || allTauriWindowsLabels.length === 1){
                 window.__TAURI__.window.getCurrent().close();
             }
         }, 1000);

--- a/src/drop-files.html
+++ b/src/drop-files.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Project Name</title>
+    <script>
+        let windowLabelOfListener;
+        window.__TAURI__.event.listen('tauri://file-drop', (event) => {
+            __TAURI__.window.appWindow.hide();
+            if(!event || !event.payload || !event.payload.length || !windowLabelOfListener){
+                return;
+            }
+            window.__TAURI__.event.emit('file-drop-event-phoenix', {
+                windowLabelOfListener,
+                pathList: event.payload
+            });
+        });
+        window.__TAURI__.event.listen("drop-attach-on-window", ({payload})=> {
+            document.getElementById("projectName").innerText = payload.projectName;
+            document.getElementById("dropMessage").innerText = payload.dropMessage;
+            windowLabelOfListener = payload.windowLabelOfListener;
+        });
+        window.addEventListener('mouseout', function(event) {
+            // Check if the mouse is leaving the window (relatedTarget is null)
+            __TAURI__.window.appWindow.hide();
+        });
+        window.addEventListener('dragleave', ()=>{
+            __TAURI__.window.appWindow.hide();
+        });
+        window.addEventListener('dragend', ()=>{
+            __TAURI__.window.appWindow.hide();
+        });
+        window.addEventListener('click', ()=>{
+            __TAURI__.window.appWindow.hide();
+        });
+        document.addEventListener('visibilitychange', () => {
+            if (document.hidden) {
+                __TAURI__.window.appWindow.hide();
+            }
+        });
+        setInterval(async ()=>{
+            // close window if the metrics hidden window and file drop window is the only one around.
+            const allTauriWindowsLabels  = await window.__TAURI__.invoke('_get_window_labels');
+            if(allTauriWindowsLabels.length === 2 || allTauriWindowsLabels.length === 1){
+                window.__TAURI__.window.getCurrent().close();
+            }
+        }, 1000);
+    </script>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        html,
+        body {
+            height: 100%;
+            font-family: Arial, sans-serif;
+            background-color: #212123;
+            color: #ffffff; /* Default text color */
+        }
+
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+            justify-content: center;
+            align-items: center;
+            background-color: #212123;
+        }
+
+        header {
+            position: absolute;
+            top: 20px;
+            width: 100%;
+            text-align: center;
+        }
+
+        header h1 {
+            font-size: 2rem;
+            color: #cccccc;
+        }
+
+        .drop-area {
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            border: 2px dashed #555555;
+            border-radius: 10px;
+            padding: 50px;
+            background-color: #333333;
+            width: 80%;
+            height: 80%;
+        }
+
+        .drop-area .icon {
+            font-size: 3rem;
+            color: #aaaaaa;
+            margin-bottom: 20px;
+        }
+
+        .drop-area p {
+            font-size: 1.2rem;
+            color: #cccccc;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <header>
+        <h1 id="projectName">Project Name</h1>
+    </header>
+    <div class="drop-area">
+        <div class="icon">&#128193;</div>
+        <!-- This is a Unicode character for a folder icon -->
+        <p id="dropMessage">Drop file here to open</p>
+    </div>
+</div>
+</body>
+</html>
+

--- a/src/drop-files.html
+++ b/src/drop-files.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Project Name</title>
     <script>
-        let windowLabelOfListener;
+        let windowLabelOfListener, dropMessage, dropProjectMessage, dropMessageOneFile;
         window.__TAURI__.event.listen('tauri://file-drop', (event) => {
             __TAURI__.window.appWindow.hide();
             if(!event || !event.payload || !event.payload.length || !windowLabelOfListener){
@@ -16,9 +16,32 @@
                 pathList: event.payload
             });
         });
+        window.__TAURI__.event.listen('tauri://file-drop-cancelled', (event) => {
+            __TAURI__.window.appWindow.hide();
+        });
+        window.__TAURI__.event.listen('tauri://file-drop-hover', (event) => {
+            if(!event || !event.payload || !dropProjectMessage || !dropMessage){
+                return;
+            }
+            if(event.payload.length === 1) {
+                window.__TAURI__.fs.readDir(event.payload[0])
+                    .then(async ()=>{
+                        // if a single folder is present, we treat it as drop project
+                        document.getElementById("dropMessage").innerText = dropProjectMessage
+                            .replace("{0}", await window.__TAURI__.path.basename(event.payload[0]));
+                    }).catch(()=>{
+                    document.getElementById("dropMessage").innerText = dropMessageOneFile;
+                })
+            } else {
+                document.getElementById("dropMessage").innerText = dropMessage;
+            }
+        });
         window.__TAURI__.event.listen("drop-attach-on-window", ({payload})=> {
             document.getElementById("projectName").innerText = payload.projectName;
-            document.getElementById("dropMessage").innerText = payload.dropMessage;
+            // dropMessage will be set on drag hover events depending on file/files/project
+            dropMessage = payload.dropMessage;
+            dropProjectMessage = payload.dropProjectMessage;
+            dropMessageOneFile = payload.dropMessageOneFile;
             windowLabelOfListener = payload.windowLabelOfListener;
         });
         window.addEventListener('mouseout', function(event) {

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -97,6 +97,9 @@ define({
     "ERROR_CREATING_FILE_TITLE": "Error Creating {0}",
     "ERROR_CREATING_FILE": "An error occurred when trying to create the {0} <span class='dialog-filename'>{1}</span>. {2}",
     "ERROR_MIXED_DRAGDROP": "Cannot open a folder at the same time as opening other files.",
+    "DROP_TO_OPEN_FILES": "Drop to open files",
+    "DROP_TO_OPEN_FILE": "Drop to open file",
+    "DROP_TO_OPEN_PROJECT": "Drop to open folder `{0}` as project",
 
     // User key map error strings
     "ERROR_KEYMAP_TITLE": "Error Reading User Key Map",

--- a/src/phoenix/shell.js
+++ b/src/phoenix/shell.js
@@ -78,7 +78,8 @@ async function openURLInPhoenixWindow(url, {
             minHeight: minHeight || 600,
             width: width || defaultWidth,
             minWidth: minWidth || 800,
-            acceptFirstMouse: acceptFirstMouse === undefined ? true : acceptFirstMouse
+            acceptFirstMouse: acceptFirstMouse === undefined ? true : acceptFirstMouse,
+            fileDropEnabled: false
         });
         tauriWindow.isTauriWindow = true;
         return tauriWindow;

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -168,6 +168,17 @@ define(function (require, exports, module) {
             });
     }
 
+    async function _focusAndOpenDroppedFiles(droppedPaths) {
+        try{
+            const currentWindow = window.__TAURI__.window.getCurrent();
+            await currentWindow.setAlwaysOnTop(true);
+            await currentWindow.setAlwaysOnTop(false);
+        } catch (e) {
+            console.error("Error focusing window");
+        }
+        openDroppedFiles(droppedPaths);
+    }
+
     if(Phoenix.isNativeApp){
         window.__TAURI__.event.listen('file-drop-event-phoenix', ({payload})=> {
             if(!payload || !payload.pathList || !payload.pathList.length || !payload.windowLabelOfListener
@@ -182,7 +193,7 @@ define(function (require, exports, module) {
                     console.error("Error resolving dropped path: ", droppedPath);
                 }
             }
-            openDroppedFiles(droppedVirtualPaths);
+            _focusAndOpenDroppedFiles(droppedVirtualPaths);
         });
     }
 
@@ -223,7 +234,9 @@ define(function (require, exports, module) {
         const isSamePosition = currentPosition.x === newPosition.x && currentPosition.y === newPosition.y;
         window.__TAURI__.event.emit("drop-attach-on-window", {
             projectName: window.path.basename(ProjectManager.getProjectRoot().fullPath),
-            dropMessage: "Drop files to open or drop a folder to open it as a project",
+            dropMessage: Strings.DROP_TO_OPEN_FILES,
+            dropMessageOneFile: Strings.DROP_TO_OPEN_FILE,
+            dropProjectMessage: Strings.DROP_TO_OPEN_PROJECT,
             windowLabelOfListener: window.__TAURI__.window.appWindow.label
         });
         if (isSameSize && isSamePosition && (await fileDropWindow.isVisible())) {


### PR DESCRIPTION
Related shell change: https://github.com/phcode-dev/phoenix-desktop/pull/441

Tauri's file drag and drop is broken. See: 
https://discord.com/channels/616186924390023171/1245330514404048896

## How this is fixed then?

So we create a hidden fileDrop window that has `fileDropEnabled` set to true. When we detect a file drop drag over event using html5 apis, we use tauri apis to show the `fileDrop` window over the html element. the bounds over which the window should be rendered is calculated with tauri api's as well. it is tested in multi monitor setups to work in linux, windows and mac.

## only in windows and mac desktop, not in linux desktop
In linux there is this strange artifact coming when dropping files over a droppable window. 
![image](https://github.com/phcode-dev/phoenix/assets/5336369/609ff773-41e3-4a05-8f2e-39b49bfe1e17)

so we have disabled this is linux for the time being. 

## in browser
No yet implemented as we wont get write access to the dropped file/folder in most browsers. deferred till we have cloud storage.

https://github.com/phcode-dev/phoenix/assets/5336369/7acde94c-55c9-438c-a9d8-ed8ada375b5d

