### PR TITLE
feat: drag and drop experimental menu in linux

### DIFF
--- a/src/extensions/default/DebugCommands/main.js
+++ b/src/extensions/default/DebugCommands/main.js
@@ -35,7 +35,7 @@ define(function (require, exports, module) {
         PerfUtils              = brackets.getModule("utils/PerfUtils"),
         StringUtils            = brackets.getModule("utils/StringUtils"),
         Dialogs                = brackets.getModule("widgets/Dialogs"),
-        DefaultDialogs         = brackets.getModule("widgets/DefaultDialogs"),
+        DragAndDrop            = brackets.getModule("utils/DragAndDrop"),
         Strings                = brackets.getModule("strings"),
         PreferencesManager     = brackets.getModule("preferences/PreferencesManager"),
         LocalizationUtils      = brackets.getModule("utils/LocalizationUtils"),
@@ -53,7 +53,8 @@ define(function (require, exports, module) {
 
     const KeyboardPrefs = JSON.parse(require("text!keyboard.json"));
 
-    const DIAGNOSTICS_SUBMENU = "debug-diagnostics-sub-menu";
+    const DIAGNOSTICS_SUBMENU = "debug-diagnostics-sub-menu",
+        EXPERIMENTAL_FEATURES_SUB_MENU = "debug-experimental-features";
 
     // default preferences file name
     const DEFAULT_PREFERENCES_FILENAME = "defaultPreferences.json",
@@ -81,7 +82,8 @@ define(function (require, exports, module) {
         DEBUG_OPEN_VFS                        = "debug.openVFS",
         DEBUG_OPEN_EXTENSION_FOLDER           = "debug.openExtensionFolders",
         DEBUG_OPEN_VIRTUAL_SERVER             = "debug.openVirtualServer",
-        DEBUG_OPEN_PREFERENCES_IN_SPLIT_VIEW  = "debug.openPrefsInSplitView";
+        DEBUG_OPEN_PREFERENCES_IN_SPLIT_VIEW  = "debug.openPrefsInSplitView",
+        DEBUG_DRAG_AND_DROP                   = "debug.dragAndDrop";
 
     const LOG_TO_CONSOLE_KEY = logger.loggingOptions.LOCAL_STORAGE_KEYS.LOG_TO_CONSOLE_KEY,
         LOG_LIVE_PREVIEW_KEY = logger.loggingOptions.LOCAL_STORAGE_KEYS.LOG_LIVE_PREVIEW;
@@ -823,6 +825,19 @@ define(function (require, exports, module) {
     diagnosticsSubmenu.addMenuItem(DEBUG_OPEN_VIRTUAL_SERVER, undefined, undefined, undefined, {
         hideWhenCommandDisabled: true
     });
+
+    if(Phoenix.isNativeApp && Phoenix.platform === "linux") {
+        // there is only one experimental feature- drag and drop available in native linux apps only.
+        const experimentalSubmenu = debugMenu.addSubMenu(Strings.CMD_EXPERIMENTAL_FEATURES, EXPERIMENTAL_FEATURES_SUB_MENU);
+        CommandManager.register(Strings.CMD_ENABLE_DRAG_AND_DROP, DEBUG_DRAG_AND_DROP, ()=>{
+            PreferencesManager.set(DragAndDrop._PREF_DRAG_AND_DROP,
+                !PreferencesManager.get(DragAndDrop._PREF_DRAG_AND_DROP));
+        });
+        PreferencesManager.on("change", DragAndDrop._PREF_DRAG_AND_DROP, function () {
+            CommandManager.get(DEBUG_DRAG_AND_DROP).setChecked(PreferencesManager.get(DragAndDrop._PREF_DRAG_AND_DROP));
+        });
+        experimentalSubmenu.addMenuItem(DEBUG_DRAG_AND_DROP);
+    }
 
     CommandManager.get(DEBUG_UNLOAD_CURRENT_EXTENSION)
         .setEnabled(extensionDevelopment.isProjectLoadedAsExtension());

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -579,6 +579,8 @@ define({
     // Debug menu commands
     "CMD_OPEN_VFS": "Open Virtual File System",
     "CMD_DIAGNOSTIC_TOOLS": "{APP_NAME} Diagnostic Tools",
+    "CMD_EXPERIMENTAL_FEATURES": "Experimental Features",
+    "CMD_ENABLE_DRAG_AND_DROP": "Drag And Drop Files",
     "CMD_OPEN_EXTENSIONS_FOLDER": "Open Extensions Folder\u2026",
     "CMD_OPEN_VIRTUAL_SERVER": "Open Virtual Server",
 
@@ -1001,6 +1003,7 @@ define({
     "DESCRIPTION_RULERS_COLUMNS": "An array of column numbers to draw vertical rulers in the editor. Eg: [80, 100]",
     "DESCRIPTION_RULERS_COLORS": "An array of ruler colors corresponding to the rulers option in the editor. Eg: [\"#3d3d3d\", \"red\"]",
     "DESCRIPTION_RULERS_ENABLED": "true to enable editor rulers, else false",
+    "DESCRIPTION_DRAG_AND_DROP_ENABLED": "true to enable drag and drop functionality for files and folders from the file explorer or Finder",
     "DESCRIPTION_SMART_INDENT": "Automatically indent when creating a new block",
     "DESCRIPTION_SOFT_TABS": "false to turn off soft tabs behavior",
     "DESCRIPTION_SORT_DIRECTORIES_FIRST": "true to sort the directories first in the project tree",

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -22,7 +22,7 @@
 define(function (require, exports, module) {
 
 
-    var Async           = require("utils/Async"),
+    const Async           = require("utils/Async"),
         CommandManager  = require("command/CommandManager"),
         Commands        = require("command/Commands"),
         Dialogs         = require("widgets/Dialogs"),
@@ -33,6 +33,7 @@ define(function (require, exports, module) {
         FileUtils       = require("file/FileUtils"),
         ProjectManager  = require("project/ProjectManager"),
         Strings         = require("strings"),
+        Metrics = require("utils/Metrics"),
         StringUtils     = require("utils/StringUtils");
 
     const _PREF_DRAG_AND_DROP = "dragAndDrop"; // used in debug menu
@@ -117,6 +118,7 @@ define(function (require, exports, module) {
                         }
                     }
 
+                    Metrics.countEvent(Metrics.EVENT_TYPE.PLATFORM, "dragAndDrop", "fileOpen");
                     CommandManager.execute(Commands.CMD_ADD_TO_WORKINGSET_AND_OPEN,
                         {fullPath: path, silent: true})
                         .done(function () {
@@ -128,6 +130,7 @@ define(function (require, exports, module) {
                         });
                 } else if (!err && item.isDirectory && paths.length === 1) {
                     // One folder was dropped, open it.
+                    Metrics.countEvent(Metrics.EVENT_TYPE.PLATFORM, "dragAndDrop", "projectOpen");
                     ProjectManager.openProject(path)
                         .done(function () {
                             result.resolve();
@@ -191,6 +194,7 @@ define(function (require, exports, module) {
                 || payload.windowLabelOfListener !== window.__TAURI__.window.appWindow.label){
                 return;
             }
+            Metrics.countEvent(Metrics.EVENT_TYPE.PLATFORM, "dragAndDrop", "any");
             const droppedVirtualPaths = [];
             for(const droppedPath of payload.pathList) {
                 try{
@@ -295,7 +299,8 @@ define(function (require, exports, module) {
         function handleDrop(event) {
             event = event.originalEvent || event;
 
-            var files = event.dataTransfer.files;
+            const files = event.dataTransfer.files;
+            Metrics.countEvent(Metrics.EVENT_TYPE.PLATFORM, "dragAndDrop", "any");
 
             stopURIListPropagation(files, event);
 

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -29,10 +29,16 @@ define(function (require, exports, module) {
         DefaultDialogs  = require("widgets/DefaultDialogs"),
         MainViewManager = require("view/MainViewManager"),
         FileSystem      = require("filesystem/FileSystem"),
+        PreferencesManager  = require("preferences/PreferencesManager"),
         FileUtils       = require("file/FileUtils"),
         ProjectManager  = require("project/ProjectManager"),
         Strings         = require("strings"),
         StringUtils     = require("utils/StringUtils");
+
+    const _PREF_DRAG_AND_DROP = "dragAndDrop"; // used in debug menu
+    PreferencesManager.definePreference(_PREF_DRAG_AND_DROP, "boolean",
+        Phoenix.isNativeApp && Phoenix.platform !== "linux", {description: Strings.DESCRIPTION_DRAG_AND_DROP_ENABLED}
+    );
 
     /**
      * Returns true if the drag and drop items contains valid drop objects.
@@ -265,7 +271,7 @@ define(function (require, exports, module) {
             var files = event.dataTransfer.files;
 
             stopURIListPropagation(files, event);
-            if(Phoenix.isNativeApp && Phoenix.platform !== "linux" &&
+            if(PreferencesManager.get(_PREF_DRAG_AND_DROP) &&
                 event.dataTransfer.types && event.dataTransfer.types.includes("Files")){
                 // in linux, there is a bug in ubuntu 24 where dropping a file will cause a ghost icon which only
                 // goes away on reboot. So we dont support drop files in linux for now.
@@ -333,4 +339,7 @@ define(function (require, exports, module) {
     exports.attachHandlers      = attachHandlers;
     exports.isValidDrop         = isValidDrop;
     exports.openDroppedFiles    = openDroppedFiles;
+
+    // private exports
+    exports._PREF_DRAG_AND_DROP = _PREF_DRAG_AND_DROP;
 });

--- a/src/utils/Metrics.js
+++ b/src/utils/Metrics.js
@@ -90,13 +90,13 @@ define(function (require, exports, module) {
      * @type {Object}
      */
     const EVENT_TYPE = {
-        PLATFORM: "phoenix.platform",
+        PLATFORM: "platform",
         PROJECT: "project",
         THEMES: "themes",
         EXTENSIONS: "extensions",
         NOTIFICATIONS: "notifications",
-        UI: "phoenix.UI",
-        UI_MENU: "phoenix.UIMenu",
+        UI: "UI",
+        UI_MENU: "UIMenu",
         UI_DIALOG: "ui-dialog",
         UI_BOTTOM_PANEL: "ui-bottomPanel",
         UI_SIDE_PANEL: "ui-sidePanel",


### PR DESCRIPTION
This menu is shown only in desktop Linux builds as
1. drag and drop is supported in windows/mac.
2. In Linux, there is some icon ghosting seen, so its under a flag.
3. in browsers drag and drop is not supported at all for now.

![image](https://github.com/phcode-dev/phoenix/assets/5336369/a37493b4-ef3e-456c-bf08-44ec07d5486a)
