### PR TITLE
drag and drop in native builds ui rendering fixes for tauri

### DIFF
--- a/src/drop-files.html
+++ b/src/drop-files.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Project Name</title>
     <script>
-        let windowLabelOfListener, dropMessage, dropProjectMessage, dropMessageOneFile;
+        let windowLabelOfListener, dropMessage, dropProjectMessage, dropMessageOneFile, platform;
         window.__TAURI__.event.listen('tauri://file-drop', (event) => {
             __TAURI__.window.appWindow.hide();
             if(!event || !event.payload || !event.payload.length || !windowLabelOfListener){
@@ -16,8 +16,22 @@
                 pathList: event.payload
             });
         });
-        window.__TAURI__.event.listen('tauri://file-drop-cancelled', (event) => {
-            //__TAURI__.window.appWindow.hide();
+        window.addEventListener('mouseout', function(_event) {
+            __TAURI__.window.appWindow.hide();
+        });
+        window.__TAURI__.event.listen('tauri://file-drop-cancelled', (_event) => {
+            // usually in mac, when the drag leaves the window, we would get a mouseout event. this doesnt
+            // happen in windows as tauri has a custom hwnd window overlay over this dop window and appear
+            // to be swallowing the mouse out events. So we listen to tauri's drop cancelled event instead
+            // on windows only.
+            if(platform === "win") {
+                // in windows, tauri drop work differently, we have to do this to prevent the drop window not
+                // disappearing on mouse out.
+                __TAURI__.window.appWindow.hide();
+            }
+        });
+        window.addEventListener('click', ()=>{
+            __TAURI__.window.appWindow.hide();
         });
         window.__TAURI__.event.listen('tauri://file-drop-hover', (event) => {
             if(!event || !event.payload || !dropProjectMessage || !dropMessage){
@@ -43,25 +57,22 @@
             dropProjectMessage = payload.dropProjectMessage;
             dropMessageOneFile = payload.dropMessageOneFile;
             windowLabelOfListener = payload.windowLabelOfListener;
+            platform = payload.platform;
         });
-        window.addEventListener('mouseout', function(event) {
-            // Check if the mouse is leaving the window (relatedTarget is null)
-            __TAURI__.window.appWindow.hide();
-        });
-        window.addEventListener('dragleave', ()=>{
-            //__TAURI__.window.appWindow.hide();
-        });
-        window.addEventListener('dragend', ()=>{
-            //__TAURI__.window.appWindow.hide();
-        });
-        window.addEventListener('click', ()=>{
-            __TAURI__.window.appWindow.hide();
-        });
-        document.addEventListener('visibilitychange', () => {
-            if (document.hidden) {
-                //__TAURI__.window.appWindow.hide();
-            }
-        });
+
+        // The below code is commented as it was causing flicker issues in some platforms. IF adding these below
+        // event handlers, tread carefully.
+        // window.addEventListener('dragleave', ()=>{
+        //     //__TAURI__.window.appWindow.hide();
+        // });
+        // window.addEventListener('dragend', ()=>{
+        //     //__TAURI__.window.appWindow.hide();
+        // });
+        // document.addEventListener('visibilitychange', () => {
+        //     if (document.hidden) {
+        //         //__TAURI__.window.appWindow.hide();
+        //     }
+        // });
         setInterval(async ()=>{
             // close window if the metrics hidden window and file drop window is the only one around.
             const allTauriWindowsLabels  = await window.__TAURI__.invoke('_get_window_labels');

--- a/src/drop-files.html
+++ b/src/drop-files.html
@@ -17,7 +17,7 @@
             });
         });
         window.__TAURI__.event.listen('tauri://file-drop-cancelled', (event) => {
-            __TAURI__.window.appWindow.hide();
+            //__TAURI__.window.appWindow.hide();
         });
         window.__TAURI__.event.listen('tauri://file-drop-hover', (event) => {
             if(!event || !event.payload || !dropProjectMessage || !dropMessage){
@@ -49,17 +49,17 @@
             __TAURI__.window.appWindow.hide();
         });
         window.addEventListener('dragleave', ()=>{
-            __TAURI__.window.appWindow.hide();
+            //__TAURI__.window.appWindow.hide();
         });
         window.addEventListener('dragend', ()=>{
-            __TAURI__.window.appWindow.hide();
+            //__TAURI__.window.appWindow.hide();
         });
         window.addEventListener('click', ()=>{
             __TAURI__.window.appWindow.hide();
         });
         document.addEventListener('visibilitychange', () => {
             if (document.hidden) {
-                __TAURI__.window.appWindow.hide();
+                //__TAURI__.window.appWindow.hide();
             }
         });
         setInterval(async ()=>{

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -207,18 +207,25 @@ define(function (require, exports, module) {
         });
     }
 
+    const MAC_TITLE_BAR_HEIGHT = 28;
     async function _computeNewPositionAndSizeWebkit() {
         const currentWindow = window.__TAURI__.window.getCurrent();
         const newSize = await currentWindow.innerSize();
         const newPosition = await currentWindow.innerPosition();
         if(Phoenix.platform === "mac") {
-            newPosition.y = newPosition.y + 28;
-            newSize.height = newSize.height - 28;
+            // in mac we somehow get the top left of the window including the title bar even though we are calling the
+            // tauri innerPosition api. So we just adjust for a generally constant title bar height of mac that is 28px.
+            newPosition.y = newPosition.y + MAC_TITLE_BAR_HEIGHT;
+            newSize.height = newSize.height - MAC_TITLE_BAR_HEIGHT;
         }
         return {newSize, newPosition};
     }
 
     async function _computeNewPositionAndSizeWindows() {
+        // Note that the drop window may be on different screens if multi window setup. in windows os, there can be
+        // of different scale factors like 1x and 1.5x on another monitor. Additionally, we may apply our own zoom
+        // settings. So its is always better to just use the tauri provided positions. the tauri api returned values
+        // will position the window to the correct monitor as well.
         const currentWindow = window.__TAURI__.window.getCurrent();
         const newSize = await currentWindow.innerSize();
         const newPosition = await currentWindow.innerPosition();

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -253,7 +253,7 @@ define(function (require, exports, module) {
             return;
         }
 
-        const {newSize, newPosition} = await _computeNewPositionAndSize($activeElement);
+        const {newSize, newPosition} = await _computeNewPositionAndSize();
         const currentSize = await fileDropWindow.innerSize();
         const currentPosition = await fileDropWindow.innerPosition();
         const isSameSize = currentSize.width === newSize.width && currentSize.height === newSize.height;

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -211,8 +211,10 @@ define(function (require, exports, module) {
         const currentWindow = window.__TAURI__.window.getCurrent();
         const newSize = await currentWindow.innerSize();
         const newPosition = await currentWindow.innerPosition();
-        newPosition.y = newPosition.y + 28;
-        newSize.height = newSize.height - 28;
+        if(Phoenix.platform === "mac") {
+            newPosition.y = newPosition.y + 28;
+            newSize.height = newSize.height - 28;
+        }
         return {newSize, newPosition};
     }
 

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -207,22 +207,12 @@ define(function (require, exports, module) {
         });
     }
 
-    async function _computeNewPositionAndSizeWebkit($activeElement) {
-        // Get the current window
+    async function _computeNewPositionAndSizeWebkit() {
         const currentWindow = window.__TAURI__.window.getCurrent();
-
-        // Get the bounds of the current window
-        const size = await currentWindow.innerSize();
-        // in mac, the innerSize api in tauri gets the full size including titlebar. Since our sidebar is full size
-        const titlebarHeightIfAny = size.height - window.innerHeight;
-        const currentWindowPos = await currentWindow.innerPosition();
-        const offset = $activeElement.offset();
-        const width = $activeElement.outerWidth();
-        const height = $activeElement.outerHeight();
-        const x = currentWindowPos.x + offset.left,
-            y =currentWindowPos.y + titlebarHeightIfAny + offset.top;
-        const newSize = new window.__TAURI__.window.LogicalSize(width, height);
-        const newPosition = new window.__TAURI__.window.LogicalPosition(x, y);
+        const newSize = await currentWindow.innerSize();
+        const newPosition = await currentWindow.innerPosition();
+        newPosition.y = newPosition.y + 28;
+        newSize.height = newSize.height - 28;
         return {newSize, newPosition};
     }
 
@@ -233,11 +223,11 @@ define(function (require, exports, module) {
         return {newSize, newPosition};
     }
 
-    async function _computeNewPositionAndSize($activeElement) {
+    async function _computeNewPositionAndSize() {
         if(Phoenix.platform === "win") {
             return _computeNewPositionAndSizeWindows();
         }
-        return _computeNewPositionAndSizeWebkit($activeElement);
+        return _computeNewPositionAndSizeWebkit();
     }
 
     async function showAndResizeFileDropWindow(event) {

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -256,7 +256,8 @@ define(function (require, exports, module) {
             dropMessage: Strings.DROP_TO_OPEN_FILES,
             dropMessageOneFile: Strings.DROP_TO_OPEN_FILE,
             dropProjectMessage: Strings.DROP_TO_OPEN_PROJECT,
-            windowLabelOfListener: window.__TAURI__.window.appWindow.label
+            windowLabelOfListener: window.__TAURI__.window.appWindow.label,
+            platform: Phoenix.platform
         });
         if (isSameSize && isSamePosition && (await fileDropWindow.isVisible())) {
             return; // Do nothing if the window is already at the correct size and position and visible


### PR DESCRIPTION
Related to https://github.com/phcode-dev/phoenix/pull/1699

We now draw the drop area as full window
![image](https://github.com/phcode-dev/phoenix/assets/5336369/ddd96ff7-bc99-46a6-a62d-6f6f5b78438b)


 Note that the drop window may be on different screens if multi window setup. in windows os, there can be
 of different scale factors like 1x and 1.5x on another monitor. Additionally, we may apply our own zoom
 settings. So its is always better to just use the tauri provided positions. the tauri api returned values
 will position the window to the correct monitor as well.

so we removed the old html element relative drawing as its not trivial to account for all the scale factor/zoom/display resolutions combos when the tauri api itself behaves unpredictable in different platforms/display conditions. We now draw over the full window bounds.