### PR TITLE
fix: drop and drop window overlaps mac titlebar in some macs

### DIFF
--- a/src/assets/default-project/en/Newly_added_features.md
+++ b/src/assets/default-project/en/Newly_added_features.md
@@ -7,7 +7,7 @@ We are continuously adding features every week to improve the life of web develo
 
 Here's a list of top features recently added to Phoenix:
 
-## Drag and Drop Files and Folders in Desktop Apps
+## Drag and Drop Files and Folders in Desktop Apps - Experimental
 
 `Added on June, 2024`
 

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -207,17 +207,14 @@ define(function (require, exports, module) {
         });
     }
 
-    const MAC_TITLE_BAR_HEIGHT = 28;
     async function _computeNewPositionAndSizeWebkit() {
         const currentWindow = window.__TAURI__.window.getCurrent();
         const newSize = await currentWindow.innerSize();
         const newPosition = await currentWindow.innerPosition();
-        if(Phoenix.platform === "mac") {
-            // in mac we somehow get the top left of the window including the title bar even though we are calling the
-            // tauri innerPosition api. So we just adjust for a generally constant title bar height of mac that is 28px.
-            newPosition.y = newPosition.y + MAC_TITLE_BAR_HEIGHT;
-            newSize.height = newSize.height - MAC_TITLE_BAR_HEIGHT;
-        }
+        // in mac we somehow get the top left of the window including the title bar even though we are calling the
+        // tauri innerPosition api. We earlier adjusted for a generally constant title bar height of mac that is 28px.
+        // But then is nome macs due to display scaling, it was not 28px all the time.
+        // so, we just draw over the entire window in mac alone.
         return {newSize, newPosition};
     }
 


### PR DESCRIPTION
 in mac we somehow get the top left of the window including the title bar even though we are calling the tauri innerPosition api. We earlier adjusted for a generally constant title bar height of mac that is 28px. But then is nome macs due to display scaling, it was not 28px all the time. so, we just draw over the entire window in mac alone.