### PR TITLE
Reopen closed files - ctrl-shift-t

### DIFF
--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -290,6 +290,9 @@
     "navigate.gotoDefinition":  [
         "Ctrl-T"
     ],
+    "view.toggleProblems":  [
+        "Ctrl-Shift-M"
+    ],
     "navigate.jumptoDefinition":  [
         "Ctrl-J"
     ],

--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -290,9 +290,6 @@
     "navigate.gotoDefinition":  [
         "Ctrl-T"
     ],
-    "navigate.gotoDefinitionInProject":  [
-        "Ctrl-Shift-T"
-    ],
     "navigate.jumptoDefinition":  [
         "Ctrl-J"
     ],

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -124,6 +124,7 @@ define(function (require, exports, module) {
     exports.VIEW_SCROLL_LINE_UP         = "view.scrollLineUp";          // ViewCommandHandlers.js       _handleScrollLineUp()
     exports.VIEW_SCROLL_LINE_DOWN       = "view.scrollLineDown";        // ViewCommandHandlers.js       _handleScrollLineDown()
     exports.VIEW_TOGGLE_INSPECTION      = "view.toggleCodeInspection";  // CodeInspection.js            toggleEnabled()
+    exports.VIEW_TOGGLE_PROBLEMS        = "view.toggleProblems";        // CodeInspection.js            toggleProblems()
     exports.TOGGLE_LINE_NUMBERS         = "view.toggleLineNumbers";     // EditorOptionHandlers.js      _getToggler()
     exports.TOGGLE_ACTIVE_LINE          = "view.toggleActiveLine";      // EditorOptionHandlers.js      _getToggler()
     exports.TOGGLE_WORD_WRAP            = "view.toggleWordWrap";        // EditorOptionHandlers.js      _getToggler()

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -49,6 +49,7 @@ define(function (require, exports, module) {
     exports.FILE_CLOSE                  = "file.close";                 // DocumentCommandHandlers.js   handleFileClose()
     exports.FILE_CLOSE_ALL              = "file.close_all";             // DocumentCommandHandlers.js   handleFileCloseAll()
     exports.FILE_CLOSE_LIST             = "file.close_list";            // DocumentCommandHandlers.js   handleFileCloseList()
+    exports.FILE_REOPEN_CLOSED          = "file.reopen_closed";         // DocumentCommandHandlers.js   handleReopenClosed()
     exports.FILE_OPEN_DROPPED_FILES     = "file.openDroppedFiles";      // DragAndDrop.js               openDroppedFiles()
     exports.FILE_LIVE_FILE_PREVIEW      = "file.liveFilePreview";       // LiveDevelopment/main.js      _handleGoLiveCommand()
     exports.FILE_LIVE_FILE_PREVIEW_SETTINGS = "file.liveFilePreviewSettings";       // LiveDevelopment/main.js      _handleGoLiveCommand()

--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -75,6 +75,7 @@ define(function (require, exports, module) {
     const fileCloseAllShortcut = isDesktop ? "Ctrl-Shift-W" : ""; // Ctrl-Alt-Shift-W` universal shortcut is set in keyboard.json
     const openFileShortcut = isDesktop ? "Ctrl-O" : "";
     const openFolderShortcut = isBrowser ? "Ctrl-O" : "";
+    const reopenClosedShortcut = isBrowser ? "" : "Ctrl-Shift-T";
 
     AppInit.htmlReady(function () {
         /**
@@ -119,6 +120,7 @@ define(function (require, exports, module) {
         menu.addMenuItem(Commands.FILE_OPEN_FOLDER, openFolderShortcut);
         menu.addMenuItem(Commands.FILE_CLOSE, fileCloseShortcut);
         menu.addMenuItem(Commands.FILE_CLOSE_ALL, fileCloseAllShortcut);
+        menu.addMenuItem(Commands.FILE_REOPEN_CLOSED, reopenClosedShortcut);
         menu.addMenuDivider();
         menu.addMenuItem(Commands.FILE_SAVE);
         menu.addMenuItem(Commands.FILE_SAVE_ALL);

--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -221,6 +221,7 @@ define(function (require, exports, module) {
         menu.addMenuDivider();
         menu.addMenuItem(Commands.FILE_LIVE_HIGHLIGHT);
         menu.addMenuDivider();
+        menu.addMenuItem(Commands.VIEW_TOGGLE_PROBLEMS);
         menu.addMenuItem(Commands.VIEW_TOGGLE_INSPECTION);
 
         /*

--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -76,6 +76,8 @@ define(function (require, exports, module) {
     const openFileShortcut = isDesktop ? "Ctrl-O" : "";
     const openFolderShortcut = isBrowser ? "Ctrl-O" : "";
     const reopenClosedShortcut = isBrowser ? "" : "Ctrl-Shift-T";
+    const nextDocShortcut = isBrowser ? "Alt-PageDown" : "Ctrl-PageDown";
+    const prevDocShortcut = isBrowser ? "Alt-PageUp" : "Ctrl-PageUp";
 
     AppInit.htmlReady(function () {
         /**
@@ -237,8 +239,8 @@ define(function (require, exports, module) {
         menu.addMenuDivider();
         menu.addMenuItem(Commands.NAVIGATE_NEXT_DOC);
         menu.addMenuItem(Commands.NAVIGATE_PREV_DOC);
-        menu.addMenuItem(Commands.NAVIGATE_NEXT_DOC_LIST_ORDER);
-        menu.addMenuItem(Commands.NAVIGATE_PREV_DOC_LIST_ORDER);
+        menu.addMenuItem(Commands.NAVIGATE_NEXT_DOC_LIST_ORDER, nextDocShortcut);
+        menu.addMenuItem(Commands.NAVIGATE_PREV_DOC_LIST_ORDER, prevDocShortcut);
         menu.addMenuDivider();
         menu.addMenuItem(Commands.NAVIGATE_SHOW_IN_FILE_TREE);
         menu.addMenuDivider();

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -651,7 +651,9 @@ define(function (require, exports, module) {
             $menuItem.on("mouseenter", function () {
                 // This is to prevent size jumps when the keyboard
                 // icon hides and shows as selection changes
+                $menuAnchor.addClass("use-invisible-for-width-compute");
                 const currentWidth = $(this).width(); // Get the current width
+                $menuAnchor.removeClass("use-invisible-for-width-compute");
                 $(this).css('min-width', currentWidth + 'px');
                 self.closeSubMenu();
                 // now show selection
@@ -819,10 +821,13 @@ define(function (require, exports, module) {
                          "<span class='right-pusher'></span>" +
                          "<span>&rtrif;</span>"   +
                          "</a></li>");
+        const $menuAnchor = $menuItem.find(".menuAnchor");
 
         let self = this;
         $menuItem.on("mouseenter", function(e) {
+            $menuAnchor.addClass("use-invisible-for-width-compute");
             const currentWidth = $(this).width(); // Get the current width
+            $menuAnchor.removeClass("use-invisible-for-width-compute");
             $(this).css('min-width', currentWidth + 'px'); // Set min-width to the current width
             if (self.openSubMenu && self.openSubMenu.id === menu.id) {
                 return;

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1347,7 +1347,8 @@ define(function (require, exports, module) {
             if(MainViewManager.getPaneCount() === 1) {
                 paneToUse = MainViewManager.ACTIVE_PANE;
             }
-            FileViewController.openFileAndAddToWorkingSet(leastRecentlyClosedPath, paneToUse);
+            _enableOrDisableReopenClosedCmd();
+            return FileViewController.openFileAndAddToWorkingSet(leastRecentlyClosedPath, paneToUse);
         }
         _enableOrDisableReopenClosedCmd();
     }

--- a/src/extensionsIntegrated/DisplayShortcuts/templates/bottom-panel.html
+++ b/src/extensionsIntegrated/DisplayShortcuts/templates/bottom-panel.html
@@ -4,7 +4,7 @@
         <a href="#" class="close">&times;</a>
         <button class="btn reset-to-default" title="{{KEYBOARD_SHORTCUT_PANEL_RESET_DEFAULT}}">{{{KEYBOARD_SHORTCUT_PANEL_RESET}}}</button>
         <input class="filter" type="search" placeholder="{{{KEYBOARD_SHORTCUT_PANEL_FILTER}}}">
-        <span class="presetPickerContainer forced-hidden" title="{{KEYBOARD_SHORTCUT_PRESET_TOOLTIP}}"></span>
+        <span class="presetPickerContainer" title="{{KEYBOARD_SHORTCUT_PRESET_TOOLTIP}}"></span>
     </div>
     <div class="resizable-content"></div>
 </div>

--- a/src/extensionsIntegrated/DisplayShortcuts/vscode.json
+++ b/src/extensionsIntegrated/DisplayShortcuts/vscode.json
@@ -13,5 +13,10 @@
   "Ctrl-B": "view.toggleSidebar",
   "Ctrl-J": "view.togglePanels",
   "Ctrl-Shift-X": "file.extensionManager",
-  "Alt-Z": "view.toggleWordWrap"
+  "Alt-Z": "view.toggleWordWrap",
+  "Ctrl-Alt--": "navigation.jump.back",
+  "Ctrl-Shift-_": "navigation.jump.fwd",
+  "Ctrl-P": "navigate.quickOpen",
+  "Ctrl-Shift-P": "cmd.keyboardNavUI",
+  "Ctrl-Shift-O": "navigate.gotoDefinition"
 }

--- a/src/extensionsIntegrated/DisplayShortcuts/vscode.json
+++ b/src/extensionsIntegrated/DisplayShortcuts/vscode.json
@@ -1,2 +1,17 @@
 {
+  "Ctrl-3": null,
+  "Ctrl-Alt-Shift-W": null,
+  "Ctrl-Shift-W": null,
+  "Ctrl-Alt-S": null,
+  "Ctrl-Shift-Up": "edit.addCursorToPrevLine",
+  "Ctrl-Shift-Down": "edit.addCursorToNextLine",
+  "Ctrl-Shift-L": "cmd.findAllAndSelect",
+  "Ctrl-Shift-A": "edit.blockComment",
+  "Alt-Up": "edit.lineUp",
+  "Alt-Down": "edit.lineDown",
+  "Ctrl-D": "cmd.addNextMatch",
+  "Ctrl-B": "view.toggleSidebar",
+  "Ctrl-J": "view.togglePanels",
+  "Ctrl-Shift-X": "file.extensionManager",
+  "Alt-Z": "view.toggleWordWrap"
 }

--- a/src/extensionsIntegrated/NavigationAndHistory/keyboard.json
+++ b/src/extensionsIntegrated/NavigationAndHistory/keyboard.json
@@ -1,7 +1,4 @@
 {
-    "recent-files.show": [
-        "Ctrl-Alt-Shift-O"
-    ],
     "recent-files.next":  [
         {
             "key": "Ctrl-Tab"

--- a/src/extensionsIntegrated/NavigationAndHistory/main.js
+++ b/src/extensionsIntegrated/NavigationAndHistory/main.js
@@ -731,7 +731,7 @@ define(function (require, exports, module) {
         KeyBindingManager.addBinding(PREV_IN_RECENT_FILES, KeyboardPrefs[PREV_IN_RECENT_FILES]);
 
         var menu = Menus.getMenu(Menus.AppMenuBar.FILE_MENU);
-        menu.addMenuItem(SHOW_RECENT_FILES, "", Menus.AFTER, Commands.FILE_OPEN_FOLDER);
+        menu.addMenuItem(SHOW_RECENT_FILES, "", Menus.AFTER, Commands.FILE_REOPEN_CLOSED);
     }
 
     function _initDefaultNavigationCommands() {

--- a/src/extensionsIntegrated/NavigationAndHistory/main.js
+++ b/src/extensionsIntegrated/NavigationAndHistory/main.js
@@ -715,7 +715,8 @@ define(function (require, exports, module) {
 
         if (!CommandManager.get(SHOW_RECENT_FILES)) {
             CommandManager.register(Strings.CMD_RECENT_FILES_OPEN, SHOW_RECENT_FILES, _showRecentFileList);
-            KeyBindingManager.addBinding(SHOW_RECENT_FILES, KeyboardPrefs[SHOW_RECENT_FILES]);
+            KeyBindingManager.addBinding(SHOW_RECENT_FILES,
+                Phoenix.isNativeApp ? "Ctrl-R" : "Ctrl-Alt-Shift-O");
         }
 
         // Keyboard only - Navigate to the next doc in MROF list

--- a/src/language/CodeInspection.js
+++ b/src/language/CodeInspection.js
@@ -583,6 +583,7 @@ define(function (require, exports, module) {
                     }
                     toggleCollapsed(false);
                     scrollToProblem(pos.line);
+                    // todo strobe effect
                 });
                 $problemView.find(".copy-qv-error-text-btn").click(function (evt) {
                     evt.preventDefault();
@@ -1013,6 +1014,10 @@ define(function (require, exports, module) {
         run();
     }
 
+    function toggleProblems() {
+        toggleCollapsed();
+    }
+
     let lastRunTime;
     $(window.document).on("mousemove", ()=>{
         if(Phoenix.isTestWindow){
@@ -1073,6 +1078,7 @@ define(function (require, exports, module) {
 
     // Register command handlers
     CommandManager.register(Strings.CMD_VIEW_TOGGLE_INSPECTION, Commands.VIEW_TOGGLE_INSPECTION,        toggleEnabled);
+    CommandManager.register(Strings.CMD_VIEW_TOGGLE_PROBLEMS, Commands.VIEW_TOGGLE_PROBLEMS,        toggleProblems);
     CommandManager.register(Strings.CMD_GOTO_FIRST_PROBLEM,     Commands.NAVIGATE_GOTO_FIRST_PROBLEM,   handleGotoFirstProblem);
 
     // Register preferences

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -464,6 +464,7 @@ define({
     "CMD_OPEN_FOLDER": "Open Folder\u2026",
     "CMD_FILE_CLOSE": "Close",
     "CMD_FILE_CLOSE_ALL": "Close All",
+    "CMD_REOPEN_CLOSED": "Reopen Closed File",
     "CMD_FILE_CLOSE_LIST": "Close List",
     "CMD_FILE_CLOSE_OTHERS": "Close Others",
     "CMD_FILE_CLOSE_ABOVE": "Close Others Above",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -550,6 +550,7 @@ define({
     "CMD_TOGGLE_WORD_WRAP": "Word Wrap",
     "CMD_LIVE_HIGHLIGHT": "Live Preview Highlight",
     "CMD_VIEW_TOGGLE_INSPECTION": "Lint Files on Save",
+    "CMD_VIEW_TOGGLE_PROBLEMS": "Problems",
     "CMD_WORKINGSET_SORT_BY_ADDED": "Sort by Added",
     "CMD_WORKINGSET_SORT_BY_NAME": "Sort by Name",
     "CMD_WORKINGSET_SORT_BY_TYPE": "Sort by Type",

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -543,16 +543,21 @@ a:focus {
     }
 }
 
-.menuAnchor.selected .menu-shortcut:not(.fixed-shortcut) {
+.menuAnchor:hover .menu-shortcut:not(.fixed-shortcut) {
     display: none;
 }
 
-.menuAnchor.selected .keyboard-icon {
+.menuAnchor.use-invisible-for-width-compute:hover .menu-shortcut:not(.fixed-shortcut) {
+    visibility: hidden;
+    display: unset;
+}
+
+.menuAnchor:hover .keyboard-icon {
     cursor: pointer;
     visibility: visible;
 }
 
-.menuAnchor.selected .keyboard-icon:hover {
+.menuAnchor:hover .keyboard-icon:hover {
     color: @bc-secondary-btn-border;
 }
 

--- a/test/UnitTestSuite.js
+++ b/test/UnitTestSuite.js
@@ -116,6 +116,7 @@ define(function (require, exports, module) {
     require("spec/file-encoding-integ-test");
     require("spec/StateManager-test");
     require("spec/TaskManager-integ-test");
+    require("spec/Generic-integ-test");
     // Integrated extension tests
     require("spec/Extn-InAppNotifications-integ-test");
     require("spec/Extn-RemoteFileAdapter-integ-test");

--- a/test/spec/Generic-integ-test.js
+++ b/test/spec/Generic-integ-test.js
@@ -1,0 +1,178 @@
+/*
+ * GNU AGPL-3.0 License
+ *
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
+ * Original work Copyright (c) 2013 - 2021 Adobe Systems Incorporated. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
+ *
+ */
+
+/*global describe, path, it, expect, awaitsForDone, beforeAll, afterAll */
+
+define(function (require, exports, module) {
+
+
+    // Load dependent modules
+    let DocumentManager,      // loaded from brackets.test
+        EditorManager,        // loaded from brackets.test
+        MainViewManager,      // loaded from brackets.test
+        CommandManager,
+        Commands,
+        SpecRunnerUtils  = require("spec/SpecRunnerUtils");
+
+
+    describe("integration:Misc", function () {
+
+        let testWindow,
+            _$;
+
+        beforeAll(async function () {
+            testWindow = await SpecRunnerUtils.createTestWindowAndRun();
+            _$ = testWindow.$;
+
+            // Load module instances from brackets.test
+            DocumentManager = testWindow.brackets.test.DocumentManager;
+            EditorManager   = testWindow.brackets.test.EditorManager;
+            MainViewManager = testWindow.brackets.test.MainViewManager;
+            CommandManager = testWindow.brackets.test.CommandManager;
+            Commands = testWindow.brackets.test.Commands;
+        }, 30000);
+
+        afterAll(async function () {
+            await SpecRunnerUtils.parkProject(true);
+            testWindow      = null;
+            DocumentManager = null;
+            EditorManager   = null;
+            MainViewManager = null;
+            CommandManager = null;
+            Commands = null;
+            await SpecRunnerUtils.closeTestWindow();
+        }, 30000);
+
+        async function _openProjectFile(fileName, paneID) {
+            await awaitsForDone(SpecRunnerUtils.openProjectFiles([fileName], paneID), "opening "+ fileName);
+        }
+
+        async function _closeCurrentFile() {
+            await awaitsForDone(CommandManager.execute(Commands.FILE_CLOSE));
+        }
+
+        async function _reopenClosedFile() {
+            await awaitsForDone(CommandManager.execute(Commands.FILE_REOPEN_CLOSED));
+        }
+
+        describe("reopen closed files test", function () {
+            let currentProjectPath;
+            beforeAll(async function () {
+                // Working set behavior is sensitive to whether file lives in the project or outside it, so make
+                // the project root a known quantity.
+                currentProjectPath = await SpecRunnerUtils.getTempTestDirectory("/spec/DocumentCommandHandlers-test-files");
+                await SpecRunnerUtils.loadProjectInTestWindow(currentProjectPath);
+            });
+
+            afterAll(async function () {
+                MainViewManager.setLayoutScheme(1, 1);
+                await SpecRunnerUtils.parkProject(true);
+            });
+
+            it("should reopen be disabled at first and then enabled on closing a file", async function () {
+                const testFilePath = "test.js";
+                expect(CommandManager.get(Commands.FILE_REOPEN_CLOSED).getEnabled()).toBeFalse();
+                await _openProjectFile(testFilePath);
+                expect(CommandManager.get(Commands.FILE_REOPEN_CLOSED).getEnabled()).toBeFalse();
+                await _closeCurrentFile();
+                expect(CommandManager.get(Commands.FILE_REOPEN_CLOSED).getEnabled()).toBeTrue();
+                await _reopenClosedFile();
+                expect(CommandManager.get(Commands.FILE_REOPEN_CLOSED).getEnabled()).toBeFalse();
+                expect(MainViewManager.getCurrentlyViewedPath(MainViewManager.ACTIVE_PANE))
+                    .toEqual(path.join(currentProjectPath, testFilePath));
+            });
+
+            it("should reopen multiple files", async function () {
+                const testFilePath = "test.js", testFilePath2 = "couz.png";
+                expect(CommandManager.get(Commands.FILE_REOPEN_CLOSED).getEnabled()).toBeFalse();
+                await _openProjectFile(testFilePath);
+                await _openProjectFile(testFilePath2);
+                expect(CommandManager.get(Commands.FILE_REOPEN_CLOSED).getEnabled()).toBeFalse();
+                await _closeCurrentFile(); // couz.png is closed
+                await _closeCurrentFile(); // test.js - closed. so the reopen order is js then png
+                expect(CommandManager.get(Commands.FILE_REOPEN_CLOSED).getEnabled()).toBeTrue();
+                await _reopenClosedFile();
+                expect(CommandManager.get(Commands.FILE_REOPEN_CLOSED).getEnabled()).toBeTrue();
+                expect(MainViewManager.getCurrentlyViewedPath(MainViewManager.ACTIVE_PANE))
+                    .toEqual(path.join(currentProjectPath, testFilePath));
+                await _reopenClosedFile();
+                expect(CommandManager.get(Commands.FILE_REOPEN_CLOSED).getEnabled()).toBeFalse();
+                expect(MainViewManager.getCurrentlyViewedPath(MainViewManager.ACTIVE_PANE))
+                    .toEqual(path.join(currentProjectPath, testFilePath2));
+            });
+
+            it("should reopen multiple files in multiple panes", async function () {
+                expect(CommandManager.get(Commands.FILE_REOPEN_CLOSED).getEnabled()).toBeFalse();
+                const test = "test.js", test2 = "couz.png";
+                const couz = "couz.png", couz2 = "couz2.png";
+                MainViewManager.setLayoutScheme(1, 2);
+                await _openProjectFile(test, MainViewManager.FIRST_PANE);
+                await _openProjectFile(couz, MainViewManager.FIRST_PANE);
+                await _openProjectFile(test2, MainViewManager.SECOND_PANE);
+                await _openProjectFile(couz2, MainViewManager.SECOND_PANE);
+                expect(CommandManager.get(Commands.FILE_REOPEN_CLOSED).getEnabled()).toBeFalse();
+                MainViewManager.setActivePaneId(MainViewManager.FIRST_PANE);
+                await _closeCurrentFile(); // couz.png is closed
+                MainViewManager.setActivePaneId(MainViewManager.SECOND_PANE);
+                await _closeCurrentFile(); // couz2.png is closed. so the reopen order is couz2 then couz
+                expect(CommandManager.get(Commands.FILE_REOPEN_CLOSED).getEnabled()).toBeTrue();
+                MainViewManager.setActivePaneId(MainViewManager.FIRST_PANE);
+                await _reopenClosedFile();
+                expect(CommandManager.get(Commands.FILE_REOPEN_CLOSED).getEnabled()).toBeTrue();
+                expect(MainViewManager.getActivePaneId()).toBe(MainViewManager.SECOND_PANE);
+                expect(MainViewManager.getCurrentlyViewedPath(MainViewManager.ACTIVE_PANE))
+                    .toEqual(path.join(currentProjectPath, couz2));
+                await _reopenClosedFile();
+                expect(CommandManager.get(Commands.FILE_REOPEN_CLOSED).getEnabled()).toBeFalse();
+                expect(MainViewManager.getActivePaneId()).toBe(MainViewManager.FIRST_PANE);
+                expect(MainViewManager.getCurrentlyViewedPath(MainViewManager.ACTIVE_PANE))
+                    .toEqual(path.join(currentProjectPath, couz));
+            });
+
+            it("should reopen multiple files even if multiple panes collapses into single", async function () {
+                expect(CommandManager.get(Commands.FILE_REOPEN_CLOSED).getEnabled()).toBeFalse();
+                const test = "test.js", test2 = "couz.png";
+                const couz = "couz.png", couz2 = "couz2.png";
+                MainViewManager.setLayoutScheme(1, 2);
+                await _openProjectFile(test, MainViewManager.FIRST_PANE);
+                await _openProjectFile(couz, MainViewManager.FIRST_PANE);
+                await _openProjectFile(test2, MainViewManager.SECOND_PANE);
+                await _openProjectFile(couz2, MainViewManager.SECOND_PANE);
+                expect(CommandManager.get(Commands.FILE_REOPEN_CLOSED).getEnabled()).toBeFalse();
+                MainViewManager.setActivePaneId(MainViewManager.FIRST_PANE);
+                await _closeCurrentFile(); // couz.png is closed
+                MainViewManager.setActivePaneId(MainViewManager.SECOND_PANE);
+                await _closeCurrentFile(); // couz2.png is closed. so the reopen order is couz2 then couz
+                // now we move to a single pane layout from multi pane. reopen should still work
+                MainViewManager.setLayoutScheme(1, 1);
+                expect(CommandManager.get(Commands.FILE_REOPEN_CLOSED).getEnabled()).toBeTrue();
+                await _reopenClosedFile();
+                expect(CommandManager.get(Commands.FILE_REOPEN_CLOSED).getEnabled()).toBeTrue();
+                expect(MainViewManager.getCurrentlyViewedPath(MainViewManager.ACTIVE_PANE))
+                    .toEqual(path.join(currentProjectPath, couz2));
+                await _reopenClosedFile();
+                expect(CommandManager.get(Commands.FILE_REOPEN_CLOSED).getEnabled()).toBeFalse();
+                expect(MainViewManager.getCurrentlyViewedPath(MainViewManager.ACTIVE_PANE))
+                    .toEqual(path.join(currentProjectPath, couz));
+            });
+        });
+    });
+});

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -787,7 +787,7 @@ define(function (require, exports, module) {
 
     async function loadProjectInTestWindow(path) {
         let result = _testWindow.brackets.test.ProjectManager.openProject(path);
-        await awaitsForDone(result);
+        await awaitsForDone(result, "Error opening project "+path);
     }
 
     /**


### PR DESCRIPTION
![image](https://github.com/phcode-dev/phoenix/assets/5336369/e1f7111d-0602-4c91-a7d0-4ea77e718ee1)

* `ctrl-shift-T` is reassigned from navigate.jump to definition in project as only 7 people has used it in the last month and i suspect they were trying to do reopen closed workflow as in vscode.

* `ctrl-shift-T` shortcut is not assignable in browser as it is open last closed tab browser shortcut. So in browser, this is left blank for user to choose.