### PR TITLE
feat: go to next and previous problem

### DIFF
--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -305,10 +305,10 @@
         }
     ],
     "navigate.gotoNextProblem": [
-        "F8"
+        "Ctrl-I"
     ],
     "navigate.gotoPrevProblem": [
-        "Shift-F8"
+        "Ctrl-Shift-I"
     ],
     "navigate.prevDocListOrder":  [
         {

--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -304,6 +304,12 @@
             "key": "Alt-PageDown"
         }
     ],
+    "navigate.gotoNextProblem": [
+        "F8"
+    ],
+    "navigate.gotoPrevProblem": [
+        "Shift-F8"
+    ],
     "navigate.prevDocListOrder":  [
         {
             "key": "Alt-PageUp"

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -149,6 +149,8 @@ define(function (require, exports, module) {
     exports.NAVIGATE_GOTO_DEFINITION_PROJECT = "navigate.gotoDefinitionInProject";    // QuickOpen.js                 doDefinitionSearchInProject()
     exports.NAVIGATE_GOTO_LINE          = "navigate.gotoLine";          // QuickOpen.js                 doGotoLine()
     exports.NAVIGATE_GOTO_FIRST_PROBLEM = "navigate.gotoFirstProblem";  // CodeInspection.js            handleGotoFirstProblem()
+    exports.NAVIGATE_GOTO_NEXT_PROBLEM = "navigate.gotoNextProblem";  // CodeInspection.js            handleGotoNextProblem()
+    exports.NAVIGATE_GOTO_PREV_PROBLEM = "navigate.gotoPrevProblem";  // CodeInspection.js            handleGotoPrevProblem()
     exports.TOGGLE_QUICK_EDIT           = "navigate.toggleQuickEdit";   // EditorManager.js             _toggleInlineWidget()
     exports.TOGGLE_QUICK_DOCS           = "navigate.toggleQuickDocs";   // EditorManager.js             _toggleInlineWidget()
     exports.QUICK_EDIT_NEXT_MATCH       = "navigate.nextMatch";         // MultiRangeInlineEditor.js    _nextRange()

--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -235,7 +235,8 @@ define(function (require, exports, module) {
         menu.addMenuItem(Commands.NAVIGATE_GOTO_DEFINITION);
         menu.addMenuItem(Commands.NAVIGATE_GOTO_DEFINITION_PROJECT);
         menu.addMenuItem(Commands.NAVIGATE_JUMPTO_DEFINITION);
-        menu.addMenuItem(Commands.NAVIGATE_GOTO_FIRST_PROBLEM);
+        menu.addMenuItem(Commands.NAVIGATE_GOTO_NEXT_PROBLEM);
+        menu.addMenuItem(Commands.NAVIGATE_GOTO_PREV_PROBLEM);
         menu.addMenuDivider();
         menu.addMenuItem(Commands.NAVIGATE_NEXT_DOC);
         menu.addMenuItem(Commands.NAVIGATE_PREV_DOC);

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1334,6 +1334,26 @@ define(function (require, exports, module) {
     };
 
     /**
+     * Returns the first mark of a specific type found after the given position.
+     * @param {{line: number, ch: number}} position - The starting position to search from.
+     * @param {string} markType - The type of mark to look for.
+     * @returns {Array[TextMarker]} The array of text markers found, or an empty array if none are found.
+     */
+    Editor.prototype.getMarksAfter = function (position, markType) {
+        return this.findMarks(position, { line: this.lineCount(), ch: 0 }, markType) || [];
+    };
+
+    /**
+     * Returns the first mark of a specific type found before the given position.
+     * @param {{line: number, ch: number}} position - The ending position to search up to.
+     * @param {string} markType - The type of mark to look for.
+     * @returns {Array[TextMarker]} The array of text markers found, or an empty array if none are found.
+     */
+    Editor.prototype.getMarksBefore = function (position, markType) {
+        return this.findMarks({ line: 0, ch: 0 }, position, markType) || [];
+    };
+
+    /**
      * Returns an array containing all marked ranges in the document.
      * @param {string} [markType] - Optional, if given will only return marks of that type. Else returns everything.
      * @returns {Array[TextMarker]} TextMarker - A text marker array

--- a/src/extensionsIntegrated/DisplayShortcuts/vscode.json
+++ b/src/extensionsIntegrated/DisplayShortcuts/vscode.json
@@ -18,5 +18,7 @@
   "Ctrl-Shift-_": "navigation.jump.fwd",
   "Ctrl-P": "navigate.quickOpen",
   "Ctrl-Shift-P": "cmd.keyboardNavUI",
-  "Ctrl-Shift-O": "navigate.gotoDefinition"
+  "Ctrl-Shift-O": "navigate.gotoDefinition",
+  "F8": "navigate.gotoNextProblem",
+  "Shift-F8": "navigate.gotoPrevProblem"
 }

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -567,6 +567,8 @@ define({
     "CMD_GOTO_DEFINITION": "Quick Find Definition",
     "CMD_GOTO_DEFINITION_PROJECT": "Quick Find Definition in Project",
     "CMD_GOTO_FIRST_PROBLEM": "Go to First Problem",
+    "CMD_GOTO_NEXT_PROBLEM": "Go to Next Problem",
+    "CMD_GOTO_PREV_PROBLEM": "Go to Previous Problem",
     "CMD_TOGGLE_QUICK_EDIT": "Quick Edit",
     "CMD_TOGGLE_QUICK_DOCS": "Quick Docs",
     "CMD_QUICK_EDIT_PREV_MATCH": "Previous Quick Edit Item",


### PR DESCRIPTION

![image](https://github.com/phcode-dev/phoenix/assets/5336369/eacc41c3-0b52-4a66-8477-881d45e6ba65)

* Brackets had got to first problem option only. That is not very useful.
* This matches vscode implementation to go to next and prev problem from cursor.
* Goto first problem command is there for backward compatibility, but it has been omitted from UI.
* shortcut is `ctrl-i` and `ctrl-shift-i` in all platforms. we didnt use vscodes `f8` key as `f8` will be reserved for browser dev tools operations as phcode is web first editor and we will try to use browser shortcuts when possible.
* Vscode shortcut pack will use `f8` and `shift f8`