### PR TITLE
chore: survey prefetch for better UX

### DIFF
--- a/src/extensionsIntegrated/Phoenix/guided-tour.js
+++ b/src/extensionsIntegrated/Phoenix/guided-tour.js
@@ -38,7 +38,7 @@ define(function (require, exports, module) {
     // All popup notifications will show immediately on boot, we don't want to interrupt user amidst his work
     // by showing it at a later point in time.
     const GENERAL_SURVEY_TIME = 600000, // 10 min
-        POWER_USER_SURVEY_TIME = 7000, // 7 seconds to allow the survey to preload, but not
+        POWER_USER_SURVEY_TIME = 10000, // 10 seconds to allow the survey to preload, but not
         // enough time to break user workflow
         ONE_MONTH_IN_DAYS = 30,
         POWER_USER_SURVEY_INTERVAL_DAYS = 35,

--- a/src/extensionsIntegrated/Phoenix/html/survey-template.html
+++ b/src/extensionsIntegrated/Phoenix/html/survey-template.html
@@ -1,5 +1,5 @@
 <div class="modal" style="height: 60vh; display: flex; flex-direction: column; justify-content: space-between">
-    <iframe title="Phoenix Survey" id="frame1" width="100%" height="100%" src={{surveyURL}} style="border: 0px;"></iframe>
+    <div id="surveyFrameContainer" style="border: 0; width: 100%; height: 100%"></div>
     <div class="modal-footer">
         <button class="dialog-button btn primary" data-button-id="ok">{{Strings.CLOSE}}</button>
     </div>

--- a/src/index.html
+++ b/src/index.html
@@ -911,6 +911,9 @@
     <div id="overlay-instruction-text" class="instruction-text">
     </div>
 </div>
+<div id="alwaysHiddenElements">
+<!--    absoluteley positioned hidden elements go here.-->
+</div>
 <!-- HTML content is dynamically loaded and rendered by brackets.js after _loadPhoenixAfterSplashScreen.
      Any modules that depend on or modify HTML during load should
      require the "utils/AppInit" module and install a callback for


### PR DESCRIPTION
Surveys now popup instantly without waiting for the loading screen, which will reduce user frustration on seeing a loading screen without knowing what it is and possibly increasing the survey participation rate.