### PR TITLE
fix: clicking on svg image quick views break open of that svg file

### DIFF
--- a/src-node/package-lock.json
+++ b/src-node/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@phcode/node-core",
-    "version": "3.9.0-0",
+    "version": "3.9.1-0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@phcode/node-core",
-            "version": "3.9.0-0",
+            "version": "3.9.1-0",
             "license": "GNU-AGPL3.0",
             "dependencies": {
                 "@phcode/fs": "^3.0.1",

--- a/src/extensions/default/QuickView/ImagePreviewProvider.js
+++ b/src/extensions/default/QuickView/ImagePreviewProvider.js
@@ -169,10 +169,12 @@ define(function (require, exports, module) {
 
             function _imageToDataURI(file, cb) {
                 let contentType = "data:image;base64,";
+                let doNotCache = false;
                 if(file.name.endsWith('.svg')){
                     contentType = "data:image/svg+xml;base64,";
+                    doNotCache = true;
                 }
-                file.read({encoding: window.fs.BYTE_ARRAY_ENCODING}, function (err, content) {
+                file.read({encoding: window.fs.BYTE_ARRAY_ENCODING, doNotCache}, function (err, content) {
                     if(err){
                         cb(err);
                         return;

--- a/src/extensions/default/QuickView/unittests.js
+++ b/src/extensions/default/QuickView/unittests.js
@@ -352,6 +352,23 @@ define(function (require, exports, module) {
                 }, "waits for image to open");
             });
 
+            it("Should click on svg image preview open the corresponding file", async function () {
+                // should alos be able to load an svg with chinese unicode alphabets. This is here as if svg is
+                // read as text, the chinese text will go dodo, we read as binary.
+                const popoverInfo = await getPopoverAtPos(225, 26),
+                    imagePreview = popoverInfo.content.find("#quick-view-image-preview"),
+                    imagePath = imagePreview.attr("data-for-test"),
+                    expectedPathEnding = "img/chinese.svg";
+
+                // Just check end of path - local drive location prefix unimportant
+                expect(imagePath.substr(imagePath.length - expectedPathEnding.length)).toBe(expectedPathEnding);
+                imagePreview.click();
+                await awaitsFor(()=>{
+                    let currentFile = MainViewManager.getCurrentlyViewedFile();
+                    return currentFile.fullPath.endsWith(expectedPathEnding);
+                }, "waits for chinese sch image to open");
+            });
+
             it("Should show image preview for urls with http/https",async function () {
                 await checkImagePathAtPos("https://raw.github.com/gruehle/HoverPreview/master/screenshots/Image.png", 145, 26);
             });

--- a/src/filesystem/File.js
+++ b/src/filesystem/File.js
@@ -120,20 +120,24 @@ define(function (require, exports, module) {
 
         this._impl.readFile(this._path, options, function (err, data, encoding, preserveBOM, stat) {
             if (err) {
-                this._clearCachedData();
+                if(!options.doNotCache){
+                    this._clearCachedData();
+                }
                 callback(err);
                 return;
             }
 
-            // Always store the hash
-            this._hash = stat._hash;
-            this._encoding = encoding;
-            this._preserveBOM = preserveBOM;
+            if(!options.doNotCache) {
+                // Always store the hash
+                this._hash = stat._hash;
+                this._encoding = encoding;
+                this._preserveBOM = preserveBOM;
 
-            // Only cache data for watched files
-            if (watched) {
-                this._stat = stat;
-                this._contents = data;
+                // Only cache data for watched files
+                if (watched) {
+                    this._stat = stat;
+                    this._contents = data;
+                }
             }
 
             callback(err, data, encoding, stat);

--- a/test/spec/quickview-extn-test-files/img/chinese.svg
+++ b/test/spec/quickview-extn-test-files/img/chinese.svg
@@ -1,0 +1,6 @@
+<svg width="200px" height="100px" xmlns="http://www.w3.org/2000/svg">
+    <!-- Background Rectangle -->
+    <rect width="100%" height="100%" fill="#7f6ad3"/>
+    <!-- Chinese Text -->
+    <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="20" fill="black">你好</text>
+</svg>

--- a/test/spec/quickview-extn-test-files/test.css
+++ b/test/spec/quickview-extn-test-files/test.css
@@ -221,3 +221,7 @@ background: -ms-linear-gradient(top,  #d2dfed 0%,#c8d7eb 26%,#bed0ea 51%,#a6c0e3
     background: "https://website.com/archive.zip";
     background: "https://website.com/archive.tgz";
 }
+
+.chinese-svg {
+    background: url("img/chinese.svg");
+}


### PR DESCRIPTION
This was as we always read images for quick view as binary and base64 encoded it. But for SVG files, if we read it as binary once, it gets cached as binary encoding, and will never read as htf8 text if not explicitly specified. since normal flows wont specify it, the file cannot be opened again due to encoding mismatch.