### PR TITLE
fix: code folding markers disapear when hovering over gutter in dark theme

### DIFF
--- a/src/extensions/default/DarkTheme/main.less
+++ b/src/extensions/default/DarkTheme/main.less
@@ -112,7 +112,7 @@
 
 .CodeMirror.over-gutter, .CodeMirror-activeline {
     .CodeMirror-foldgutter-open:after {
-        color: #242424;
+        color: #ddd;
     }
 }
 


### PR DESCRIPTION
Earlier the dark theme gutter was so  close to background color. The dark theme was affected as we changed the `.codemirror`  CSS elements hierarchy on an earlier change for fixing active line HTML black highlights mostly.
![image](https://github.com/user-attachments/assets/4d8cf613-9270-4b3a-9553-898c59b12368)
