### PR TITLE
feat: auto rename html/XML/SVG tags

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1057,6 +1057,24 @@ define(function (require, exports, module) {
     };
 
     /**
+     * Retrieves a single character from the specified position in the editor.
+     *
+     * @param {CodeMirror.Position} pos - The position from which to retrieve the character.
+     *                                    This should be an object with `line` and `ch` properties.
+     * @returns {string|null} The character at the given position if within bounds,
+     *                        otherwise `null` if the position is out of range.
+     */
+    Editor.prototype.getCharacterAtPosition = function (pos) {
+        const cm = this._codeMirror;
+        let lineText = cm.getLine(pos.line);
+        if (pos.ch >= lineText.length || pos.line >= cm.lineCount()) {
+            return null;
+        }
+
+        return cm.getRange(pos, {line: pos.line, ch: pos.ch + 1});
+    };
+
+    /**
      * Get the token after the one at the given cursor position
      *
      * @param {{line: number, ch: number}} [cursor] - Optional cursor position after

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -941,6 +941,15 @@ define(function (require, exports, module) {
     };
 
     /**
+     * Check if the editor has multiple cursors or selections
+     * @returns {boolean}
+     */
+    Editor.prototype.hasMultipleCursors = function () {
+        const selections = this._codeMirror.listSelections();
+        return selections.length > 1;
+    };
+
+    /**
      * Takes the given selections, and expands each selection so it encompasses whole lines. Merges
      * adjacent line selections together. Keeps track of each original selection associated with a given
      * line selection (there might be multiple if individual selections were merged into a single line selection).

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1067,7 +1067,7 @@ define(function (require, exports, module) {
 
     /**
      * Retrieves a single character from the specified position in the editor.
-     *
+     * x|y where `|` is the cursor, will return y
      * @param {CodeMirror.Position} pos - The position from which to retrieve the character.
      *                                    This should be an object with `line` and `ch` properties.
      * @returns {string|null} The character at the given position if within bounds,
@@ -1081,6 +1081,22 @@ define(function (require, exports, module) {
         }
 
         return cm.getRange(pos, {line: pos.line, ch: pos.ch + 1});
+    };
+
+    /**
+     * Retrieves a single character previous to the specified position in the editor in the same line if possible.
+     * x|y where `|` is the cursor, will return x
+     *
+     * @param {CodeMirror.Position} pos - The position from which to retrieve the character.
+     *                                    This should be an object with `line` and `ch` properties.
+     * @returns {string|null} The character previous to the given position if within bounds,
+     *                        otherwise `null` if the position is out of range.
+     */
+    Editor.prototype.getPrevCharacterAtPosition = function (pos) {
+        if(pos.ch === 0) {
+            return null;
+        }
+        return this.getCharacterAtPosition({line: pos.line, ch: pos.ch-1});
     };
 
     /**

--- a/src/extensions/default/DefaultExtensions.json
+++ b/src/extensions/default/DefaultExtensions.json
@@ -30,7 +30,7 @@
    "note": "This is only to for legacy extensions that havent been updated for a long time, remove flag unconditionally if instructed by the extension author, but inform of the issues in extension.",
    "extensionIDs": [
      "brackets-beautify", "beautify.io", "hirse.beautify", "jsbeautifier", "sizuhiko.brackets.prettier", "pretty_json",
-     "bib-locked-live-preview", "brackets-display-shortcuts"
+     "bib-locked-live-preview", "brackets-display-shortcuts", "changing-tags"
    ]
  }
 }

--- a/src/extensionsIntegrated/htmlTagSyncEdit/main.js
+++ b/src/extensionsIntegrated/htmlTagSyncEdit/main.js
@@ -1,0 +1,166 @@
+/*
+ * GNU AGPL-3.0 License
+ *
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
+ *
+ */
+
+/*global*/
+
+// This file handles synchronous tag edit for html files. ie, if we edit <div> then the </div> part is also updated.
+
+define(function (require, exports, module) {
+    const AppInit = require("utils/AppInit"),
+        Editor = require("editor/Editor").Editor,
+        CodeMirror = require("thirdparty/CodeMirror/lib/codemirror"),
+        EditorManager = require("editor/EditorManager");
+
+    const HTML_TAG_SYNC = ".htmlTagSync",
+        MARK_TYPE_TAG_RENAME_START = "startTagSyncEdit",
+        MARK_TYPE_TAG_RENAME_END = "endTagSyncEdit";
+    const MARK_STYLE = {
+        className: "editor-text-tag-sync-underline",
+        clearWhenEmpty: false,
+        inclusiveLeft: true,
+        inclusiveRight: true
+    };
+    let activeEditor, marksPresent, tagPosition;
+
+    const tagSyncFileModes = new Set(["htm", "html", "xhtml", "xml"]);
+
+    function isTagSyncEditable() {
+        if (!activeEditor) {
+            return false;
+        }
+        let language = activeEditor.getLanguageForSelection();
+        return tagSyncFileModes.has(language.getId());
+    }
+
+    function clearRenameMarkers() {
+        if(!marksPresent || !activeEditor){
+            return;
+        }
+        marksPresent = false;
+        console.log("detach");
+        activeEditor.off(Editor.EVENT_CHANGE + HTML_TAG_SYNC);
+        activeEditor.clearAllMarks(MARK_TYPE_TAG_RENAME_START);
+        activeEditor.clearAllMarks(MARK_TYPE_TAG_RENAME_END);
+    }
+
+    function _getTagToken(cursor) {
+        let token = activeEditor.getToken(cursor);
+        if(token && token.type === "tag bracket") {// the cursosr is just before the tag like: <|tag or </|tag or <|/tag
+            cursor.ch++; // move one step to <t|ag or </t|ag or </|tag ; position </|tag is still invalid tough
+            token = activeEditor.getToken(cursor);
+        }
+        if(!token || !(token.type === "tag" || token.type === "tag error")) {
+            return null;
+        }
+        return token;
+    }
+
+    function _changeHandler(_evt, _editor, changes) {
+        if(!changes || !changes.length){
+            return;
+        }
+        const cursor = activeEditor.getCursorPos();
+        let token = _getTagToken(cursor);
+        if(!token || !marksPresent) {
+            clearRenameMarkers();
+            return;
+        }
+        const tag = token.string;
+        let markToReplace = activeEditor.getAllMarks(MARK_TYPE_TAG_RENAME_END);
+        if(tagPosition === "close"){
+            markToReplace = activeEditor.getAllMarks(MARK_TYPE_TAG_RENAME_START);
+        }
+        if(!markToReplace.length) {
+            return;
+        }
+        markToReplace = markToReplace[0].find();
+        const markedText = activeEditor.getTextBetween(markToReplace.from, markToReplace.to);
+        if(markedText === tag){
+            return;
+        }
+        activeEditor.replaceRange(tag, markToReplace.from, markToReplace.to, changes[0].origin);
+    }
+
+    function updateRenameMarkers(matchingTags, cursor) {
+        // todo multi cursor
+        const tagName = matchingTags.open.tag;
+        let openPos = matchingTags.open.from,
+            closePos = matchingTags.close.from;
+        clearRenameMarkers();
+        marksPresent = true;
+        tagPosition = matchingTags.at;
+        // we have to mark only the tag in an open tag of form <|tag| attr="...>
+        const openPosStart = {line: openPos.line, ch: openPos.ch +1};
+        const openPosEnd = {line: openPos.line, ch: openPos.ch + 1 + tagName.length};
+        activeEditor.markText(MARK_TYPE_TAG_RENAME_START, openPosStart, openPosEnd, MARK_STYLE);
+        // we have to mark only the tag in an open tag of form </|tag| attr="...>
+        const closePosStart = {line: closePos.line, ch: closePos.ch +2};
+        const closePosEnd = {line: closePos.line, ch: closePos.ch + 2 + tagName.length};
+        activeEditor.markText(MARK_TYPE_TAG_RENAME_END, closePosStart, closePosEnd, MARK_STYLE);
+        console.log("+attach");
+        activeEditor.on(Editor.EVENT_CHANGE + HTML_TAG_SYNC, _changeHandler);
+    }
+
+    function cursorActivity() {
+        const isTagEditableDoc = isTagSyncEditable();
+        if(!isTagEditableDoc){
+            clearRenameMarkers();
+            return;
+        }
+        const cursor = activeEditor.getCursorPos();
+        let token = _getTagToken(cursor);
+        if(!token) {
+            clearRenameMarkers();
+            return;
+        }
+        const startMark = activeEditor.findMarksAt(cursor, MARK_TYPE_TAG_RENAME_START);
+        const endMark = activeEditor.findMarksAt(cursor, MARK_TYPE_TAG_RENAME_END);
+        if(startMark.length || endMark.length) {
+            // there is already a mark here, don't do anything. This will come in play when the user is editing a start
+            // or end tag and we need to sync update in change handler.
+            return;
+        }
+        const matchingTags = CodeMirror.findMatchingTag(activeEditor._codeMirror, cursor);
+        if(!matchingTags) {
+            clearRenameMarkers();
+            return;
+        }
+        if(!matchingTags.close){
+            clearRenameMarkers();
+            return;
+        }
+        updateRenameMarkers(matchingTags, cursor);
+    }
+
+    AppInit.appReady(function () {
+        EditorManager.on(EditorManager.EVENT_ACTIVE_EDITOR_CHANGED + HTML_TAG_SYNC, ()=>{
+            if(activeEditor) {
+                activeEditor.off(Editor.EVENT_CURSOR_ACTIVITY + HTML_TAG_SYNC);
+                clearRenameMarkers();
+            }
+            activeEditor = EditorManager.getActiveEditor();
+            if(!activeEditor){
+                return;
+            }
+            activeEditor.on(Editor.EVENT_CURSOR_ACTIVITY + HTML_TAG_SYNC, cursorActivity);
+            cursorActivity();
+        });
+    });
+});

--- a/src/extensionsIntegrated/htmlTagSyncEdit/main.js
+++ b/src/extensionsIntegrated/htmlTagSyncEdit/main.js
@@ -75,7 +75,15 @@ define(function (require, exports, module) {
     }
 
     function _getTagToken(cursor) {
+        let curChar = activeEditor.getCharacterAtPosition(cursor);
+        if(curChar === "<"){ // <|<  or <div>|</div> is not a valid tag edit point
+            return null;
+        }
         let token = activeEditor.getToken(cursor);
+        if(token && token.string === "<>"){
+            // empty tags are not syncable if they are not being edited
+            return null;
+        }
         if(token && token.type === "tag bracket") {// the cursosr is just before the tag like: <|tag or </|tag or <|/tag
             cursor.ch++; // move one step to <t|ag or </t|ag or </|tag ; position </|tag is still invalid tough
             token = activeEditor.getToken(cursor);

--- a/src/extensionsIntegrated/htmlTagSyncEdit/main.js
+++ b/src/extensionsIntegrated/htmlTagSyncEdit/main.js
@@ -112,6 +112,7 @@ define(function (require, exports, module) {
         let token = _getTagToken(cursor);
         if(!token && marksPresent && _isEditingEmptyTag()) {
             ignoreChanges = true;
+            activeEditor.undo();
             activeEditor.operation(()=>{
                 _replaceMarkText(MARK_TYPE_TAG_RENAME_START, "", "syncTagPaste");
                 _replaceMarkText(MARK_TYPE_TAG_RENAME_END, "", "syncTagPaste");
@@ -137,16 +138,15 @@ define(function (require, exports, module) {
             return;
         }
         ignoreChanges = true;
+        let editOrigin = changes[0].origin;
         if(changes[0].origin === "paste"){
-            activeEditor.undo();
-            activeEditor.operation(()=>{
-                _replaceMarkText(MARK_TYPE_TAG_RENAME_START, tag, "syncTagPaste");
-                _replaceMarkText(MARK_TYPE_TAG_RENAME_END, tag, "syncTagPaste");
-            });
-            ignoreChanges = false;
-            return;
+            editOrigin = "syncTagPaste";
         }
-        activeEditor.replaceRange(tag, markToReplace.from, markToReplace.to, changes[0].origin);
+        activeEditor.undo();
+        activeEditor.operation(()=>{
+            _replaceMarkText(MARK_TYPE_TAG_RENAME_START, tag, editOrigin);
+            _replaceMarkText(MARK_TYPE_TAG_RENAME_END, tag, editOrigin);
+        });
         ignoreChanges = false;
     }
 

--- a/src/extensionsIntegrated/htmlTagSyncEdit/main.js
+++ b/src/extensionsIntegrated/htmlTagSyncEdit/main.js
@@ -188,7 +188,6 @@ define(function (require, exports, module) {
     }
 
     function updateRenameMarkers(matchingTags, cursor) {
-        // todo multi cursor
         const tagName = matchingTags.open.tag;
         let openPos = matchingTags.open.from,
             closePos = matchingTags.close.from;

--- a/src/extensionsIntegrated/htmlTagSyncEdit/main.js
+++ b/src/extensionsIntegrated/htmlTagSyncEdit/main.js
@@ -290,7 +290,7 @@ define(function (require, exports, module) {
             activeEditor.off(Editor.EVENT_CURSOR_ACTIVITY + HTML_TAG_SYNC);
             clearRenameMarkers();
         }
-        if(!syncEditEnabled){
+        if(!syncEditEnabled || (Phoenix.isTestWindow && !window.___syncEditEnabledForTests)){
             return;
         }
         activeEditor = EditorManager.getActiveEditor();
@@ -317,11 +317,12 @@ define(function (require, exports, module) {
             activeEditor.markText(MARK_TYPE_TAG_RENAME_ESCAPED, mark.from, mark.to, MARK_STYLE_ESCAPE);
             startMark.length && startMark[0].clear();
             endMark.length && endMark[0].clear();
+            return true;
         }
+        return false;
     }
 
     AppInit.appReady(function () {
-        // todo fix legacy extension not supported
         EditorManager.on(EditorManager.EVENT_ACTIVE_EDITOR_CHANGED + HTML_TAG_SYNC, init);
         setTimeout(init, 1000);
         const toggleCmd = CommandManager.register(Strings.CMD_AUTO_RENAME_TAGS, CMD_AUTO_RENAME_TAGS,

--- a/src/extensionsIntegrated/htmlTagSyncEdit/main.js
+++ b/src/extensionsIntegrated/htmlTagSyncEdit/main.js
@@ -112,8 +112,10 @@ define(function (require, exports, module) {
         let token = _getTagToken(cursor);
         if(!token && marksPresent && _isEditingEmptyTag()) {
             ignoreChanges = true;
-            _replaceMarkText(MARK_TYPE_TAG_RENAME_START, "", "syncTagPaste");
-            _replaceMarkText(MARK_TYPE_TAG_RENAME_END, "", "syncTagPaste");
+            activeEditor.operation(()=>{
+                _replaceMarkText(MARK_TYPE_TAG_RENAME_START, "", "syncTagPaste");
+                _replaceMarkText(MARK_TYPE_TAG_RENAME_END, "", "syncTagPaste");
+            });
             ignoreChanges = false;
             return;
         }
@@ -180,11 +182,12 @@ define(function (require, exports, module) {
         const cursor = activeEditor.getCursorPos();
         let token = activeEditor.getToken(cursor);
         let curChar = activeEditor.getCharacterAtPosition(cursor);
-        if(!token || !curChar || token.type === "tag") {
+        if(!token || token.type === "tag") {
             return false;
         }
-        // <| > or </| > or <|> or </|>
-        if((token.type === "tag bracket" || token.string === "</") && (curChar === " " || curChar === ">")) {
+        // <| > or </| > or <|> or </|> or </|\n
+        if((token.type === "tag bracket" || token.string === "</") && (curChar === " " || curChar === ">" ||
+            !curChar)) { // // if curChar is null, it means that its the last charecter
             return true;
         }
         return false;

--- a/src/extensionsIntegrated/htmlTagSyncEdit/main.js
+++ b/src/extensionsIntegrated/htmlTagSyncEdit/main.js
@@ -185,9 +185,10 @@ define(function (require, exports, module) {
         if(!token || token.type === "tag") {
             return false;
         }
-        // <| > or </| > or <|> or </|> or </|\n
+        // <| > or </| > or <|> or </|> or </|\n but not >|\n
         if((token.type === "tag bracket" || token.string === "</") && (curChar === " " || curChar === ">" ||
-            !curChar)) { // // if curChar is null, it means that its the last charecter
+            (token.string !== ">" && !curChar))) {
+            // if curChar is null, it means that its the last charecter
             return true;
         }
         return false;

--- a/src/extensionsIntegrated/htmlTagSyncEdit/main.js
+++ b/src/extensionsIntegrated/htmlTagSyncEdit/main.js
@@ -272,7 +272,7 @@ define(function (require, exports, module) {
         init();
     }
 
-    const tagSyncFileModes = new Set(["htm", "html", "xhtml", "xml", "svg"]);
+    const tagSyncFileModes = new Set(["htm", "html", "xhtml", "xml", "svg", "php"]);
     function _isTagSyncEditable(editor) {
         // ideally we can just listen to html sections within non-html files too instead of only accepting html file
         // types. This was the original impl but found that html text in markdown sync edit worked as a disaster

--- a/src/extensionsIntegrated/loader.js
+++ b/src/extensionsIntegrated/loader.js
@@ -40,4 +40,5 @@ define(function (require, exports, module) {
     require("./RecentProjects/main");
     require("./DisplayShortcuts/main");
     require("./appUpdater/main");
+    require("./htmlTagSyncEdit/main");
 });

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -515,6 +515,7 @@ define({
     "CMD_SHOW_CODE_HINTS": "Show Code Hints",
     "CMD_BEAUTIFY_CODE": "Beautify Code",
     "CMD_BEAUTIFY_CODE_ON_SAVE": "Beautify Code After Save",
+    "CMD_AUTO_RENAME_TAGS": "Auto Rename HTML Tags",
 
     // Search menu commands
     "FIND_MENU": "Find",
@@ -1015,6 +1016,7 @@ define({
     "DESCRIPTION_RULERS_COLUMNS": "An array of column numbers to draw vertical rulers in the editor. Eg: [80, 100]",
     "DESCRIPTION_RULERS_COLORS": "An array of ruler colors corresponding to the rulers option in the editor. Eg: [\"#3d3d3d\", \"red\"]",
     "DESCRIPTION_RULERS_ENABLED": "true to enable editor rulers, else false",
+    "DESCRIPTION_AUTO_RENAME_TAGS": "true to automatically rename paired HTML/XML tag, else false",
     "DESCRIPTION_DRAG_AND_DROP_ENABLED": "true to enable drag and drop functionality for files and folders from the file explorer or Finder",
     "DESCRIPTION_SMART_INDENT": "Automatically indent when creating a new block",
     "DESCRIPTION_SOFT_TABS": "false to turn off soft tabs behavior",

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -144,15 +144,27 @@ html, body {
     background-color: @matching-bracket;
 }
 
+.editor-text-tag-sync-underline {
+    text-decoration-style: double;
+    text-decoration-line: underline;
+    text-decoration-skip-ink: none;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 1px;
+    text-decoration-color: @bc-primary-btn-border;
+}
+
 .editor-text-rename-outline{
-    border-top: 2px @bc-primary-btn-border solid;
-    border-bottom: 2px @bc-primary-btn-border solid;
+    border-top: 1px @bc-primary-btn-border solid;
+    border-bottom: 1px @bc-primary-btn-border solid;
 }
-.editor-text-rename-outline-left{
-    border-left: 2px @bc-primary-btn-border solid;
+.editor-text-rename-outline-left {
+    box-shadow: inset 1px 0 0 0 @bc-primary-btn-border; /* Left shadow */
 }
-.editor-text-rename-outline-right{
-    border-right: 2px @bc-primary-btn-border solid;
+.editor-text-rename-outline-right {
+    box-shadow: inset -1px 0 0 0 @bc-primary-btn-border; /* right shadow */
+}
+.editor-text-rename-outline-left.editor-text-rename-outline-right {
+    box-shadow: inset 1px 0 0 0 @bc-primary-btn-border, inset -1px 0 0 0 @bc-primary-btn-border; /* Left, right shadow */
 }
 
 // error class has highest visual precedence, followed by warning, spell error and info.


### PR DESCRIPTION
Automatically rename paired HTML/XML/SVG/et.al tags.

[Screencast from 20-07-24 04:36:17 PM IST.webm](https://github.com/user-attachments/assets/54e6b05a-e832-4f00-b36e-a975d2d80373)

1. Only works in `html/xhtml/htm/xml/svg/php/jsp` files for now.
2. pressing escape will temporarily disable the sync. but it can be enabled by moving cursor out of tag pair and coming back.
3. Menu item to disable it permanently with `Edit > Auto Rename HTML Tags` ![image](https://github.com/user-attachments/assets/fc9d58a1-7828-4872-b146-ebde3b6b3def)
