### PR TITLE
chore: better robustness for triple control key press detect and disable preference

### DIFF
--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -1115,7 +1115,7 @@ define(function (require, exports, module) {
         Meta: true
     };
     function _detectTripleCtrlKeyPress(event) {
-        if(!PreferencesManager.get(PREF_TRIPLE_CTRL_KEY_PRESS_ENABLED)){
+        if(PreferencesManager && !PreferencesManager.get(PREF_TRIPLE_CTRL_KEY_PRESS_ENABLED)){
             return false;
         }
         const currentTime = new Date().getTime(); // Get the current time

--- a/src/command/KeyboardOverlayMode.js
+++ b/src/command/KeyboardOverlayMode.js
@@ -43,7 +43,7 @@ define(function (require, exports, module) {
 
     function showOverlay(targetId) {
         // Find the target div and the overlay div
-        Metrics.countEvent(Metrics.EVENT_TYPE.KEYBOARD, "ctrlx3", "showOverlay");
+        Metrics.countEvent(Metrics.EVENT_TYPE.UI, "palette", "showOverlay");
         if(!targetId){
             console.error("No target ID for selecting overlay. Ignoring");
             return;

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -1019,6 +1019,7 @@ define({
     "DESCRIPTION_RULERS_ENABLED": "true to enable editor rulers, else false",
     "DESCRIPTION_AUTO_RENAME_TAGS": "true to automatically rename paired HTML/XML tag, else false",
     "DESCRIPTION_DRAG_AND_DROP_ENABLED": "true to enable drag and drop functionality for files and folders from the file explorer or Finder",
+    "DESCRIPTION_TRIPLE_CTRL_PALETTE": "true to enable showing the visual command overlay on pressing Ctrl/Cmd key 3 consecutive times",
     "DESCRIPTION_SMART_INDENT": "Automatically indent when creating a new block",
     "DESCRIPTION_SOFT_TABS": "false to turn off soft tabs behavior",
     "DESCRIPTION_SORT_DIRECTORIES_FIRST": "true to sort the directories first in the project tree",


### PR DESCRIPTION
Address: https://www.reddit.com/r/brackets/comments/1eam4vq/comment/leymxt4/?context=3

* Changed triple key detect algorithm to be more robust to prevent accidental engagement of the visual command palette ui
* Also added preference `tripleCtrlPalette`: `true/false` to enable/disable feature