### PR TITLE
fix: zoom editor fonts only and live preview switch issues

### DIFF
--- a/src/LiveDevelopment/MultiBrowserImpl/protocol/LiveDevProtocol.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/protocol/LiveDevProtocol.js
@@ -180,7 +180,7 @@ define(function (require, exports, module) {
             // the active editor takes the priority in the workflow. If a css related file is active,
             // then we dont need to open the html live doc. For less files, we dont check if its related as
             // its not directly linked usually and needs a compile step. so we just do a fuzzy search.
-            activeEditor.focus();
+            _focusEditorIfNeeded(activeEditor, nodeName, contentEditable);
             _searchAndCursorIfCSS(activeEditor, allSelectors, nodeName);
             // in this case, see if we need to do any css reverse highlight magic here
         } else if(openLiveDocEditor) {

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -2131,7 +2131,7 @@ define(function (require, exports, module) {
                 if(nodeTerminateDueToShutdown){
                     return; // normal shutdown
                 }
-                Metrics.countEvent(Metrics.EVENT_TYPE.NODEJS, 'crash', "dlgShown");
+                Metrics.countEvent(Metrics.EVENT_TYPE.NODEJS, 'crash', Phoenix.platform);
                 window.fs.forceUseNodeWSEndpoint(false);
                 Dialogs
                     .showErrorDialog(Strings.ERROR_NODE_JS_CRASH_TITLE, Strings.ERROR_NODE_JS_CRASH_MESSAGE)

--- a/src/view/fontrules/font-based-rules.less
+++ b/src/view/fontrules/font-based-rules.less
@@ -22,8 +22,6 @@
 @defaultmenuwidth: 300px/@defaultfontsize;
 
 @lineheight: @fontsize +  @fontsize * @lineheightoffset;
-@menuFontSize: @fontsize + 2;
-@titleFontSize: @fontsize + 6;
 
 .CodeMirror {
     font-size: @fontsize !important;
@@ -32,23 +30,6 @@
 .codehint-menu .dropdown-menu li a, .inlinemenu-menu .dropdown-menu li a{
     font-size: @fontsize !important;
     line-height: @lineheight  !important;
-}
-
-.modal-bar{
-    font-size: @menuFontSize !important;
-}
-
-.context-menu .dropdown-menu li a , .toolbar .nav .dropdown-menu li a{
-    font-size: @menuFontSize !important;
-    line-height: @lineheight  !important;
-}
-
-.toolbar .title  {
-    font-size: @titleFontSize !important;
-}
-
-#titlebar {
-    font-size: @menuFontSize !important;
 }
 
 span.brackets-js-hints-with-type-details {


### PR DESCRIPTION
### Zoom Fonts should only zoom the editor font and nothing else
  This was the basic behavior in brackets. But to implement system wide zoom, phoenix first extended the font zoom logic to menus and other items to virtually zoom without access to zoom apis in tauri. We eventually added native zoom capability to tauri laye. But the font zoom to every ui elkemt was not reverted after we were able to implement system wide zoom. So now that we have system wide zoom, restoring the editor zoom capability.

 Fixes: https://github.com/orgs/phcode-dev/discussions/1798