### PR TITLE
fix: live preview UX where clicking on lp will open html when editing unrelated ts/json/js file

### DIFF
--- a/src/LiveDevelopment/MultiBrowserImpl/protocol/LiveDevProtocol.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/protocol/LiveDevProtocol.js
@@ -163,8 +163,7 @@ define(function (require, exports, module) {
             activeEditor && activeEditor.focus(); // restore focus from live preview
             return;
         }
-        const openFullEditors = MainViewManager.findInOpenPane(liveDocPath);
-        const openLiveDocEditor = openFullEditors.length ? openFullEditors[0].editor : null;
+        const allOpenFileCount = MainViewManager.getWorkingSetSize(MainViewManager.ALL_PANES);
         function selectInHTMLEditor(fullHtmlEditor) {
             const position = HTMLInstrumentation.getPositionFromTagId(fullHtmlEditor, parseInt(tagId, 10));
             if(position && fullHtmlEditor) {
@@ -183,19 +182,10 @@ define(function (require, exports, module) {
             _focusEditorIfNeeded(activeEditor, nodeName, contentEditable);
             _searchAndCursorIfCSS(activeEditor, allSelectors, nodeName);
             // in this case, see if we need to do any css reverse highlight magic here
-        } else if(openLiveDocEditor) {
-            // If we are on multi pane mode, the html doc was open in an inactive unfocused editor.
-            selectInHTMLEditor(openLiveDocEditor);
-        } else {
-            // no open editor for the live doc in panes, check if there is one in the working set.
-            const foundInWorkingSetPane = MainViewManager.findInAllWorkingSets(liveDocPath);
-            const paneToUse = foundInWorkingSetPane.length ?
-                foundInWorkingSetPane[0].paneId:
-                MainViewManager.ACTIVE_PANE; // if pane id is active pane, then the file is not open in working set
-            const viewToUse = (paneToUse === MainViewManager.ACTIVE_PANE) ?
-                FileViewController.PROJECT_MANAGER:
-                FileViewController.WORKING_SET_VIEW;
-            FileViewController.openAndSelectDocument(liveDocPath, viewToUse, paneToUse)
+        } else if(!allOpenFileCount){
+            // no open editor in any panes, then open the html file directly.
+            FileViewController.openAndSelectDocument(liveDocPath,
+                FileViewController.WORKING_SET_VIEW, MainViewManager.ACTIVE_PANE)
                 .done(()=>{
                     selectInHTMLEditor(EditorManager.getActiveEditor());
                 });

--- a/test/spec/LiveDevelopmentMultiBrowser-test.js
+++ b/test/spec/LiveDevelopmentMultiBrowser-test.js
@@ -1431,38 +1431,6 @@ define(function (require, exports, module) {
             await endPreviewSession();
         }, 30000);
 
-        it("should open html in correct pane on clicking live preview in split pane", async function () {
-            MainViewManager.setLayoutScheme(1, 2);
-            MainViewManager.setActivePaneId(MainViewManager.FIRST_PANE);
-            await awaitsForDone(SpecRunnerUtils.openProjectFiles(["cssLivePreview.html"], MainViewManager.FIRST_PANE),
-                "SpecRunnerUtils.openProjectFiles cssLivePreview.html");
-
-            await waitsForLiveDevelopmentToOpen();
-
-            await awaitsForDone(SpecRunnerUtils.openProjectFiles(["simple1.css"], MainViewManager.SECOND_PANE),
-                "SpecRunnerUtils.openProjectFiles simple1.css"); // non related file
-            await awaitsForDone(SpecRunnerUtils.openProjectFiles(["blank.css"], MainViewManager.FIRST_PANE),
-                "SpecRunnerUtils.openProjectFiles blank.css");  // non related file
-
-            // now the live preview page's editor is not visible in any panes, but is already open in first pane
-            // so, on clicking live preview, it should open the file in first pane
-            MainViewManager.setActivePaneId(MainViewManager.SECOND_PANE);
-
-            await forRemoteExec(`document.getElementById("testId2").click()`);
-            let editor = EditorManager.getActiveEditor();
-            await awaitsFor(()=>{
-                editor = EditorManager.getActiveEditor();
-                return editor && editor.document.file.name === "cssLivePreview.html";
-            }, "cssLivePreview.html to open as active editor");
-            await _forSelection("#testId", editor, { line: 13, ch: 4, sticky: null });
-            editor = EditorManager.getActiveEditor();
-            expect(editor.document.file.name).toBe("cssLivePreview.html");
-            expect(MainViewManager.getActivePaneId()).toBe(MainViewManager.FIRST_PANE);
-
-            MainViewManager.setLayoutScheme(1, 1);
-            await endPreviewSession();
-        }, 30000);
-
         it("should reverse highlight open previewed html file if not open on clicking live preview", async function () {
             await awaitsForDone(SpecRunnerUtils.openProjectFiles(["simple1.html"]),
                 "SpecRunnerUtils.openProjectFiles simple1.html");


### PR DESCRIPTION
### Context and Problem
 Currently, when live previewing an HTML file (e.g., a.html) and switching to an unrelated file (e.g., a.json or a TypeScript file generated by a build step), clicking on the live preview unexpectedly switches the editor back to the main HTML file. This behavior disrupts the user’s workflow, especially when working on files indirectly related to the HTML being previewed. Users might find themselves forcibly navigated away from the task at hand, leading to potential confusion and inefficiency.

The behavior was initially added to phoenix to help new users navigate better, but is not hindering more advanced workflows that needs more user context. So we are reverting this change.

### This change
 This pull request introduces a change to maintain workflow continuity:

1. **Preserve Current Editor State:** If a user is working on an unrelated file and clicks on the live preview, the editor will no longer switch back to the main HTML file automatically.
1. **Explicit Navigation Option:** To view or edit the main HTML file in the context of live preview, users can now explicitly click on the title bar of the live preview pane. This action will open the associated HTML file, providing a deliberate choice to switch contexts without disrupting the current workflow. ![image](https://github.com/user-attachments/assets/a81ef1a6-5eed-4636-8bb7-eb5d0cb8d262)
