### PR TITLE
feat: auto tab spacing detection

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -249,6 +249,7 @@ define(function (require, exports, module) {
             DocumentModule: require("document/Document"),
             DragAndDrop: require("utils/DragAndDrop"),
             EditorManager: require("editor/EditorManager"),
+            Editor: require("editor/Editor"),
             EventManager: require("utils/EventManager"),
             ExtensionLoader: require("utils/ExtensionLoader"),
             ExtensionUtils: require("utils/ExtensionUtils"),

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -2932,10 +2932,6 @@ define(function (require, exports, module) {
             });
         });
     });
-    
-    function f() {
-        
-    }
 
     // Define public API
     exports.Editor                  = Editor;

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -2597,6 +2597,9 @@ define(function (require, exports, module) {
             computedValues.useTabChar = value;
             // persist explicitly user set values to storage
             tabSpacesStateManager.set(fullPath, computedValues);
+            Editor.forEveryEditor(editor=>{
+                editor._updateOption(USE_TAB_CHAR);
+            }, fullPath);
             return true;
         }
         var options = fullPath && {context: fullPath};
@@ -2630,6 +2633,9 @@ define(function (require, exports, module) {
                 computedValues.tabSize = value;
                 // persist explicitly user set values to storage
                 tabSpacesStateManager.set(fullPath, computedValues);
+                Editor.forEveryEditor(editor=>{
+                    editor._updateOption(TAB_SIZE);
+                }, fullPath);
             }
             return true;
         }
@@ -2722,6 +2728,9 @@ define(function (require, exports, module) {
                 computedValues.spaceUnits = value;
                 // persist explicitly user set values to storage
                 tabSpacesStateManager.set(fullPath, computedValues);
+                Editor.forEveryEditor(editor=>{
+                    editor._updateOption(SPACE_UNITS);
+                }, fullPath);
             }
             return true;
         }
@@ -2847,11 +2856,19 @@ define(function (require, exports, module) {
     };
 
     /**
-     * Runs callback for every Editor instance that currently exists
+     * Runs callback for every Editor instance that currently exists or only the editors matching the given fullPath.
      * @param {!function(!Editor)} callback
+     * @param {string} [fullPath] an optional second argument, if given will only callback for all editors
+     *  that is editing the file for the given fullPath
      */
-    Editor.forEveryEditor = function (callback) {
-        _instances.forEach(callback);
+    Editor.forEveryEditor = function (callback, fullPath) {
+        _instances.forEach(function (editor) {
+            if(!fullPath) {
+                callback(editor);
+            } else if(editor.document.file.fullPath === fullPath) {
+                callback(editor);
+            }
+        });
     };
 
     /**

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -2621,7 +2621,8 @@ define(function (require, exports, module) {
     };
 
     let computedTabSpaces = new Map();
-    Editor._autoDetectTabSpaces = function (editor) {
+    const MAX_LINES_TO_SCAN_FOR_INDENT = 700; // this is high to account for any js docs/ file comments
+    Editor._autoDetectTabSpaces = function (editor, scanFullFile) {
         if(!editor){
             return;
         }
@@ -2633,8 +2634,8 @@ define(function (require, exports, module) {
             editor._updateOption(AUTO_TAB_SPACES);
             return;
         }
-        const text = editor.document.getText();
-        const detectedVals = IndentHelper.detectIndent(text);
+        // we only scan the first 200 lines of text to determine the spaces.
+        const detectedVals = editor._detectIndent(scanFullFile? undefined : MAX_LINES_TO_SCAN_FOR_INDENT);
         const useTabChar = (detectedVals.type === "tab");
         let amount = detectedVals.amount;
         if(!detectedVals.type || !amount){

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -2579,6 +2579,11 @@ define(function (require, exports, module) {
      * @return {boolean} true if value was valid
      */
     Editor.setUseTabChar = function (value, fullPath) {
+        let computedValues = computedTabSpaces.get(fullPath);
+        if(Editor.getAutoTabSpaces(fullPath) && computedValues) {
+            computedValues.useTabChar = value;
+            return true;
+        }
         var options = fullPath && {context: fullPath};
         return PreferencesManager.set(USE_TAB_CHAR, value, options);
     };
@@ -2604,6 +2609,13 @@ define(function (require, exports, module) {
      * @return {boolean} true if value was valid
      */
     Editor.setTabSize = function (value, fullPath) {
+        let computedValues = computedTabSpaces.get(fullPath);
+        if(Editor.getAutoTabSpaces(fullPath) && computedValues) {
+            if(EditorPreferences.isValidTabSize(value)){
+                computedValues.tabSize = value;
+            }
+            return true;
+        }
         var options = fullPath && {context: fullPath};
         return PreferencesManager.set(TAB_SIZE, value, options);
     };
@@ -2687,6 +2699,13 @@ define(function (require, exports, module) {
      * @return {boolean} true if value was valid
      */
     Editor.setSpaceUnits = function (value, fullPath) {
+        let computedValues = computedTabSpaces.get(fullPath);
+        if(Editor.getAutoTabSpaces(fullPath) && computedValues) {
+            if(EditorPreferences.isValidSpaceUnit(value)){
+                computedValues.spaceUnits = value;
+            }
+            return true;
+        }
         var options = fullPath && {context: fullPath};
         return PreferencesManager.set(SPACE_UNITS, value, options);
     };

--- a/src/editor/EditorHelper/EditorPreferences.js
+++ b/src/editor/EditorHelper/EditorPreferences.js
@@ -166,6 +166,14 @@ define(function (require, exports, module) {
         description: Strings.DESCRIPTION_INPUT_STYLE
     });
 
+    function isValidTabSize (size) {
+        return ValidationUtils.isIntegerInRange(size, MIN_TAB_SIZE, MAX_TAB_SIZE);
+    }
+
+    function isValidSpaceUnit (size) {
+        return ValidationUtils.isIntegerInRange(size, MIN_SPACE_UNITS, MAX_SPACE_UNITS);
+    }
+
     function init(cmOptions) {
         // Mappings from Brackets preferences to CodeMirror options
         cmOptions[CLOSE_BRACKETS]     = "autoCloseBrackets";
@@ -218,4 +226,6 @@ define(function (require, exports, module) {
     exports.CODE_FOLDING_GUTTER_PRIORITY    = CODE_FOLDING_GUTTER_PRIORITY;
 
     exports.init =init;
+    exports.isValidTabSize = isValidTabSize;
+    exports.isValidSpaceUnit = isValidSpaceUnit;
 });

--- a/src/editor/EditorHelper/EditorPreferences.js
+++ b/src/editor/EditorHelper/EditorPreferences.js
@@ -43,6 +43,7 @@ define(function (require, exports, module) {
         SPACE_UNITS         = "spaceUnits",
         STYLE_ACTIVE_LINE   = "styleActiveLine",
         TAB_SIZE            = "tabSize",
+        AUTO_TAB_SPACES     = "autoTabSpaces",
         UPPERCASE_COLORS    = "uppercaseColors",
         USE_TAB_CHAR        = "useTabChar",
         WORD_WRAP           = "wordWrap",
@@ -141,6 +142,9 @@ define(function (require, exports, module) {
         validator: _.partialRight(ValidationUtils.isIntegerInRange, MIN_TAB_SIZE, MAX_TAB_SIZE),
         description: Strings.DESCRIPTION_TAB_SIZE
     });
+    PreferencesManager.definePreference(AUTO_TAB_SPACES,    "boolean", true, {
+        description: Strings.DESCRIPTION_AUTO_TAB_SPACE
+    });
     PreferencesManager.definePreference(UPPERCASE_COLORS,   "boolean", false, {
         description: Strings.DESCRIPTION_UPPERCASE_COLORS
     });
@@ -194,6 +198,7 @@ define(function (require, exports, module) {
     exports.SPACE_UNITS         = SPACE_UNITS;
     exports.STYLE_ACTIVE_LINE   = STYLE_ACTIVE_LINE;
     exports.TAB_SIZE            = TAB_SIZE;
+    exports.AUTO_TAB_SPACES     = AUTO_TAB_SPACES;
     exports.UPPERCASE_COLORS    = UPPERCASE_COLORS;
     exports.USE_TAB_CHAR        = USE_TAB_CHAR;
     exports.WORD_WRAP           = WORD_WRAP;

--- a/src/editor/EditorHelper/IndentHelper.js
+++ b/src/editor/EditorHelper/IndentHelper.js
@@ -32,6 +32,175 @@ define(function (require, exports, module) {
 
     const SOFT_TABS = EditorPreferences.SOFT_TABS;
 
+    /*Start of modified code: https://www.npmjs.com/package/detect-indent
+    * We modified the code to specify `scanLineLimit` for partial scans in a large text*/
+    // Detect either spaces or tabs but not both to properly handle tabs for indentation and spaces for alignment
+    const INDENT_REGEX = /^(?:( )+|\t+)/;
+
+    const INDENT_TYPE_SPACE = 'space';
+    const INDENT_TYPE_TAB = 'tab';
+
+    /**
+     Make a Map that counts how many indents/unindents have occurred for a given size and how many lines follow a given indentation.
+
+     The key is a concatenation of the indentation type (s = space and t = tab) and the size of the indents/unindents.
+
+     ```
+     indents = {
+     t3: [1, 0],
+     t4: [1, 5],
+     s5: [1, 0],
+     s12: [1, 0],
+     }
+     ```
+     */
+    function makeIndentsMap(string, ignoreSingleSpaces, scanLineLimit) {
+        const indents = new Map();
+
+        // Remember the size of previous line's indentation
+        let previousSize = 0;
+        let previousIndentType;
+
+        // Indents key (ident type + size of the indents/unindents)
+        let key;
+
+        for (const line of string.split(/\n/g, scanLineLimit)) {
+            if (!line) {
+                // Ignore empty lines
+                continue;
+            }
+
+            let indent;
+            let indentType;
+            let use;
+            let weight;
+            let entry;
+            const matches = line.match(INDENT_REGEX);
+
+            if (matches === null) {
+                previousSize = 0;
+                previousIndentType = '';
+            } else {
+                indent = matches[0].length;
+                indentType = matches[1] ? INDENT_TYPE_SPACE : INDENT_TYPE_TAB;
+
+                // Ignore single space unless it's the only indent detected to prevent common false positives
+                if (ignoreSingleSpaces && indentType === INDENT_TYPE_SPACE && indent === 1) {
+                    continue;
+                }
+
+                if (indentType !== previousIndentType) {
+                    previousSize = 0;
+                }
+
+                previousIndentType = indentType;
+
+                use = 1;
+                weight = 0;
+
+                const indentDifference = indent - previousSize;
+                previousSize = indent;
+
+                // Previous line have same indent?
+                if (indentDifference === 0) {
+                    // Not a new "use" of the current indent:
+                    use = 0;
+                    // But do add a bit to it for breaking ties:
+                    weight = 1;
+                    // We use the key from previous loop
+                } else {
+                    const absoluteIndentDifference = indentDifference > 0 ? indentDifference : -indentDifference;
+                    key = encodeIndentsKey(indentType, absoluteIndentDifference);
+                }
+
+                // Update the stats
+                entry = indents.get(key);
+                entry = entry === undefined ? [1, 0] : [entry[0] + use, entry[1] + weight];
+
+                indents.set(key, entry);
+            }
+        }
+
+        return indents;
+    }
+
+    // Encode the indent type and amount as a string (e.g. 's4') for use as a compound key in the indents Map.
+    function encodeIndentsKey(indentType, indentAmount) {
+        const typeCharacter = indentType === INDENT_TYPE_SPACE ? 's' : 't';
+        return typeCharacter + String(indentAmount);
+    }
+
+    // Extract the indent type and amount from a key of the indents Map.
+    function decodeIndentsKey(indentsKey) {
+        const keyHasTypeSpace = indentsKey[0] === 's';
+        const type = keyHasTypeSpace ? INDENT_TYPE_SPACE : INDENT_TYPE_TAB;
+
+        const amount = Number(indentsKey.slice(1));
+
+        return {type, amount};
+    }
+
+    // Return the key (e.g. 's4') from the indents Map that represents the most common indent,
+    // or return undefined if there are no indents.
+    function getMostUsedKey(indents) {
+        let result;
+        let maxUsed = 0;
+        let maxWeight = 0;
+
+        for (const [key, [usedCount, weight]] of indents) {
+            if (usedCount > maxUsed || (usedCount === maxUsed && weight > maxWeight)) {
+                maxUsed = usedCount;
+                maxWeight = weight;
+                result = key;
+            }
+        }
+
+        return result;
+    }
+
+    function makeIndentString(type, amount) {
+        const indentCharacter = type === INDENT_TYPE_SPACE ? ' ' : '\t';
+        return indentCharacter.repeat(amount);
+    }
+
+    /**
+     * computes the tab/spaces config for the file
+     * @param string the text to determine the indent config
+     * @param scanLineLimit - the number of lines to scan. This can be used if you dont want to scan
+     *   full text for large texts
+     * @returns {{amount: number, indent: string, type: (string)}}
+     */
+    function detectIndent(string, scanLineLimit) {
+        if (typeof string !== 'string') {
+            throw new TypeError('Expected a string');
+        }
+
+        // Identify indents while skipping single space indents to avoid common edge cases (e.g. code comments)
+        // If no indents are identified, run again and include all indents for comprehensive detection
+        let indents = makeIndentsMap(string, true, scanLineLimit);
+        if (indents.size === 0) {
+            indents = makeIndentsMap(string, false, scanLineLimit);
+        }
+
+        const keyOfMostUsedIndent = getMostUsedKey(indents);
+
+        let type;
+        let amount = 0;
+        let indent = '';
+
+        if (keyOfMostUsedIndent !== undefined) {
+            ({type, amount} = decodeIndentsKey(keyOfMostUsedIndent));
+            indent = makeIndentString(type, amount);
+        }
+
+        return {
+            amount,
+            type,
+            indent
+        };
+    }
+    /*End of copied code: https://www.npmjs.com/package/detect-indent*/
+
     /**
      * Helper function for `_handleTabKey()` (case 2) - see comment in that function.
      * @param {Array.<{start:{line:number, ch:number}, end:{line:number, ch:number}, reversed:boolean, primary:boolean}>} selections
@@ -250,4 +419,5 @@ define(function (require, exports, module) {
     }
 
     exports.addHelpers =addHelpers;
+    exports.detectIndent =detectIndent;
 });

--- a/src/editor/EditorStatusBar.js
+++ b/src/editor/EditorStatusBar.js
@@ -60,6 +60,7 @@ define(function (require, exports, module) {
         $cursorInfo,
         $fileInfo,
         $indentType,
+        $indentAuto,
         $indentWidthLabel,
         $indentWidthInput,
         $statusOverwrite;
@@ -125,6 +126,11 @@ define(function (require, exports, module) {
         $indentWidthLabel.attr("title", indentWithTabs ? Strings.STATUSBAR_INDENT_SIZE_TOOLTIP_TABS : Strings.STATUSBAR_INDENT_SIZE_TOOLTIP_SPACES);
     }
 
+    function _updateAutoIndent(fullPath) {
+        const autoIndent = Editor.getAutoTabSpaces(fullPath);
+        $indentAuto.html(autoIndent ? Strings.STATUSBAR_AUTO_INDENT : Strings.STATUSBAR_FIXED_INDENT);
+    }
+
     /**
      * Get indent size based on type
      * @param {string} fullPath Path to file in current editor
@@ -153,6 +159,20 @@ define(function (require, exports, module) {
 
         Editor.setUseTabChar(!Editor.getUseTabChar(fullPath), fullPath);
         _updateIndentType(fullPath);
+        _updateAutoIndent(fullPath);
+        _updateIndentSize(fullPath);
+    }
+
+    function _toggleAutoIndent() {
+        const current = EditorManager.getActiveEditor(),
+            fullPath = current && current.document.file.fullPath;
+        Editor.setAutoTabSpaces(!Editor.getAutoTabSpaces(fullPath), fullPath);
+        if(Editor.getAutoTabSpaces(fullPath)){
+            // if the user explicitly clicked on the auto indent status bar icon, he might mean to recompute it
+            Editor._autoDetectTabSpaces(current, true, true);
+        }
+        _updateIndentType(fullPath);
+        _updateAutoIndent(fullPath);
         _updateIndentSize(fullPath);
     }
 
@@ -294,6 +314,7 @@ define(function (require, exports, module) {
             current.on("cursorActivity.statusbar", _updateCursorInfo);
             current.on("optionChange.statusbar", function () {
                 _updateIndentType(fullPath);
+                _updateAutoIndent(fullPath);
                 _updateIndentSize(fullPath);
             });
             current.on("change.statusbar", function () {
@@ -313,6 +334,7 @@ define(function (require, exports, module) {
             _updateFileInfo(current);
             _initOverwriteMode(current);
             _updateIndentType(fullPath);
+            _updateAutoIndent(fullPath);
             _updateIndentSize(fullPath);
         }
     }
@@ -372,6 +394,7 @@ define(function (require, exports, module) {
         $cursorInfo         = $("#status-cursor");
         $fileInfo           = $("#status-file");
         $indentType         = $("#indent-type");
+        $indentAuto         = $("#indent-auto");
         $indentWidthLabel   = $("#indent-width-label");
         $indentWidthInput   = $("#indent-width-input");
         $statusOverwrite    = $("#status-overwrite");
@@ -461,6 +484,7 @@ define(function (require, exports, module) {
 
         // indentation event handlers
         $indentType.on("click", _toggleIndentType);
+        $indentAuto.on("click", _toggleAutoIndent);
         $indentWidthLabel
             .on("click", function () {
                 // update the input value before displaying

--- a/src/editor/EditorStatusBar.js
+++ b/src/editor/EditorStatusBar.js
@@ -287,7 +287,8 @@ define(function (require, exports, module) {
         if (!current) {
             StatusBar.hideAllPanes();
         } else {
-            var fullPath = current.document.file.fullPath;
+            Editor._autoDetectTabSpaces(current);
+            const fullPath = current.document.file.fullPath;
             StatusBar.showAllPanes();
 
             current.on("cursorActivity.statusbar", _updateCursorInfo);

--- a/src/extensions/default/DebugCommands/MacroRunner.js
+++ b/src/extensions/default/DebugCommands/MacroRunner.js
@@ -50,6 +50,8 @@ define(function (require, exports, module) {
         KeyEvent = brackets.getModule("utils/KeyEvent"),
         Commands = brackets.getModule("command/Commands"),
         PreferencesManager  = brackets.getModule("preferences/PreferencesManager"),
+        Editor = brackets.getModule("editor/Editor"),
+        _ = brackets.getModule("thirdparty/lodash"),
         ProjectManager = brackets.getModule("project/ProjectManager");
 
     /**
@@ -304,6 +306,12 @@ define(function (require, exports, module) {
         }
     }
 
+    function validateEqual(obj1, obj2) {
+        if(!_.isEqual(obj1, obj2)){
+            throw new Error(`validateEqual: expected ${JSON.stringify(obj1)} to equal ${JSON.stringify(obj2)}`);
+        }
+    }
+
     /**
      * validates if the given mark type is present in the specified selections
      * @param {string} markType
@@ -355,9 +363,29 @@ define(function (require, exports, module) {
         return PreferencesManager.get(key);
     }
 
+    const EDITING = {
+        setEditorSpacing: function (useTabs, spaceOrTabCount, isAutoMode) {
+            const activeEditor = EditorManager.getActiveEditor();
+            if(!activeEditor){
+                throw new Error(`No active editor found to setEditorSpacing`);
+            }
+            const fullPath = activeEditor.document.file.fullPath;
+            if(Editor.Editor.getAutoTabSpaces(fullPath) !== isAutoMode){
+                Editor.Editor.setAutoTabSpaces(isAutoMode, fullPath);
+                isAutoMode && Editor.Editor._autoDetectTabSpaces(activeEditor, true, true);
+            }
+            Editor.Editor.setUseTabChar(useTabs);
+            if(useTabs) {
+                Editor.Editor.setTabSize(spaceOrTabCount);
+            } else {
+                Editor.Editor.setSpaceUnits(spaceOrTabCount);
+            }
+        }
+    };
+
     const __PR= {
         openFile, setCursors, expectCursorsToBe, keydown, typeAtCursor, validateText, validateAllMarks, validateMarks,
-        closeFile, closeAll, undo, redo, setPreference, getPreference
+        closeFile, closeAll, undo, redo, setPreference, getPreference, validateEqual, EDITING
     };
 
     async function runMacro(macroText) {

--- a/src/extensions/default/DebugCommands/MacroRunner.js
+++ b/src/extensions/default/DebugCommands/MacroRunner.js
@@ -374,11 +374,11 @@ define(function (require, exports, module) {
                 Editor.Editor.setAutoTabSpaces(isAutoMode, fullPath);
                 isAutoMode && Editor.Editor._autoDetectTabSpaces(activeEditor, true, true);
             }
-            Editor.Editor.setUseTabChar(useTabs);
+            Editor.Editor.setUseTabChar(useTabs, fullPath);
             if(useTabs) {
-                Editor.Editor.setTabSize(spaceOrTabCount);
+                Editor.Editor.setTabSize(spaceOrTabCount, fullPath);
             } else {
-                Editor.Editor.setSpaceUnits(spaceOrTabCount);
+                Editor.Editor.setSpaceUnits(spaceOrTabCount, fullPath);
             }
         }
     };

--- a/src/extensions/default/Phoenix-prettier/main.js
+++ b/src/extensions/default/Phoenix-prettier/main.js
@@ -232,7 +232,7 @@ define(function (require, exports, module) {
             options._usePlugin = parsersForLanguage[languageId];
             Object.assign(options, {
                 parser: parsersForLanguage[languageId],
-                tabWidth: indentWithTabs ? Editor.getTabSize() : Editor.getSpaceUnits(),
+                tabWidth: indentWithTabs ? Editor.getTabSize(filepath) : Editor.getSpaceUnits(filepath),
                 useTabs: indentWithTabs,
                 filepath: filepath,
                 printWidth: printWidth,

--- a/src/extensions/default/Phoenix-prettier/unittests.js
+++ b/src/extensions/default/Phoenix-prettier/unittests.js
@@ -19,7 +19,7 @@
  *
  */
 
-/*global describe, it, expect, beforeEach, afterEach, awaitsForDone*/
+/*global describe, it, expect, afterAll, afterEach, beforeAll*/
 
 define(function (require, exports, module) {
 
@@ -36,6 +36,7 @@ define(function (require, exports, module) {
 
     const jsFile = require("text!../../../../test/spec/prettier-test-files/js/test.js"),
         jsPrettyFile = require("text!../../../../test/spec/prettier-test-files/js/test-pretty.js"),
+        jsPrettyFile8Indent = require("text!../../../../test/spec/prettier-test-files/js/test-pretty-8-indent.js"),
         jsPrettyRulerFile = require("text!../../../../test/spec/prettier-test-files/js/test-pretty-ruler.js"),
         jsPrettySelection = require("text!../../../../test/spec/prettier-test-files/js/test-pretty-selection.js"),
         jsPrettySelectionOffset = require("text!../../../../test/spec/prettier-test-files/js/test-pretty-selection-offset.js"),
@@ -63,6 +64,13 @@ define(function (require, exports, module) {
     describe("integration: Phoenix Prettier", function () {
         let testEditor, testDocument;
 
+        beforeAll(async ()=>{
+            Editor.setAutoTabSpaces(false);
+        });
+        afterAll(()=>{
+            Editor.setAutoTabSpaces(true);
+        });
+
         function createMockEditor(text, language, filename) {
             let mock = SpecRunnerUtils.createMockEditor(text, language, undefined,
                 {filename: filename});
@@ -73,6 +81,7 @@ define(function (require, exports, module) {
         describe("JS Beautify", function (){
             afterEach(async function () {
                 SpecRunnerUtils.destroyMockEditor(testDocument);
+                Editor.setAutoTabSpaces(false);
                 Editor.setUseTabChar(false);
                 Editor.setSpaceUnits(4);
             });
@@ -81,6 +90,13 @@ define(function (require, exports, module) {
                 createMockEditor(jsFile, "javascript", "/test.js");
                 await BeautificationManager.beautifyEditor(testEditor);
                 expect(testEditor.document.getText(true)).toBe(jsPrettyFile);
+            });
+
+            it("should beautify editor for js with auto detected spacing", async function () {
+                Editor.setAutoTabSpaces(true);
+                createMockEditor(jsFile, "javascript", "/test.js");
+                await BeautificationManager.beautifyEditor(testEditor);
+                expect(testEditor.document.getText(true)).toBe(jsPrettyFile8Indent);
             });
 
             it("should use line max length from editor rulers by default", async function () {

--- a/src/index.html
+++ b/src/index.html
@@ -855,6 +855,7 @@
                     <div id="indent-type"></div>
                     <div id="indent-width-label"></div>
                     <input id="indent-width-input" type="number" min="1" max="10" maxlength="2" size="2" class="hidden">
+                    <div id="indent-auto"></div>
                 </div>
                 <div id="status-language"></div>
                 <div id="status-encoding"></div>

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -1028,6 +1028,7 @@ define({
     "DESCRIPTION_STYLE_ACTIVE_LINE": "true to highlight background color of the line the cursor is on",
     "DESCRIPTION_TAB_SIZE": "Number of spaces to display for tabs",
     "DESCRIPTION_USE_TAB_CHAR": "true to use tabs instead of spaces",
+    "DESCRIPTION_AUTO_TAB_SPACE": "true to auto detect tabs and spaces used in current file",
     "DESCRIPTION_UPPERCASE_COLORS": "true to generate uppercase hex colors in Inline Color Editor",
     "DESCRIPTION_WORD_WRAP": "Wrap lines that exceed the viewport width",
     "DESCRIPTION_SEARCH_AUTOHIDE": "Close the search as soon as the editor is focused",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -399,6 +399,8 @@ define({
     "STATUSBAR_INDENT_SIZE_TOOLTIP_TABS": "Click to change tab character width",
     "STATUSBAR_SPACES": "Spaces:",
     "STATUSBAR_TAB_SIZE": "Tab Size:",
+    "STATUSBAR_AUTO_INDENT": "<span title='Click to switch to fixed indents. Currently set to automatically detect and apply indents based on current file.'>Auto</span>",
+    "STATUSBAR_FIXED_INDENT": "<span title='Click to switch to Auto indent detection. Currently set to Fixed indent.'>Fixed</span>",
     "STATUSBAR_LINE_COUNT_SINGULAR": "\u2014 {0} Line",
     "STATUSBAR_LINE_COUNT_PLURAL": "\u2014 {0} Lines",
     "STATUSBAR_USER_EXTENSIONS_DISABLED": "Extensions Disabled",

--- a/src/preferences/PreferencesImpl.js
+++ b/src/preferences/PreferencesImpl.js
@@ -85,7 +85,6 @@ define(function (require, exports, module) {
     var userScopeLoading = manager.addScope("user", userScope);
 
     _addScopePromises.push(userScopeLoading);
-    _addScopePromises.push(StateManager._migrateLegacyStateFile());
 
     // Set up the .phcode.json file handling
     userScopeLoading

--- a/src/preferences/PreferencesImpl.js
+++ b/src/preferences/PreferencesImpl.js
@@ -30,7 +30,6 @@ define(function (require, exports, module) {
 
     const PreferencesBase = require("./PreferencesBase"),
         Async           = require("utils/Async"),
-        StateManager            = require("preferences/StateManager"),
 
         // The SETTINGS_FILENAME is used with a preceding "." within user projects
         SETTINGS_FILENAME = "phcode.json",

--- a/src/preferences/StateManager.js
+++ b/src/preferences/StateManager.js
@@ -29,11 +29,7 @@
 define(function (require, exports, module) {
     const _ = require("thirdparty/lodash"),
         EventDispatcher = require("utils/EventDispatcher"),
-        Metrics = require("utils/Metrics"),
         ProjectManager = require("project/ProjectManager");
-
-    const LEGACY_STATE_MANAGER_MIGRATED = "ph_state_manager_migrated";
-    const LEGACY_STATE_FILE_PATH = "/fs/app/state.json";
 
     const PROJECT_CONTEXT = "project";
     const GLOBAL_CONTEXT = "global";
@@ -239,62 +235,6 @@ define(function (require, exports, module) {
         console.warn("StateManager.getPrefixedSystem() is deprecated. Use StateManager.createExtensionStateManager()");
         return createExtensionStateManager(prefix);
     }
-
-    /**
-     * We used file based state.json in the earlier state manager impl. no  we moved to phstore. So we have to move
-     * earlier users to phstore to prevent losing their files. This code can be deleted anytime after 4 months
-     * from this commit.
-     * @private
-     */
-    function _migrateLegacyStateFile() {
-        if(Phoenix.isTestWindow || getVal(LEGACY_STATE_MANAGER_MIGRATED)){
-            return new $.Deferred().resolve().promise();
-        }
-        const _migrated = new $.Deferred();
-        console.log("Migrating legacy state file", LEGACY_STATE_FILE_PATH);
-        fs.readFile(LEGACY_STATE_FILE_PATH, "utf8", function (err, data) {
-            setVal(LEGACY_STATE_MANAGER_MIGRATED, true);
-            if (err) {
-                // if error, ignore and continue. state file not found(unlikely to be here)
-                _migrated.resolve();
-                return;
-            }
-            try{
-                const keysToMigrate = [
-                    "afterFirstLaunch",
-                    "sidebar",
-                    "workingSetSortMethod",
-                    "healthDataUsage",
-                    "main-toolbar",
-                    "recentProjects",
-                    "healthDataNotificationShown",
-                    "searchHistory",
-                    "problems-panel"
-                ];
-                const oldState = JSON.parse(data);
-                for(let key of keysToMigrate) {
-                    if(oldState[key]){
-                        console.log("Migrated Legacy state: ", key, oldState[key]);
-                        setVal(key, oldState[key]);
-                    }
-                }
-                fs.unlink(LEGACY_STATE_FILE_PATH, (unlinkErr)=>{
-                    if(unlinkErr){
-                        console.error(`Error deleting legacy state file ${LEGACY_STATE_FILE_PATH}`, unlinkErr);
-                    }
-                });
-            } catch (e) {
-                console.error("Error migrating legacy state file", LEGACY_STATE_FILE_PATH);
-            }
-            Metrics.countEvent(Metrics.EVENT_TYPE.PLATFORM, "legacyState", "migrated");
-            _migrated.resolve();
-            console.log("Legacy state migration completed");
-        });
-        return _migrated.promise();
-    }
-
-    // private API
-    exports._migrateLegacyStateFile = _migrateLegacyStateFile;
 
     // public api
     exports.get     = getVal;

--- a/src/preferences/StateManager.js
+++ b/src/preferences/StateManager.js
@@ -141,8 +141,8 @@ define(function (require, exports, module) {
     /**
      * returns a preference instance that can be listened `.on("change", cbfn(changeType))` . The callback fucntion will be called
      * whenever there is a change in the supplied id with a changeType argument. The change type can be one of the two:
-     * CHANGE_TYPE_INTERNAL - if change is made within the current editor
-     * CHANGE_TYPE_EXTERNAL - if change is made within the current editor
+     * CHANGE_TYPE_INTERNAL - if change is made within the current app window/browser tap
+     * CHANGE_TYPE_EXTERNAL - if change is made in a different app window/browser tab
      *
      * @param id
      * @param type
@@ -235,6 +235,14 @@ define(function (require, exports, module) {
         console.warn("StateManager.getPrefixedSystem() is deprecated. Use StateManager.createExtensionStateManager()");
         return createExtensionStateManager(prefix);
     }
+
+    // private api for internal use only
+    // All internal states must be registered here to prevent collisions in internal codebase state managers
+    const _INTERNAL_STATES = {
+        TAB_SPACES: "TAB_SPC_"
+    };
+    exports._INTERNAL_STATES = _INTERNAL_STATES;
+    exports._createInternalStateManager = createExtensionStateManager;
 
     // public api
     exports.get     = getVal;

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -406,12 +406,12 @@ a, img {
     display: none;
 }
 
-#indent-type, #indent-width-label {
+#indent-type, #indent-auto, #indent-width-label {
     cursor: pointer;
     margin-right: 3px;
 }
 
-#status-overwrite:hover, #indent-type:hover, #indent-width-label:hover {
+#status-overwrite:hover, #indent-type:hover, #indent-auto:hover, #indent-width-label:hover {
     text-decoration: underline;
 }
 

--- a/src/thirdparty/licences/credits.md
+++ b/src/thirdparty/licences/credits.md
@@ -9,6 +9,7 @@ Please find all other licenses and attributions below:
 
 ## Other Libraries used
 1. https://www.npmjs.com/package/@pixelbrackets/gfm-stylesheet under AGPL 2.0 license
+2. https://www.npmjs.com/package/detect-indent detect-indent MIT Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
 
 ## Attributions for Images and other assets used
 

--- a/test/UnitTestSuite.js
+++ b/test/UnitTestSuite.js
@@ -117,6 +117,7 @@ define(function (require, exports, module) {
     require("spec/StateManager-test");
     require("spec/TaskManager-integ-test");
     require("spec/Generic-integ-test");
+    require("spec/spacing-auto-detect-integ-test");
     // Integrated extension tests
     require("spec/Extn-InAppNotifications-integ-test");
     require("spec/Extn-RemoteFileAdapter-integ-test");

--- a/test/spec/Document-integ-test.js
+++ b/test/spec/Document-integ-test.js
@@ -30,6 +30,7 @@ define(function (require, exports, module) {
         EditorManager,       // loaded from brackets.test
         DocumentModule,      // loaded from brackets.test
         DocumentManager,     // loaded from brackets.test
+        Editor,     // loaded from brackets.test
         MainViewManager,     // loaded from brackets.test
         SpecRunnerUtils     = require("spec/SpecRunnerUtils");
 
@@ -50,6 +51,7 @@ define(function (require, exports, module) {
             DocumentModule      = testWindow.brackets.test.DocumentModule;
             DocumentManager     = testWindow.brackets.test.DocumentManager;
             MainViewManager     = testWindow.brackets.test.MainViewManager;
+            Editor     = testWindow.brackets.test.Editor;
 
             await SpecRunnerUtils.loadProjectInTestWindow(testPath);
         }, 30000);
@@ -294,7 +296,7 @@ define(function (require, exports, module) {
                 var promise,
                     cssDoc,
                     cssMasterEditor;
-
+                Editor.Editor.setAutoTabSpaces(false);
                 promise = CommandManager.execute(Commands.CMD_ADD_TO_WORKINGSET_AND_OPEN, {fullPath: HTML_FILE});
                 await awaitsForDone(promise, "Open into working set");
 

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -438,6 +438,7 @@ define(function (require, exports, module) {
 
         Editor.setUseTabChar(EDITOR_USE_TABS);
         Editor.setSpaceUnits(EDITOR_SPACE_UNITS);
+        Editor._autoDetectTabSpaces(editor, undefined, true);
 
         if (pane.addView) {
             pane.addView(editor);

--- a/test/spec/prettier-test-files/js/test-pretty-8-indent.js
+++ b/test/spec/prettier-test-files/js/test-pretty-8-indent.js
@@ -1,0 +1,11 @@
+function hello() {
+        console.log("hello");
+}
+
+function world() {
+        console.log("world");
+}
+
+function yo() {
+        console.log("yo");
+}

--- a/test/spec/space-detect-test-files/space-1.js
+++ b/test/spec/space-detect-test-files/space-1.js
@@ -1,0 +1,3 @@
+function f() {
+ console.log("hello");
+}

--- a/test/spec/space-detect-test-files/space-12.js
+++ b/test/spec/space-detect-test-files/space-12.js
@@ -1,0 +1,3 @@
+function f() {
+            console.log("hello");
+}

--- a/test/spec/space-detect-test-files/space-none.js
+++ b/test/spec/space-detect-test-files/space-none.js
@@ -1,0 +1,1 @@
+function f() {console.log("hello");}

--- a/test/spec/space-detect-test-files/tab-12.js
+++ b/test/spec/space-detect-test-files/tab-12.js
@@ -1,0 +1,3 @@
+function x(){
+												console.log();
+}

--- a/test/spec/space-detect-test-files/tab-2.js
+++ b/test/spec/space-detect-test-files/tab-2.js
@@ -1,0 +1,3 @@
+function x(){
+		console.log();
+}

--- a/test/spec/spacing-auto-detect-integ-test.js
+++ b/test/spec/spacing-auto-detect-integ-test.js
@@ -1,0 +1,112 @@
+/*
+ * GNU AGPL-3.0 License
+ *
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
+ * Original work Copyright (c) 2013 - 2021 Adobe Systems Incorporated. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
+ *
+ */
+
+/*global describe, it, beforeAll, afterAll */
+
+define(function (require, exports, module) {
+
+
+    var SpecRunnerUtils = require("spec/SpecRunnerUtils");
+
+    describe("integration:Auto space and tabs detect", function () {
+        const testRootSpec = "/spec/space-detect-test-files/";
+        let testProjectsFolder = SpecRunnerUtils.getTestPath(testRootSpec),
+            testWindow,
+            $,
+            __PR; // __PR can be debugged using debug menu> phoenix code diag tools> test builder
+
+        beforeAll(async function () {
+            testWindow = await SpecRunnerUtils.createTestWindowAndRun();
+            // Load module instances from brackets.test
+            await SpecRunnerUtils.loadProjectInTestWindow(testProjectsFolder);
+            __PR = testWindow.__PR;
+            $ = testWindow.$;
+        }, 30000);
+
+        afterAll(async function () {
+            await __PR.closeAll();
+            testWindow    = null;
+            __PR          = null;
+            $             = null;
+            await SpecRunnerUtils.closeTestWindow();
+        }, 30000);
+
+        function validateSpacing(type, value, autoMode) {
+            __PR.validateEqual($("#indent-type").text(), type);
+            __PR.validateEqual($("#indent-width-label").text(), value);
+            __PR.validateEqual($("#indent-auto").text(), autoMode);
+        }
+
+        it(`should detect 1 space auto`, async function () {
+            await __PR.openFile("space-1.js");
+            validateSpacing("Spaces:", "1", "Auto");
+            await __PR.closeFile();
+        });
+
+        it(`should detect 12 space as 10 spaces auto`, async function () {
+            await __PR.openFile("space-12.js");
+            validateSpacing("Spaces:", "10", "Auto");
+            await __PR.closeFile();
+        });
+
+        it(`should detect no space as default 4 spaces auto`, async function () {
+            await __PR.openFile("space-none.js");
+            validateSpacing("Spaces:", "4", "Auto");
+            await __PR.closeFile();
+        });
+
+        it(`should detect 2 tabs auto`, async function () {
+            await __PR.openFile("tab-2.js");
+            validateSpacing("Tab Size:", "2", "Auto");
+            await __PR.closeFile();
+        });
+
+        it(`should detect 12 tabs as 10 tabs auto`, async function () {
+            await __PR.openFile("tab-12.js");
+            validateSpacing("Tab Size:", "10", "Auto");
+            await __PR.closeFile();
+        });
+
+        it(`should be able to override individual file's tab/spacing in auto mode`, async function () {
+            await __PR.openFile("space-1.js");
+            validateSpacing("Spaces:", "1", "Auto");
+            $("#indent-type").click();
+            validateSpacing("Tab Size:", "4", "Auto");
+            // now switch to another file
+            await __PR.openFile("tab-2.js");
+            validateSpacing("Tab Size:", "2", "Auto");
+            // now switch back and it should remember the overridden settings
+            await __PR.openFile("space-1.js");
+            validateSpacing("Tab Size:", "4", "Auto");
+            // now change the tab units
+            __PR.EDITING.setEditorSpacing(true, 6, true);
+            validateSpacing("Tab Size:", "6", "Auto");
+            // now close the file and switch to another file
+            await __PR.closeFile();
+            await __PR.openFile("tab-2.js");
+            validateSpacing("Tab Size:", "2", "Auto");
+            // now switch back and it should remember the overridden settings
+            await __PR.openFile("space-1.js");
+            validateSpacing("Tab Size:", "6", "Auto");
+            await __PR.closeFile();
+        });
+    });
+});

--- a/test/spec/spacing-auto-detect-integ-test.js
+++ b/test/spec/spacing-auto-detect-integ-test.js
@@ -108,5 +108,38 @@ define(function (require, exports, module) {
             validateSpacing("Tab Size:", "6", "Auto");
             await __PR.closeFile();
         });
+
+        it(`should switching to fixed mode default to 4 spaces for all files`, async function () {
+            await __PR.openFile("tab-2.js");
+            validateSpacing("Tab Size:", "2", "Auto");
+            $("#indent-auto").click();
+            validateSpacing("Spaces:", "4", "Fixed");
+            await __PR.openFile("space-1.js");
+            validateSpacing("Spaces:", "4", "Fixed");
+            await __PR.closeFile();
+        });
+
+        it(`should be able to change spacing/tabs settings of fixed mode`, async function () {
+            await __PR.openFile("tab-2.js");
+            // now change the fixed width
+            __PR.EDITING.setEditorSpacing(true, 6, false);
+            validateSpacing("Tab Size:", "6", "Fixed");
+            await __PR.openFile("space-12.js");
+            validateSpacing("Tab Size:", "6", "Fixed");
+            // revert back to defaults
+            __PR.EDITING.setEditorSpacing(false, 4, false);
+            await __PR.closeFile();
+        });
+
+        it(`should toggling auto mode recompute the spacing`, async function () {
+            await __PR.openFile("tab-2.js");
+            __PR.EDITING.setEditorSpacing(false, 3, true);
+            validateSpacing("Spaces:", "3", "Auto");
+            // now toggle the auto to fixed and then to auto once to force recompute spacing
+            $("#indent-auto").click();
+            $("#indent-auto").click();
+            validateSpacing("Tab Size:", "2", "Auto");
+            await __PR.closeFile();
+        });
     });
 });


### PR DESCRIPTION
## Detect Indents automatically based on current file
 This will be the default mode. This can be toggled from the status bar by using the fixed/Auto toggle as shown below.

![image](https://github.com/user-attachments/assets/f4de4bdc-75f2-42c0-9bbd-94e22ace37f9)
![image](https://github.com/user-attachments/assets/5b020965-37e3-4cfa-9524-ffe806b2bbd6)

## features
1. The auto detcted indents of each file can be overriden by manually entering the spacing and tab config as usual in the status bar. Those details will be persited for that file across reboots.
2. To recompute the tab spacing config for a file, just click on the `auto` toggle in status bar twice. (to change mode to fixed and back to auto will recompute the spacing for the current file). Not entirely intuitive, but should be a very rare use case and didnt wanted to complicate the ui with more options and dropdows like in other editors.
3. changing to fixed mode will set to fixed spaic across the system.
4. There is also a json preference available to toggle this setting: `"autoTabSpaces" : true` - to enable

## How it works
We use a modified version of https://www.npmjs.com/package/detect-indent . On creating a new editor, we scan the first 700 lines of text to determine the most probable indentation for the current editor. 

700 lines was selected as it should be large enough to account for file comment headers if any and then we performance analysis and it takes <0.1 ms in most cases to scan 700 lines. Further, we modified the lib to directly use our editor APIs to get lines instead of getting text from the edtor as a whole and then splitting lines to improve perfomance.

The spacing computed for the file is cached temporarily for the current session and will be reused to reduce file switch times.
