### PR TITLE
fix: remove alert patch as tauri fixed alert issue in windows

### DIFF
--- a/src/LiveDevelopment/BrowserScripts/LivePreviewTransportRemote.js
+++ b/src/LiveDevelopment/BrowserScripts/LivePreviewTransportRemote.js
@@ -329,22 +329,6 @@
         }
     });
 
-    let alertStr = "Alert", confirmStr = "Confirm";
-
-    function alertPatch(message) {
-        // in tauri windows, only the prompt API works. so we use it for alerts as well
-        // we cant use html alerts here as the alert api will pause js which we cant do via js alone.
-        prompt(alertStr, message);
-    }
-
-    function confirmPatch(message) {
-        // in tauri windows, only the prompt API works. so we use it for confirm as well
-        // we cant use html alerts here as the alert api will pause js which we cant do via js alone.
-        const response = prompt(confirmStr, message);
-        // prompt will return null if cancel is pressed
-        return !!response;
-    }
-
     // this is for managing who am i context in iframes embedded in phoenix to have special handling.
     window.addEventListener('message', function(event) {
         if (!TRANSPORT_CONFIG.TRUSTED_ORIGINS_EMBED[event.origin]) {
@@ -352,15 +336,9 @@
         }
         if(event.data.type === "WHO_AM_I_RESPONSE") {
             window.__PHOENIX_EMBED_INFO = {
-                isTauri: event.data.isTauri
+                isTauri: event.data.isTauri,
+                platform: event.data.platform
             };
-            alertStr = event.data.alertStr || alertStr;
-            confirmStr = event.data.confirmStr || confirmStr;
-            if(event.data.isTauri && event.data.platform === 'win') {
-                // patch alert and confirm as in windows iframes in tauri, these are not present.
-                window.alert = alertPatch;
-                window.confirm = confirmPatch;
-            }
         }
     });
     if(window.self !== window.parent){

--- a/src/extensionsIntegrated/Phoenix-live-preview/main.js
+++ b/src/extensionsIntegrated/Phoenix-live-preview/main.js
@@ -130,9 +130,7 @@ define(function (require, exports, module) {
             iframeDom.contentWindow.postMessage({
                 type: "WHO_AM_I_RESPONSE",
                 isTauri: Phoenix.isNativeApp,
-                platform: Phoenix.platform,
-                alertStr: Strings.ALERT,
-                confirmStr: Strings.CONFIRM
+                platform: Phoenix.platform
             }, "*"); // this is not sensitive info, and is only dispatched if requested by the iframe
         }
     });

--- a/src/extensionsIntegrated/Phoenix-live-preview/markdown.html
+++ b/src/extensionsIntegrated/Phoenix-live-preview/markdown.html
@@ -27,7 +27,8 @@
 
             if(event.data.type === "WHO_AM_I_RESPONSE") {
                 window.__PHOENIX_EMBED_INFO = {
-                    isTauri: event.data.isTauri
+                    isTauri: event.data.isTauri,
+                    platform: event.data.platform
                 };
             } else if(event.data.type === "_TEST_FOCUS_CLICK") { // for integ tests
                 document.body.click();


### PR DESCRIPTION
reverting https://github.com/phcode-dev/phoenix/pull/1750 after latest tauri integration.

confirmed working in windows and linux where the patch was applied selectiveley.

Doesnt work in macos!! Last versions too isnt working, so this is not a regression in macos. Not sure why. https://discord.com/channels/616186924390023171/1258736272814374964