### PR TITLE
fix: window.alert, confirm and prompt apis not present in embedded tauri mac live preview

### DIFF
--- a/src/LiveDevelopment/MultiBrowserImpl/transports/LivePreviewTransport.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/transports/LivePreviewTransport.js
@@ -27,6 +27,7 @@ define(function (require, exports, module) {
 
     const LiveDevProtocol      = require("LiveDevelopment/MultiBrowserImpl/protocol/LiveDevProtocol"),
         EventDispatcher = require("utils/EventDispatcher"),
+        Strings            = require("strings"),
         Metrics = require("utils/Metrics");
 
     const METRIC_SEND_INTERVAL_MS = 1000;
@@ -75,9 +76,14 @@ define(function (require, exports, module) {
             _transportBridge.getRemoteTransportScript()) || "";
         transportScript = "const TRANSPORT_CONFIG={};" +
             `TRANSPORT_CONFIG.PHOENIX_INSTANCE_ID = "${Phoenix.PHOENIX_INSTANCE_ID}";\n` +
+            `TRANSPORT_CONFIG.IS_NATIVE_APP = ${Phoenix.isNativeApp};\n` +
+            `TRANSPORT_CONFIG.PLATFORM = "${Phoenix.platform}";\n` +
             `TRANSPORT_CONFIG.LIVE_DEV_REMOTE_WORKER_SCRIPTS_FILE_NAME = "${LiveDevProtocol.LIVE_DEV_REMOTE_WORKER_SCRIPTS_FILE_NAME}";\n` +
             `TRANSPORT_CONFIG.LIVE_PREVIEW_DEBUG_ENABLED = ${logger.loggingOptions.logLivePreview};\n`+
             `TRANSPORT_CONFIG.TRUSTED_ORIGINS_EMBED = ${JSON.stringify(Phoenix.TRUSTED_ORIGINS)};\n`+
+            `TRANSPORT_CONFIG.STRINGS = {
+                UNSUPPORTED_DOM_APIS_CONFIRM: "${Strings.UNSUPPORTED_DOM_APIS_CONFIRM}"
+            };\n`+
             transportScript;
         return LivePreviewTransportRemote.replace(replaceString, transportScript)
             + "\n";

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -128,8 +128,7 @@ define({
     "ERROR_MAX_FILES": "This project contains more than 30,000 files. Features that operate across multiple files may be disabled or behave as if the project is empty. <a href='https://github.com/adobe/brackets/wiki/Large-Projects'>Read more about working with large projects</a>.",
 
     // Live Preview error strings
-    "ALERT": "Alert",
-    "CONFIRM": "Confirm",
+    "UNSUPPORTED_DOM_APIS_CONFIRM": "window.confirm and window.prompt APIS are not available in embedded Live Preview in {APP_NAME}. Please popout Live Preview to use these APIs in the browser.",
     "ERROR_LAUNCHING_BROWSER_TITLE": "Error Launching Browser",
     "ERROR_CANT_FIND_CHROME": "The Google Chrome browser could not be found. Please make sure it is installed.",
     "ERROR_LAUNCHING_BROWSER": "An error occurred when launching the browser. (error {0})",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -128,7 +128,7 @@ define({
     "ERROR_MAX_FILES": "This project contains more than 30,000 files. Features that operate across multiple files may be disabled or behave as if the project is empty. <a href='https://github.com/adobe/brackets/wiki/Large-Projects'>Read more about working with large projects</a>.",
 
     // Live Preview error strings
-    "UNSUPPORTED_DOM_APIS_CONFIRM": "window.confirm and window.prompt APIS are not available in embedded Live Preview in {APP_NAME}. Please popout Live Preview to use these APIs in the browser.",
+    "UNSUPPORTED_DOM_APIS_CONFIRM": "The `window.confirm` and `window.prompt` APIs are unavailable in the embedded Live Preview of {APP_NAME}. Please popout Live Preview to use these APIs in the browser.",
     "ERROR_LAUNCHING_BROWSER_TITLE": "Error Launching Browser",
     "ERROR_CANT_FIND_CHROME": "The Google Chrome browser could not be found. Please make sure it is installed.",
     "ERROR_LAUNCHING_BROWSER": "An error occurred when launching the browser. (error {0})",


### PR DESCRIPTION
address: https://github.com/orgs/phcode-dev/discussions/1734

![image](https://github.com/user-attachments/assets/bd34c61b-aab9-49e3-9b91-76c7dcdbca81)
![image](https://github.com/user-attachments/assets/0c8283c5-c675-4ccc-8002-37df6a2c5ecb)
