### PR TITLE
chore: corrupt preferences auto reset

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -361,34 +361,19 @@ define(function (require, exports, module) {
                         if (PreferencesManager._isUserScopeCorrupt()) {
                             const userPrefFullPath = PreferencesManager.getUserPrefFile();
                             // user scope can get corrupt only if the file exists, is readable,
-                            // but malformed. no need to check for its existance.
-                            const info = MainViewManager.findInAllWorkingSets(userPrefFullPath);
-                            let paneId;
-                            if (info.length) {
-                                paneId = info[0].paneId;
-                            }
+                            // but malformed. no need to check for its existence.
                             Metrics.countEvent(Metrics.EVENT_TYPE.STORAGE, "prefs.corrupt", "startup");
-                            FileViewController.openFileAndAddToWorkingSet(userPrefFullPath, paneId)
-                                .done(function () {
-                                    Dialogs.showModalDialog(
-                                        DefaultDialogs.DIALOG_ID_ERROR,
-                                        Strings.ERROR_PREFS_CORRUPT_TITLE,
-                                        Strings.ERROR_PREFS_CORRUPT
-                                    ).done(function () {
-                                        // give the focus back to the editor with the pref file
-                                        MainViewManager.focusActivePane();
-                                    });
-                                });
+                            let file = FileSystem.getFileForPath(userPrefFullPath);
+                            file.unlinkAsync().finally(function () {
+                                Dialogs.showModalDialog(
+                                    DefaultDialogs.DIALOG_ID_ERROR,
+                                    Strings.ERROR_PREFS_RESET_TITLE,
+                                    Strings.ERROR_PREFS_CORRUPT_RESET
+                                );
+                            });
                         }
                     });
                 });
-
-                // See if any startup files were passed to the application
-                if (brackets.app.getPendingFilesToOpen) {
-                    brackets.app.getPendingFilesToOpen(function (err, paths) {
-                        DragAndDrop.openDroppedFiles(paths);
-                    });
-                }
             });
         });
     }

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -69,12 +69,12 @@ define(function (require, exports, module) {
     require("NodeConnector");
     require("command/KeyboardOverlayMode");
     require("editor/EditorManager");
+    require("project/FileViewController");
 
     // Load dependent modules
     const AppInit             = require("utils/AppInit"),
         LanguageManager     = require("language/LanguageManager"),
         ProjectManager      = require("project/ProjectManager"),
-        FileViewController  = require("project/FileViewController"),
         FileSyncManager     = require("project/FileSyncManager"),
         Commands            = require("command/Commands"),
         CommandManager      = require("command/CommandManager"),
@@ -95,8 +95,8 @@ define(function (require, exports, module) {
         DeprecationWarning  = require("utils/DeprecationWarning"),
         ViewCommandHandlers = require("view/ViewCommandHandlers"),
         NotificationUI      = require("widgets/NotificationUI"),
-        MainViewManager     = require("view/MainViewManager"),
         Metrics             = require("utils/Metrics");
+    require("view/MainViewManager");
 
     window.EventManager = EventManager; // Main event intermediary between brackets and other web pages.
     /**

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -114,9 +114,11 @@ define({
 
     // Application preferences corrupt error strings
     "ERROR_PREFS_CORRUPT_TITLE": "Error Reading Preferences",
+    "ERROR_PREFS_RESET_TITLE": "Settings Reset - Restart Required",
     "ERROR_PREFS_PROJECT_LINT": "Project Preferences",
     "ERROR_PREFS_PROJECT_LINT_MESSAGE": "Error: The project contains both `.brackets.json` and `.phcode.json` files, causing a conflict. Please delete either `.brackets.json` or `.phcode.json` and then reload the project.",
     "ERROR_PREFS_CORRUPT": "Your preferences file is not valid JSON. The file will be opened so that you can correct the format. You will need to restart {APP_NAME} for the changes to take effect.",
+    "ERROR_PREFS_CORRUPT_RESET": "Your {APP_NAME} settings were damaged and have been reset. Please restart {APP_NAME} for the changes to take effect.",
     "ERROR_PROJ_PREFS_CORRUPT": "Your project preferences file is not valid JSON. The file will be opened so that you can correct the format. You will need to reload the project for the changes to take effect.",
 
     // Application error strings


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9d0b4983-2033-4762-a72f-9eb360733931)

Right now we just delete the preferences file if we detect a corrupt preference file.
Was planning to keep last known preference and revert to it, but only 19 users had the issue and one repeat user over the last 30 days on 32,000 total users. So the error rate is pretty low. Not worth effort.

In the future, with settings sync, this should be not an issue at all.
