### PR TITLE
fix: kaspersky trojan horse false positive mitigation

### DIFF
--- a/src/phoenix/shell.js
+++ b/src/phoenix/shell.js
@@ -515,6 +515,17 @@ Phoenix.app = {
         }
         return window.__TAURI__.tauri.invoke("zoom_window", {scaleFactor: scaleFactor});
     },
+    _openUrlInBrowserWin: function (url, browser) {
+        // private API for internal use only. May be removed at any time.
+        // Please use NodeUtils.openUrlInBrowser for a platform independent equivalent of this.
+        if(!Phoenix.isNativeApp){
+            throw new Error("_openUrlInBrowserWin is not supported in browsers");
+        }
+        if(Phoenix.platform !== "win") {
+            throw new Error("_openUrlInBrowserWin is only supported in windows");
+        }
+        return window.__TAURI__.invoke('_open_url_in_browser_win', { url, browser });
+    },
     getApplicationSupportDirectory: Phoenix.VFS.getAppSupportDir,
     getExtensionsDirectory: Phoenix.VFS.getExtensionDir,
     getUserDocumentsDirectory: Phoenix.VFS.getUserDocumentsDirectory,

--- a/src/utils/NodeUtils.js
+++ b/src/utils/NodeUtils.js
@@ -75,6 +75,9 @@ define(function (require, exports, module) {
         if(!Phoenix.isNativeApp) {
             throw new Error("openUrlInBrowser not available in browser");
         }
+        if(Phoenix.platform === "win") {
+            return Phoenix.app._openUrlInBrowserWin(url, browserName);
+        }
         return utilsConnector.execPeer("openUrlInBrowser", {url, browserName});
     }
 


### PR DESCRIPTION
Address False positive of Kaspersky detects phnode.exe and index.js as trojan horse https://github.com/phcode-dev/phoenix/issues/1821

Kaspersky is terating the background node process we use as a trojan horse if it opens a URL. We are onboarding to Kaspersky trusted applications program via kaspersky allowed lists to prevent this in the future. 

This is an interim mitigation for the time being.

Related desktop pr: https://github.com/phcode-dev/phoenix-desktop/pull/514