### PR TITLE
fix: node crashes after computer sleep

### DIFF
--- a/src-node/node-connector.js
+++ b/src-node/node-connector.js
@@ -105,27 +105,6 @@ const LARGE_DATA_THRESHOLD = 2*1024*1024; // 2MB
 let controlSocketMain = null,
     largeDataSocketMain = null;
 
-const SOCKET_HEALTH_CHECK_INTERVAL_MS = 3000; // 3 seconds
-let healthCheckFailuresCount = 0; // Count of consecutive health check failures
-const RETRY_HEALTH_CHECK_MAX_COUNT = 2;
-
-function startOrphanExitDetection() {
-    setInterval(() => {
-        if (healthCheckFailuresCount === RETRY_HEALTH_CHECK_MAX_COUNT) {
-            console.error(`No socket connection for ${healthCheckFailuresCount * SOCKET_HEALTH_CHECK_INTERVAL_MS / 1000} seconds. Exiting due to orphan node process detection.`);
-            process.exit(1);
-        }
-
-        if (controlSocketMain || largeDataSocketMain) {
-            // Reset failure count if any socket is connected
-            healthCheckFailuresCount = 0;
-            return;
-        }
-        console.warn(`No active sockets detected, node will be terminated in ${(RETRY_HEALTH_CHECK_MAX_COUNT-healthCheckFailuresCount)*SOCKET_HEALTH_CHECK_INTERVAL_MS/1000} seconds`);
-        healthCheckFailuresCount++;
-    }, SOCKET_HEALTH_CHECK_INTERVAL_MS);
-}
-
 const MAX_PENDING_SEND_BUFFER = 10000;
 let pendingSendBuffer = [];
 
@@ -366,7 +345,6 @@ function processWSCommand(ws, metadata, dataBuffer) {
             ws.isLargeData = false;
             controlSocketMain = ws;
             _drainPendingSendBuffer();
-            startOrphanExitDetection();
             return;
         case WS_COMMAND.EXEC:
             _execNodeConnectorFn(ws, metadata, dataBuffer);


### PR DESCRIPTION
Fixes https://github.com/phcode-dev/phoenix/issues/1791

Node exited after sleep as web sockets gets disconnected at sleep, and our orphan exit timer will  inccorectly determine that too much time has passed including the time the app was asleep and terminated node.

We dont need orpahn exit timers anymore as node is terminated oon stdio disconnect, which is a much more reliable way to detect process exit. We did not remove this code at node connector as it maybe a miss during the algo change?