### PR TITLE
chore: release note for v3.9 and hide vscode shortcut feature as its not ready yet

### DIFF
--- a/src/assets/default-project/en/Newly_added_features.md
+++ b/src/assets/default-project/en/Newly_added_features.md
@@ -7,6 +7,32 @@ We are continuously adding features every week to improve the life of web develo
 
 Here's a list of top features recently added to Phoenix:
 
+## Auto Tab and Spacing detection
+
+`Added on August, 2024`
+
+Phoenix Code can now automatically detect and apply the indentation style (tabs or spaces) based on the existing code in the file.
+[Read more...](https://docs.phcode.dev/docs/editing-text/#auto-space-detection)
+
+![image](https://github.com/user-attachments/assets/0adc47c5-a561-4002-bffb-d7bcde999b9d)
+
+## Auto rename start and end of HTML/XML/SVG tags
+
+`Added on July, 2024`
+
+Automatically rename paired HTML/XML/SVG tags as you type at the start or end of the tag. [Read more...](https://docs.phcode.dev/docs/editing-text/#auto-rename-tag)
+
+![tag sync](https://github.com/user-attachments/assets/ad82db8c-df1c-4c83-a5db-145caab539ec)
+
+## Now Available on ChromeOS
+
+`Added on July, 2024`
+
+All new native ChromeOS app is now available on the Google Play Store.
+The ChromeOS app is a highly requested feature and is specially made for education and student use.
+
+[![google play icon (1)](https://github.com/user-attachments/assets/0a7f20ce-653c-43a8-ac3e-3875ea74df5b)](https://play.google.com/store/apps/details?id=prod.phcode.twa)
+
 ## Drag and Drop Files and Folders in Desktop Apps - Experimental
 
 `Added on June, 2024`

--- a/src/extensionsIntegrated/DisplayShortcuts/templates/bottom-panel.html
+++ b/src/extensionsIntegrated/DisplayShortcuts/templates/bottom-panel.html
@@ -4,7 +4,7 @@
         <a href="#" class="close">&times;</a>
         <button class="btn reset-to-default" title="{{KEYBOARD_SHORTCUT_PANEL_RESET_DEFAULT}}">{{{KEYBOARD_SHORTCUT_PANEL_RESET}}}</button>
         <input class="filter" type="search" placeholder="{{{KEYBOARD_SHORTCUT_PANEL_FILTER}}}">
-        <span class="presetPickerContainer" title="{{KEYBOARD_SHORTCUT_PRESET_TOOLTIP}}"></span>
+        <span class="presetPickerContainer forced-hidden" title="{{KEYBOARD_SHORTCUT_PRESET_TOOLTIP}}"></span>
     </div>
     <div class="resizable-content"></div>
 </div>

--- a/src/htmlContent/about-dialog.html
+++ b/src/htmlContent/about-dialog.html
@@ -14,7 +14,11 @@
                 </p>
                 <p class="dialog-message">{{{Strings.ABOUT_RELEASE_CREDITS}}}
                     <a href="https://github.com/abose" target="_blank" rel="noopener" >Arun Bose</a><span>,&nbsp;
-                    <a href="https://github.com/charlypa" target="_blank" rel="noopener" >charly p abraham</a>
+                    <a href="https://github.com/charlypa" target="_blank" rel="noopener" >Charly P Abraham</a>,
+                    <a href="https://github.com/kiranbose" target="_blank" rel="noopener" >Kiran Bose</a>,
+                    <a href="https://github.com/devvaannsh" target="_blank" rel="noopener" >Devansh Agarwal</a>,
+                    <a href="https://github.com/jozsefk9" target="_blank" rel="noopener" >Jozsef</a>,
+                    <a href="https://github.com/acemi1" target="_blank" rel="noopener" >acemi1</a>
                 </p>
 
                 <p class="dialog-message"><!-- $NON-NLS$ -->Copyright 2021 - present <a href="https://core.ai">Core.ai</a> and its licensors. All rights reserved.</p>


### PR DESCRIPTION
Release credits updated
![image](https://github.com/user-attachments/assets/0eecaefe-8a37-497b-a030-78d62392a993)
