### PR TITLE
fix: bugsnag errors like Unknown exec function received htmlLint

### DIFF
--- a/src/extensions/default/CSSCodeHints/css-lint.js
+++ b/src/extensions/default/CSSCodeHints/css-lint.js
@@ -79,6 +79,9 @@ define(function (require, exports, module) {
                     resolve({ errors: lintResult });
                 }
                 resolve();
+            }).catch(err=>{
+                console.error("CSS Lint failed:", err);
+                reject(new Error("CSS Lint failed as CSS Lint plugin is not yet loaded. Please try again."));
             });
         });
     }

--- a/src/extensions/default/HTMLCodeHints/html-lint.js
+++ b/src/extensions/default/HTMLCodeHints/html-lint.js
@@ -112,6 +112,9 @@ define(function (require, exports, module) {
                     resolve({ errors: lintResult });
                 }
                 resolve();
+            }).catch(err=>{
+                console.error("HTML Lint failed:", err);
+                reject(new Error("HTML Lint failed as HTML plugin is not yet loaded. Please try again."));
             });
         });
     }

--- a/src/extensions/default/JSLint/JSHint.js
+++ b/src/extensions/default/JSLint/JSHint.js
@@ -87,7 +87,7 @@ define(function (require, exports, module) {
      * a gold star when no errors are found.
      */
     async function lintOneFile(text, _fullPath) {
-        return new Promise((resolve)=>{
+        return new Promise((resolve, reject)=>{
             if(jsHintConfigFileErrorMessage){
                 resolve({ errors: _getLinterConfigFileErrorMsg() });
                 return;
@@ -118,6 +118,9 @@ define(function (require, exports, module) {
                     resolve({ errors: errors });
                 }
                 resolve();
+            }).catch(err=>{
+                console.error("JSHint failed:", err);
+                reject(new Error("JSHint failed as JSHint plugin is not yet loaded. Please try again."));
             });
         });
     }

--- a/src/extensionsIntegrated/appUpdater/main.js
+++ b/src/extensionsIntegrated/appUpdater/main.js
@@ -421,14 +421,16 @@ define(function (require, exports, module) {
             window.fs.getTauriPlatformPath(entries[0].fullPath));
     }
 
-    function _cleanExtractedFolderSilent() {
+    function _cleanExtractedFolderSilent(logError) {
         return new Promise(resolve=>{
             const appdataDir = window._tauriBootVars.appLocalDir;
             let extractPlatformPath = path.join(appdataDir, 'installer', "extracted");
             const extractedVirtualPath = window.fs.getTauriVirtualPath(extractPlatformPath);
             let directory = FileSystem.getDirectoryForPath(extractedVirtualPath);
             directory.unlinkAsync()
-                .catch(console.error)
+                .catch(err=>{
+                    logError && console.error(`Error cleaning up ${extractedVirtualPath}`, err);
+                })
                 .finally(resolve);
         });
     }
@@ -454,7 +456,7 @@ define(function (require, exports, module) {
             throw new Error("Update script exit with non-0 exit code: " + result.code);
         }
         // now remove the original .app
-        await _cleanExtractedFolderSilent();
+        await _cleanExtractedFolderSilent(true);
     }
 
     let installerLocation;


### PR DESCRIPTION
The error happens as we load a lint extension in a web worker and phoenix calls the worker apis before the worker is loaded. This will eventually get resolved as teh worker gets loaded within a second of app load and another lint is trigerred on file change, but we get stray bugsnag errors for this expected error.