### PR TITLE
feat: get more themes button in themes dialog for discoverability

### DIFF
--- a/.github/workflows/verify_cla_signature_pr.yml
+++ b/.github/workflows/verify_cla_signature_pr.yml
@@ -58,8 +58,8 @@ jobs:
         env:
           EMPLOYER_CLA_LINK: https://raw.githubusercontent.com/phcode-dev/contributor-license-agreement/main/employer_contributor_license_agreement.md
           PERSONAL_CLA_LINK: https://raw.githubusercontent.com/phcode-dev/contributor-license-agreement/main/personal_contributor_licence_agreement.md
-      
-      - uses: actions/upload-artifact@v2
+
+      - uses: actions/upload-artifact@v4
         with:
           name: prcontext
           path: .tmp/

--- a/src/extensibility/ExtensionManagerDialog.js
+++ b/src/extensibility/ExtensionManagerDialog.js
@@ -205,7 +205,7 @@ define(function (require, exports, module) {
      * @private
      * Show a dialog that allows the user to browse and manage extensions.
      */
-    function _showDialog() {
+    function _showDialog(which) {
         Metrics.countEvent(Metrics.EVENT_TYPE.EXTENSIONS, "dialogue", "shown");
 
         let dialog,
@@ -421,6 +421,10 @@ define(function (require, exports, module) {
                 Metrics.countEvent(Metrics.EVENT_TYPE.EXTENSIONS, "install", "fromURL");
                 InstallExtensionDialog.showDialog().done(ExtensionManager.updateFromDownload);
             });
+
+        if(which === "themes"){
+            $dlg.find(".nav-tabs a.themes").click();
+        }
 
         return new $.Deferred().resolve(dialog).promise();
     }

--- a/src/htmlContent/themes-settings.html
+++ b/src/htmlContent/themes-settings.html
@@ -12,6 +12,7 @@
                         <option style="text-align:left;" value="{{name}}" data-target="theme">{{displayName}}</option>
                         {{/themes}}
                     </select>
+                    <button class="btn get-more-themes">{{Strings.GET_MORE_THEMES}}</button>
                 </div>
             </div>
 

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -677,6 +677,7 @@ define({
 
     // Strings for themes-settings.html and themes-general.html
     "CURRENT_THEME": "Current Theme",
+    "GET_MORE_THEMES": "Get More...",
     "USE_THEME_SCROLLBARS": "Use Theme Scrollbars",
     "FONT_SIZE": "Font Size",
     "FONT_FAMILY": "Font Family",

--- a/src/view/ThemeSettings.js
+++ b/src/view/ThemeSettings.js
@@ -31,6 +31,8 @@ define(function (require, exports, module) {
         ViewCommandHandlers = require("view/ViewCommandHandlers"),
         settingsTemplate    = require("text!htmlContent/themes-settings.html"),
         PreferencesManager  = require("preferences/PreferencesManager"),
+        CommandManager      = require("command/CommandManager"),
+        Commands            = require("command/Commands"),
         prefs               = PreferencesManager.getExtensionPrefs("themes");
 
     /**
@@ -140,7 +142,8 @@ define(function (require, exports, module) {
                 }
             });
 
-        Dialogs.showModalDialogUsingTemplate($template).done(function (id) {
+        const dialog = Dialogs.showModalDialogUsingTemplate($template);
+        dialog.done(function (id) {
             var setterFn;
 
             if (id === "save") {
@@ -162,6 +165,14 @@ define(function (require, exports, module) {
                 prefs.set("theme", currentSettings.theme);
             }
         });
+        $template
+            .find(".get-more-themes")
+            .click(function (event) {
+                event.preventDefault();
+                event.stopPropagation();
+                dialog.close();
+                CommandManager.execute(Commands.FILE_EXTENSION_MANAGER, "themes");
+            });
     }
 
     /**


### PR DESCRIPTION
Added a `Get More...` button in themes dialog. Clicking it will open themes tab in Extension Manager dialog.
![image](https://github.com/user-attachments/assets/d26a4fb3-2d75-446b-9f80-f2ede7c6d0a8)
