### PR TITLE
Remove redundant import statements, and fix broken links

### DIFF
--- a/src/worker/IndexingWorker.js
+++ b/src/worker/IndexingWorker.js
@@ -28,12 +28,6 @@
  * * Extensions performing large compute tasks should create their own worker and may use easy util methods in
  *   [worker/WorkerComm](../WorkerComm) to communicate with the web worker.
  *
- * ## Import
- * @example
- * ```js
- * // usage within extensions:
- * const IndexingWorker = brackets.getModule("worker/IndexingWorker");
- * ```
  * ## Extending the indexing worker
  * You can add your own custom scripts to the indexing worker by following the below example. Suppose you have an
  * extension folder with the following structure:

--- a/src/worker/IndexingWorker.js
+++ b/src/worker/IndexingWorker.js
@@ -26,7 +26,7 @@
  * worker cache to free up the main thread of heavy file access.
  *
  * * Extensions performing large compute tasks should create their own worker and may use easy util methods in
- *   [worker/WorkerComm](../WorkerComm) to communicate with the web worker.
+ *   [worker/WorkerComm](./WorkerComm) to communicate with the web worker.
  *
  * ## Extending the indexing worker
  * You can add your own custom scripts to the indexing worker by following the below example. Suppose you have an
@@ -47,7 +47,7 @@
  * Once the worker script is loaded with the above step:
  * * Phoenix can communicate with worker using the `IndexingWorker` reference in Phoenix.
  * * Worker can communicate with Phoenix with the global `WorkerComm` reference within the Indexing worker.
- * All utility methods in module [worker/WorkerComm](../WorkerComm) can be used for worker communication.
+ * All utility methods in module [worker/WorkerComm](./WorkerComm) can be used for worker communication.
  *
  * A global constant `Phoenix.baseURL` is available in the worker context to get the base url from which phoenix was
  * launched.
@@ -81,7 +81,7 @@ define(function (require, exports, module) {
      * The above methods can be used with either `IndexingWorker` reference within Phoenix
      * or the global `WorkerComm` reference within the Indexing worker. (See example below.)
      *
-     * See [worker/WorkerComm](../WorkerComm) for detailed API docs.
+     * See [worker/WorkerComm](./WorkerComm) for detailed API docs.
      *
      * ```js
      * // To Execute a named function `extensionName.sayHello` in the worker from phoenix

--- a/src/worker/WorkerComm.js
+++ b/src/worker/WorkerComm.js
@@ -24,7 +24,6 @@
  * WorkerComm provides util methods to communicate between web workers and Phoenix.
  * This module can be loaded from within web-workers and a phoenix extension that loads the web-worker.
  *
- * ## Import
  * ### Creating a WebWorker from your extension and attaching `WorkerComm` to it.
  * See an example extension code below that creates its own web worker and uses `WorkerComm` for communication.
  * @example


### PR DESCRIPTION
This PR makes the following changes :
1. In indexingWorker.js and workerComm.js, the jsdoc has import statements, so removing them as the script automatically adds import statements. 
2. The build failed issue on docs site was because of the link inside indexingWorker file. The link was supposed to lead to workerComm file, but was pointing to an invalid path. 