### PR TITLE
docs: refine api docs of Menus

### DIFF
--- a/docs/API-Reference/command/Menus.md
+++ b/docs/API-Reference/command/Menus.md
@@ -3,25 +3,209 @@
 const Menus = brackets.getModule("command/Menus")
 ```
 
+<a name="MenuItem"></a>
+
+## MenuItem
+**Kind**: global class  
+
+* [MenuItem](#MenuItem)
+    * [new MenuItem(id, command, [options])](#new_MenuItem_new)
+    * [.getCommand()](#MenuItem+getCommand) ⇒ <code>Command</code>
+    * [.getParentMenu()](#MenuItem+getParentMenu) ⇒ [<code>Menu</code>](#Menu)
+
+<a name="new_MenuItem_new"></a>
+
+### new MenuItem(id, command, [options])
+MenuItem represents a single menu item that executes a Command or a menu divider. MenuItems
+may have a sub-menu. A MenuItem may correspond to an HTML-based
+menu item or a native menu item if Brackets is running in a native application shell
+
+Since MenuItems may have a native implementation clients should create MenuItems through
+addMenuItem() and should NOT construct a MenuItem object directly.
+Clients should also not access HTML content of a menu directly and instead use
+the MenuItem API to query and modify menus items.
+
+MenuItems are views on to Command objects so modify the underlying Command to modify the
+name, enabled, and checked state of a MenuItem. The MenuItem will update automatically
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| id | <code>string</code> |  |
+| command | <code>string</code> \| <code>Command</code> | the Command this MenuItem will reflect.                                   Use DIVIDER to specify a menu divider |
+| [options] |  |  |
+| options.hideWhenCommandDisabled | <code>boolean</code> | will not show the menu item if command is disabled. |
+
+<a name="MenuItem+getCommand"></a>
+
+### menuItem.getCommand() ⇒ <code>Command</code>
+Gets the Command associated with a MenuItem
+
+**Kind**: instance method of [<code>MenuItem</code>](#MenuItem)  
+<a name="MenuItem+getParentMenu"></a>
+
+### menuItem.getParentMenu() ⇒ [<code>Menu</code>](#Menu)
+Returns the parent Menu for this MenuItem
+
+**Kind**: instance method of [<code>MenuItem</code>](#MenuItem)  
+<a name="Menu"></a>
+
+## Menu
+**Kind**: global class  
+
+* [Menu](#Menu)
+    * [new Menu(id)](#new_Menu_new)
+    * [.removeMenuItem(command)](#Menu+removeMenuItem)
+    * [.removeMenuDivider(menuItemID)](#Menu+removeMenuDivider)
+    * [.addMenuItem(command, [keyBindings], [position], [relativeID], [options])](#Menu+addMenuItem) ⇒ [<code>MenuItem</code>](#MenuItem)
+    * [.addMenuDivider(position, relativeID)](#Menu+addMenuDivider) ⇒ [<code>MenuItem</code>](#MenuItem)
+    * [.addSubMenu(name, id, position, relativeID)](#Menu+addSubMenu) ⇒ [<code>Menu</code>](#Menu)
+    * [.removeSubMenu(subMenuID)](#Menu+removeSubMenu)
+    * [.closeSubMenu()](#Menu+closeSubMenu)
+
+<a name="new_Menu_new"></a>
+
+### new Menu(id)
+Menu represents a top-level menu in the menu bar. A Menu may correspond to an HTML-based
+menu or a native menu if Brackets is running in a native application shell.
+
+Since menus may have a native implementation clients should create Menus through
+addMenu() and should NOT construct a Menu object directly.
+Clients should also not access HTML content of a menu directly and instead use
+the Menu API to query and modify menus.
+
+
+| Param | Type |
+| --- | --- |
+| id | <code>string</code> | 
+
+<a name="Menu+removeMenuItem"></a>
+
+### menu.removeMenuItem(command)
+Removes the specified menu item from this Menu. Key bindings are unaffected; use KeyBindingManager
+directly to remove key bindings if desired.
+
+**Kind**: instance method of [<code>Menu</code>](#Menu)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| command | <code>string</code> \| <code>Command</code> | command the menu would execute if we weren't deleting it. |
+
+<a name="Menu+removeMenuDivider"></a>
+
+### menu.removeMenuDivider(menuItemID)
+Removes the specified menu divider from this Menu.
+
+**Kind**: instance method of [<code>Menu</code>](#Menu)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| menuItemID | <code>string</code> | the menu item id of the divider to remove. |
+
+<a name="Menu+addMenuItem"></a>
+
+### menu.addMenuItem(command, [keyBindings], [position], [relativeID], [options]) ⇒ [<code>MenuItem</code>](#MenuItem)
+Adds a new menu item with the specified id and display text. The insertion position is
+specified via the relativeID and position arguments which describe a position
+relative to another MenuItem or MenuGroup. It is preferred that plug-ins
+insert new  MenuItems relative to a menu section rather than a specific
+MenuItem (see Menu Section Constants).
+
+TODO: Sub-menus are not yet supported, but when they are implemented this API will
+allow adding new MenuItems to sub-menus as well.
+
+Note, keyBindings are bound to Command objects not MenuItems. The provided keyBindings
+     will be bound to the supplied Command object rather than the MenuItem.
+
+**Kind**: instance method of [<code>Menu</code>](#Menu)  
+**Returns**: [<code>MenuItem</code>](#MenuItem) - the newly created MenuItem  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| command | <code>string</code> \| <code>Command</code> | the command the menu will execute.      Pass Menus.DIVIDER for a menu divider, or just call addMenuDivider() instead. |
+| [keyBindings] | <code>string</code> \| <code>Object</code> | Register one or more key bindings to associate with the supplied command |
+| [position] | <code>string</code> | constant defining the position of new MenuItem relative to      other MenuItems. Values:          - With no relativeID, use Menus.FIRST or LAST (default is LAST)          - Relative to a command id, use BEFORE or AFTER (required)          - Relative to a MenuSection, use FIRST_IN_SECTION or LAST_IN_SECTION (required) |
+| [relativeID] | <code>string</code> | command id OR one of the MenuSection.* constants. Required      for all position constants except FIRST and LAST. |
+| [options] |  |  |
+| options.hideWhenCommandDisabled | <code>boolean</code> | will not show the menu item if command is disabled. Helps to   clear the clutter on greyed out menu items if not applicable to context. |
+
+<a name="Menu+addMenuDivider"></a>
+
+### menu.addMenuDivider(position, relativeID) ⇒ [<code>MenuItem</code>](#MenuItem)
+Inserts divider item in menu.
+
+**Kind**: instance method of [<code>Menu</code>](#Menu)  
+**Returns**: [<code>MenuItem</code>](#MenuItem) - the newly created divider  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| position | <code>string</code> | constant defining the position of new the divider relative      to other MenuItems. Default is LAST.  (see Insertion position constants). |
+| relativeID | <code>string</code> | id of menuItem, sub-menu, or menu section that the new      divider will be positioned relative to. Required for all position constants      except FIRST and LAST |
+
+<a name="Menu+addSubMenu"></a>
+
+### menu.addSubMenu(name, id, position, relativeID) ⇒ [<code>Menu</code>](#Menu)
+Creates a new submenu and a menuItem and adds the menuItem of the submenu
+to the menu and returns the submenu.
+
+A submenu will have the same structure of a menu with a additional field
+parentMenuItem which has the reference of the submenu's parent menuItem.
+A submenu will raise the following events:
+- beforeSubMenuOpen
+- beforeSubMenuClose
+
+Note, This function will create only a context submenu.
+
+TODO: Make this function work for Menus
+
+**Kind**: instance method of [<code>Menu</code>](#Menu)  
+**Returns**: [<code>Menu</code>](#Menu) - the newly created submenu  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| name | <code>string</code> | displayed in menu item of the submenu |
+| id | <code>string</code> |  |
+| position | <code>string</code> | constant defining the position of new MenuItem of the submenu relative to      other MenuItems. Values:          - With no relativeID, use Menus.FIRST or LAST (default is LAST)          - Relative to a command id, use BEFORE or AFTER (required)          - Relative to a MenuSection, use FIRST_IN_SECTION or LAST_IN_SECTION (required) |
+| relativeID | <code>string</code> | command id OR one of the MenuSection.* constants. Required      for all position constants except FIRST and LAST. |
+
+<a name="Menu+removeSubMenu"></a>
+
+### menu.removeSubMenu(subMenuID)
+Removes the specified submenu from this Menu.
+
+Note, this function will only remove context submenus
+
+TODO: Make this function work for Menus
+
+**Kind**: instance method of [<code>Menu</code>](#Menu)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| subMenuID | <code>string</code> | the menu id of the submenu to remove. |
+
+<a name="Menu+closeSubMenu"></a>
+
+### menu.closeSubMenu()
+Closes the submenu if the menu has a submenu open.
+
+**Kind**: instance method of [<code>Menu</code>](#Menu)  
 <a name="ContextMenu"></a>
 
-## ContextMenu ⇐ [<code>Menu</code>](#new_Menu_new)
+## ContextMenu ⇐ [<code>Menu</code>](#Menu)
 **Kind**: global class  
-**Extends**: [<code>Menu</code>](#new_Menu_new)  
+**Extends**: [<code>Menu</code>](#Menu)  
 
-* [ContextMenu](#ContextMenu) ⇐ [<code>Menu</code>](#new_Menu_new)
+* [ContextMenu](#ContextMenu) ⇐ [<code>Menu</code>](#Menu)
     * [new ContextMenu()](#new_ContextMenu_new)
     * _instance_
         * [.open(mouseOrLocation)](#ContextMenu+open)
         * [.close()](#ContextMenu+close)
         * [.isOpen()](#ContextMenu+isOpen)
-        * [._getMenuItemForCommand(command)](#Menu+_getMenuItemForCommand) ⇒ <code>HTMLLIElement</code>
-        * [._getRelativeMenuItem(relativeID, position)](#Menu+_getRelativeMenuItem) ⇒ <code>HTMLLIElement</code>
         * [.removeMenuItem(command)](#Menu+removeMenuItem)
         * [.removeMenuDivider(menuItemID)](#Menu+removeMenuDivider)
-        * [.addMenuItem(command, [keyBindings], [position], [relativeID], [options])](#Menu+addMenuItem) ⇒ [<code>MenuItem</code>](#new_MenuItem_new)
-        * [.addMenuDivider(position, relativeID)](#Menu+addMenuDivider) ⇒ [<code>MenuItem</code>](#new_MenuItem_new)
-        * [.addSubMenu(name, id, position, relativeID)](#Menu+addSubMenu) ⇒ [<code>Menu</code>](#new_Menu_new)
+        * [.addMenuItem(command, [keyBindings], [position], [relativeID], [options])](#Menu+addMenuItem) ⇒ [<code>MenuItem</code>](#MenuItem)
+        * [.addMenuDivider(position, relativeID)](#Menu+addMenuDivider) ⇒ [<code>MenuItem</code>](#MenuItem)
+        * [.addSubMenu(name, id, position, relativeID)](#Menu+addSubMenu) ⇒ [<code>Menu</code>](#Menu)
         * [.removeSubMenu(subMenuID)](#Menu+removeSubMenu)
         * [.closeSubMenu()](#Menu+closeSubMenu)
     * _static_
@@ -30,12 +214,30 @@ const Menus = brackets.getModule("command/Menus")
 <a name="new_ContextMenu_new"></a>
 
 ### new ContextMenu()
-Represents a context menu that can open at a specific location in the UI.Clients should not create this object directly and should instead use registerContextMenu()to create new ContextMenu objects.Context menus in brackets may be HTML-based or native so clients should not reach intothe HTML and should instead manipulate ContextMenus through the API.Events:- beforeContextMenuOpen- beforeContextMenuClose
+Represents a context menu that can open at a specific location in the UI.
+
+Clients should not create this object directly and should instead use registerContextMenu()
+to create new ContextMenu objects.
+
+Context menus in brackets may be HTML-based or native so clients should not reach into
+the HTML and should instead manipulate ContextMenus through the API.
+
+Events:
+- beforeContextMenuOpen
+- beforeContextMenuClose
 
 <a name="ContextMenu+open"></a>
 
 ### contextMenu.open(mouseOrLocation)
-Displays the ContextMenu at the specified location and dispatches the"beforeContextMenuOpen" event or "beforeSubMenuOpen" event (for submenus).The menu location may be adjusted to prevent clipping by the browser window.All other menus and ContextMenus will be closed before a new menuwill be closed before a new menu is shown (if the new menu is nota submenu).In case of submenus, the parentMenu of the submenu will not be closed when thesub menu is open.
+Displays the ContextMenu at the specified location and dispatches the
+"beforeContextMenuOpen" event or "beforeSubMenuOpen" event (for submenus).
+The menu location may be adjusted to prevent clipping by the browser window.
+All other menus and ContextMenus will be closed before a new menu
+will be closed before a new menu is shown (if the new menu is not
+a submenu).
+
+In case of submenus, the parentMenu of the submenu will not be closed when the
+sub menu is open.
 
 **Kind**: instance method of [<code>ContextMenu</code>](#ContextMenu)  
 
@@ -55,35 +257,11 @@ Closes the context menu.
 Detect if current context menu is already open
 
 **Kind**: instance method of [<code>ContextMenu</code>](#ContextMenu)  
-<a name="Menu+_getMenuItemForCommand"></a>
-
-### contextMenu.\_getMenuItemForCommand(command) ⇒ <code>HTMLLIElement</code>
-Determine MenuItem in this Menu, that has the specified command
-
-**Kind**: instance method of [<code>ContextMenu</code>](#ContextMenu)  
-**Returns**: <code>HTMLLIElement</code> - menu item list element  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| command | <code>Command</code> | the command to search for. |
-
-<a name="Menu+_getRelativeMenuItem"></a>
-
-### contextMenu.\_getRelativeMenuItem(relativeID, position) ⇒ <code>HTMLLIElement</code>
-Determine relative MenuItem
-
-**Kind**: instance method of [<code>ContextMenu</code>](#ContextMenu)  
-**Returns**: <code>HTMLLIElement</code> - menu item list element  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| relativeID | <code>string</code> | id of command (future: sub-menu). |
-| position | <code>string</code> | only needed when relativeID is a MenuSection |
-
 <a name="Menu+removeMenuItem"></a>
 
 ### contextMenu.removeMenuItem(command)
-Removes the specified menu item from this Menu. Key bindings are unaffected; use KeyBindingManagerdirectly to remove key bindings if desired.
+Removes the specified menu item from this Menu. Key bindings are unaffected; use KeyBindingManager
+directly to remove key bindings if desired.
 
 **Kind**: instance method of [<code>ContextMenu</code>](#ContextMenu)  
 
@@ -104,11 +282,21 @@ Removes the specified menu divider from this Menu.
 
 <a name="Menu+addMenuItem"></a>
 
-### contextMenu.addMenuItem(command, [keyBindings], [position], [relativeID], [options]) ⇒ [<code>MenuItem</code>](#new_MenuItem_new)
-Adds a new menu item with the specified id and display text. The insertion position isspecified via the relativeID and position arguments which describe a positionrelative to another MenuItem or MenuGroup. It is preferred that plug-insinsert new  MenuItems relative to a menu section rather than a specificMenuItem (see Menu Section Constants).TODO: Sub-menus are not yet supported, but when they are implemented this API willallow adding new MenuItems to sub-menus as well.Note, keyBindings are bound to Command objects not MenuItems. The provided keyBindings     will be bound to the supplied Command object rather than the MenuItem.
+### contextMenu.addMenuItem(command, [keyBindings], [position], [relativeID], [options]) ⇒ [<code>MenuItem</code>](#MenuItem)
+Adds a new menu item with the specified id and display text. The insertion position is
+specified via the relativeID and position arguments which describe a position
+relative to another MenuItem or MenuGroup. It is preferred that plug-ins
+insert new  MenuItems relative to a menu section rather than a specific
+MenuItem (see Menu Section Constants).
+
+TODO: Sub-menus are not yet supported, but when they are implemented this API will
+allow adding new MenuItems to sub-menus as well.
+
+Note, keyBindings are bound to Command objects not MenuItems. The provided keyBindings
+     will be bound to the supplied Command object rather than the MenuItem.
 
 **Kind**: instance method of [<code>ContextMenu</code>](#ContextMenu)  
-**Returns**: [<code>MenuItem</code>](#new_MenuItem_new) - the newly created MenuItem  
+**Returns**: [<code>MenuItem</code>](#MenuItem) - the newly created MenuItem  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -121,11 +309,11 @@ Adds a new menu item with the specified id and display text. The insertion posit
 
 <a name="Menu+addMenuDivider"></a>
 
-### contextMenu.addMenuDivider(position, relativeID) ⇒ [<code>MenuItem</code>](#new_MenuItem_new)
+### contextMenu.addMenuDivider(position, relativeID) ⇒ [<code>MenuItem</code>](#MenuItem)
 Inserts divider item in menu.
 
 **Kind**: instance method of [<code>ContextMenu</code>](#ContextMenu)  
-**Returns**: [<code>MenuItem</code>](#new_MenuItem_new) - the newly created divider  
+**Returns**: [<code>MenuItem</code>](#MenuItem) - the newly created divider  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -134,11 +322,22 @@ Inserts divider item in menu.
 
 <a name="Menu+addSubMenu"></a>
 
-### contextMenu.addSubMenu(name, id, position, relativeID) ⇒ [<code>Menu</code>](#new_Menu_new)
-Creates a new submenu and a menuItem and adds the menuItem of the submenuto the menu and returns the submenu.A submenu will have the same structure of a menu with a additional fieldparentMenuItem which has the reference of the submenu's parent menuItem.A submenu will raise the following events:- beforeSubMenuOpen- beforeSubMenuCloseNote, This function will create only a context submenu.TODO: Make this function work for Menus
+### contextMenu.addSubMenu(name, id, position, relativeID) ⇒ [<code>Menu</code>](#Menu)
+Creates a new submenu and a menuItem and adds the menuItem of the submenu
+to the menu and returns the submenu.
+
+A submenu will have the same structure of a menu with a additional field
+parentMenuItem which has the reference of the submenu's parent menuItem.
+A submenu will raise the following events:
+- beforeSubMenuOpen
+- beforeSubMenuClose
+
+Note, This function will create only a context submenu.
+
+TODO: Make this function work for Menus
 
 **Kind**: instance method of [<code>ContextMenu</code>](#ContextMenu)  
-**Returns**: [<code>Menu</code>](#new_Menu_new) - the newly created submenu  
+**Returns**: [<code>Menu</code>](#Menu) - the newly created submenu  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -150,7 +349,11 @@ Creates a new submenu and a menuItem and adds the menuItem of the submenuto the
 <a name="Menu+removeSubMenu"></a>
 
 ### contextMenu.removeSubMenu(subMenuID)
-Removes the specified submenu from this Menu.Note, this function will only remove context submenusTODO: Make this function work for Menus
+Removes the specified submenu from this Menu.
+
+Note, this function will only remove context submenus
+
+TODO: Make this function work for Menus
 
 **Kind**: instance method of [<code>ContextMenu</code>](#ContextMenu)  
 
@@ -167,69 +370,17 @@ Closes the submenu if the menu has a submenu open.
 <a name="ContextMenu.assignContextMenuToSelector"></a>
 
 ### ContextMenu.assignContextMenuToSelector()
-Associate a context menu to a DOM element.This static function take care of registering event handlers for the click eventlistener and passing the right "position" object to the Context#open method
+Associate a context menu to a DOM element.
+This static function take care of registering event handlers for the click event
+listener and passing the right "position" object to the Context#open method
 
 **Kind**: static method of [<code>ContextMenu</code>](#ContextMenu)  
-<a name="MenuSection"></a>
-
-## MenuSection
-Brackets Application Menu Section ConstantsIt is preferred that plug-ins specify the location of new MenuItemsin terms of a menu section rather than a specific MenuItem. This provideslooser coupling to Bracket's internal MenuItems and makes menu organizationmore semantic.Use these constants as the "relativeID" parameter when calling addMenuItem() andspecify a position of FIRST_IN_SECTION or LAST_IN_SECTION.Menu sections are denoted by dividers or the beginning/end of a menu
-
-**Kind**: global variable  
 <a name="DIVIDER"></a>
 
 ## DIVIDER
 Other constants
 
 **Kind**: global variable  
-<a name="menuMap"></a>
-
-## menuMap : <code>Object</code>
-Maps menuID's to Menu objects
-
-**Kind**: global variable  
-**Properties**
-
-| Name | Type | Description |
-| --- | --- | --- |
-| menuID | <code>Object.&lt;string, Menu&gt;</code> | A map of Menu IDs to Menu objects. |
-
-<a name="contextMenuMap"></a>
-
-## contextMenuMap : <code>Object</code>
-Maps contextMenuID's to ContextMenu objects
-
-**Kind**: global variable  
-**Properties**
-
-| Name | Type | Description |
-| --- | --- | --- |
-| contextMenuID | <code>Object.&lt;string, ContextMenu&gt;</code> | A map of ContextMenu IDs to ContextMenu objects. |
-
-<a name="menuItemMap"></a>
-
-## menuItemMap : <code>Object</code>
-Maps menuItemID's to MenuItem object
-
-**Kind**: global variable  
-**Properties**
-
-| Name | Type | Description |
-| --- | --- | --- |
-| menuItemID | <code>Object.&lt;string, MenuItem&gt;</code> | A map of MenuItem IDs to MenuItem objects. |
-
-<a name="subMenuItemMap"></a>
-
-## subMenuItemMap : <code>Object</code>
-Maps menuItemID's to ContextMenu objects
-
-**Kind**: global variable  
-**Properties**
-
-| Name | Type | Description |
-| --- | --- | --- |
-| menuItemId | <code>Object.&lt;string, ContextMenu&gt;</code> | A map of MenuItem IDs to ContextMenu objects. |
-
 <a name="AppMenuBar"></a>
 
 ## AppMenuBar : <code>enum</code>
@@ -265,15 +416,59 @@ Brackets Context Menu Constants
 | WORKING_SET_CONFIG_MENU | <code>string</code> | <code>&quot;workingset-configuration-menu&quot;</code> | 
 | SPLITVIEW_MENU | <code>string</code> | <code>&quot;splitview-menu&quot;</code> | 
 
+<a name="MenuSection"></a>
+
+## MenuSection : <code>enum</code>
+Brackets Application Menu Section Constants
+It is preferred that plug-ins specify the location of new MenuItems
+in terms of a menu section rather than a specific MenuItem. This provides
+looser coupling to Bracket's internal MenuItems and makes menu organization
+more semantic.
+Use these constants as the "relativeID" parameter when calling addMenuItem() and
+specify a position of FIRST_IN_SECTION or LAST_IN_SECTION.
+
+Menu sections are denoted by dividers or the beginning/end of a menu
+
+**Kind**: global enum  
+**Properties**
+
+| Name | Type | Default |
+| --- | --- | --- |
+| FILE_OPEN_CLOSE_COMMANDS | <code>string</code> | <code>&quot;{\&quot;sectionMarker\&quot;:\&quot;\&quot;}&quot;</code> | 
+| FILE_SAVE_COMMANDS | <code>string</code> | <code>&quot;{\&quot;sectionMarker\&quot;:\&quot;\&quot;}&quot;</code> | 
+| FILE_LIVE | <code>string</code> | <code>&quot;{\&quot;sectionMarker\&quot;:\&quot;\&quot;}&quot;</code> | 
+| FILE_SETTINGS | <code>string</code> | <code>&quot;{\&quot;sectionMarker\&quot;:\&quot;\&quot;}&quot;</code> | 
+| FILE_EXTENSION_MANAGER | <code>string</code> | <code>&quot;{\&quot;sectionMarker\&quot;:\&quot;\&quot;}&quot;</code> | 
+| EDIT_UNDO_REDO_COMMANDS | <code>string</code> | <code>&quot;{\&quot;sectionMarker\&quot;:\&quot;\&quot;}&quot;</code> | 
+| EDIT_TEXT_COMMANDS | <code>string</code> | <code>&quot;{\&quot;sectionMarker\&quot;:\&quot;\&quot;}&quot;</code> | 
+| EDIT_SELECTION_COMMANDS | <code>string</code> | <code>&quot;{\&quot;sectionMarker\&quot;:\&quot;\&quot;}&quot;</code> | 
+| EDIT_MODIFY_SELECTION | <code>string</code> | <code>&quot;{\&quot;sectionMarker\&quot;:\&quot;\&quot;}&quot;</code> | 
+| EDIT_COMMENT_SELECTION | <code>string</code> | <code>&quot;{\&quot;sectionMarker\&quot;:\&quot;\&quot;}&quot;</code> | 
+| EDIT_CODE_HINTS_COMMANDS | <code>string</code> | <code>&quot;{\&quot;sectionMarker\&quot;:\&quot;\&quot;}&quot;</code> | 
+| EDIT_TOGGLE_OPTIONS | <code>string</code> | <code>&quot;{\&quot;sectionMarker\&quot;:\&quot;\&quot;}&quot;</code> | 
+| FIND_FIND_COMMANDS | <code>string</code> | <code>&quot;{\&quot;sectionMarker\&quot;:\&quot;\&quot;}&quot;</code> | 
+| FIND_FIND_IN_COMMANDS | <code>string</code> | <code>&quot;{\&quot;sectionMarker\&quot;:\&quot;\&quot;}&quot;</code> | 
+| FIND_REPLACE_COMMANDS | <code>string</code> | <code>&quot;{\&quot;sectionMarker\&quot;:\&quot;\&quot;}&quot;</code> | 
+| VIEW_HIDESHOW_COMMANDS | <code>string</code> | <code>&quot;{\&quot;sectionMarker\&quot;:\&quot;\&quot;}&quot;</code> | 
+| VIEW_FONTSIZE_COMMANDS | <code>string</code> | <code>&quot;{\&quot;sectionMarker\&quot;:\&quot;\&quot;}&quot;</code> | 
+| VIEW_TOGGLE_OPTIONS | <code>string</code> | <code>&quot;{\&quot;sectionMarker\&quot;:\&quot;\&quot;}&quot;</code> | 
+| NAVIGATE_GOTO_COMMANDS | <code>string</code> | <code>&quot;{\&quot;sectionMarker\&quot;:\&quot;\&quot;}&quot;</code> | 
+| NAVIGATE_DOCUMENTS_COMMANDS | <code>string</code> | <code>&quot;{\&quot;sectionMarker\&quot;:\&quot;\&quot;}&quot;</code> | 
+| NAVIGATE_OS_COMMANDS | <code>string</code> | <code>&quot;{\&quot;sectionMarker\&quot;:\&quot;\&quot;}&quot;</code> | 
+| NAVIGATE_QUICK_EDIT_COMMANDS | <code>string</code> | <code>&quot;{\&quot;sectionMarker\&quot;:\&quot;\&quot;}&quot;</code> | 
+| NAVIGATE_QUICK_DOCS_COMMANDS | <code>string</code> | <code>&quot;{\&quot;sectionMarker\&quot;:\&quot;\&quot;}&quot;</code> | 
+
 <a name="BEFORE"></a>
 
 ## BEFORE : <code>enum</code>
-Insertion position constantsUsed by addMenu(), addMenuItem(), and addSubMenu() tospecify the relative position of a newly created menu object
+Insertion position constants
+Used by addMenu(), addMenuItem(), and addSubMenu() to
+specify the relative position of a newly created menu object
 
 **Kind**: global enum  
 <a name="getMenu"></a>
 
-## getMenu(id) ⇒ [<code>Menu</code>](#new_Menu_new)
+## getMenu(id) ⇒ [<code>Menu</code>](#Menu)
 Retrieves the Menu object for the corresponding id.
 
 **Kind**: global function  
@@ -314,11 +509,11 @@ Removes the attached event listeners from the corresponding object.
 
 | Param | Type |
 | --- | --- |
-| menuItem | [<code>MenuItem</code>](#new_MenuItem_new) | 
+| menuItem | [<code>MenuItem</code>](#MenuItem) | 
 
 <a name="getMenuItem"></a>
 
-## getMenuItem(id) ⇒ [<code>MenuItem</code>](#new_MenuItem_new)
+## getMenuItem(id) ⇒ [<code>MenuItem</code>](#MenuItem)
 Retrieves the MenuItem object for the corresponding id.
 
 **Kind**: global function  
@@ -333,6 +528,17 @@ Retrieves the MenuItem object for the corresponding id.
 Closes all menus that are open
 
 **Kind**: global function  
+<a name="openMenu"></a>
+
+## openMenu(id) ⇒ <code>null</code>
+Opens a menu with the given id
+
+**Kind**: global function  
+
+| Param |
+| --- |
+| id | 
+
 <a name="getOpenMenu"></a>
 
 ## getOpenMenu() ⇒ <code>null</code> \| <code>string</code>
@@ -341,11 +547,11 @@ returns the currently open menu id if present or null
 **Kind**: global function  
 <a name="addMenu"></a>
 
-## addMenu(name, id, position, relativeID) ⇒ [<code>Menu</code>](#new_Menu_new)
+## addMenu(name, id, position, relativeID) ⇒ [<code>Menu</code>](#Menu)
 Adds a top-level menu to the application menu bar which may be native or HTML-based.
 
 **Kind**: global function  
-**Returns**: [<code>Menu</code>](#new_Menu_new) - the newly created Menu  
+**Returns**: [<code>Menu</code>](#Menu) - the newly created Menu  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -368,7 +574,24 @@ Removes a top-level menu from the application menu bar which may be native or HT
 <a name="registerContextMenu"></a>
 
 ## registerContextMenu(id) ⇒ [<code>ContextMenu</code>](#ContextMenu)
-Registers new context menu with Brackets.Extensions should generally use the predefined context menus built into Brackets. Use thisAPI to add a new context menu to UI that is specific to an extension.After registering  a new context menu clients should:     - use addMenuItem() to add items to the context menu     - call open() to show the context menu.     For example:     ```js     $("#my_ID").contextmenu(function (e) {         if (e.which === 3) {             my_cmenu.open(e);         }     });     ```To make menu items be contextual to things like selection, listen for the "beforeContextMenuOpen"to make changes to Command objects before the context menu is shown. MenuItems are views ofCommands, which control a MenuItem's name, enabled state, and checked state.
+Registers new context menu with Brackets.
+Extensions should generally use the predefined context menus built into Brackets. Use this
+API to add a new context menu to UI that is specific to an extension.
+
+After registering  a new context menu clients should:
+     - use addMenuItem() to add items to the context menu
+     - call open() to show the context menu.
+     For example:
+     ```js
+     $("#my_ID").contextmenu(function (e) {
+         if (e.which === 3) {
+             my_cmenu.open(e);
+         }
+     });
+     ```
+To make menu items be contextual to things like selection, listen for the "beforeContextMenuOpen"
+to make changes to Command objects before the context menu is shown. MenuItems are views of
+Commands, which control a MenuItem's name, enabled state, and checked state.
 
 **Kind**: global function  
 **Returns**: [<code>ContextMenu</code>](#ContextMenu) - the newly created context menu  
@@ -377,3 +600,27 @@ Registers new context menu with Brackets.Extensions should generally use the pr
 | --- | --- | --- |
 | id | <code>string</code> | unique identifier for context menu.      Core context menus in Brackets use a simple title as an id.      Extensions should use the following format: "author.myextension.mycontextmenu name" |
 
+<a name="event_EVENT_BEFORE_CONTEXT_MENU_OPEN"></a>
+
+## "EVENT_BEFORE_CONTEXT_MENU_OPEN"
+Event triggered before the context menu opens.
+
+**Kind**: event emitted  
+<a name="event_EVENT_BEFORE_CONTEXT_MENU_CLOSE"></a>
+
+## "EVENT_BEFORE_CONTEXT_MENU_CLOSE"
+Event triggered before the context menu closes.
+
+**Kind**: event emitted  
+<a name="event_EVENT_BEFORE_SUB_MENU_OPEN"></a>
+
+## "EVENT_BEFORE_SUB_MENU_OPEN"
+Event triggered before a sub-menu opens.
+
+**Kind**: event emitted  
+<a name="event_EVENT_BEFORE_SUB_MENU_CLOSE"></a>
+
+## "EVENT_BEFORE_SUB_MENU_CLOSE"
+Event triggered before a sub-menu closes.
+
+**Kind**: event emitted  

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -75,10 +75,30 @@ define(function (require, exports, module) {
         SPLITVIEW_MENU: "splitview-menu"
     };
 
-    const EVENT_BEFORE_CONTEXT_MENU_OPEN = "beforeContextMenuOpen",
-        EVENT_BEFORE_CONTEXT_MENU_CLOSE = "beforeContextMenuClose",
-        EVENT_BEFORE_SUB_MENU_OPEN = "beforeSubMenuOpen",
-        EVENT_BEFORE_SUB_MENU_CLOSE = "beforeSubMenuClose";
+    /**
+     * Event triggered before the context menu opens.
+     * @event EVENT_BEFORE_CONTEXT_MENU_OPEN
+     */
+    const EVENT_BEFORE_CONTEXT_MENU_OPEN = "beforeContextMenuOpen";
+
+    /**
+     * Event triggered before the context menu closes.
+     * @event EVENT_BEFORE_CONTEXT_MENU_CLOSE
+     */
+    const EVENT_BEFORE_CONTEXT_MENU_CLOSE = "beforeContextMenuClose";
+
+    /**
+     * Event triggered before a sub-menu opens.
+     * @event EVENT_BEFORE_SUB_MENU_OPEN
+     */
+    const EVENT_BEFORE_SUB_MENU_OPEN = "beforeSubMenuOpen";
+
+    /**
+     * Event triggered before a sub-menu closes.
+     * @event EVENT_BEFORE_SUB_MENU_CLOSE
+     */
+    const EVENT_BEFORE_SUB_MENU_CLOSE = "beforeSubMenuClose";
+
 
     /**
      * Brackets Application Menu Section Constants
@@ -90,6 +110,8 @@ define(function (require, exports, module) {
      * specify a position of FIRST_IN_SECTION or LAST_IN_SECTION.
      *
      * Menu sections are denoted by dividers or the beginning/end of a menu
+     *
+     * @enum {string}
      */
     let MenuSection = {
         // Menu Section                     Command ID to mark the section
@@ -129,7 +151,7 @@ define(function (require, exports, module) {
      * specify the relative position of a newly created menu object
      * @enum {string}
      */
-    let BEFORE = "before",
+    const BEFORE = "before",
         AFTER = "after",
         FIRST = "first",
         LAST = "last",
@@ -146,6 +168,7 @@ define(function (require, exports, module) {
      * Maps menuID's to Menu objects
      * @type {Object} menuMap
      * @property {Object.<string, Menu>} menuID - A map of Menu IDs to Menu objects.
+     * @private
      */
     let menuMap = {};
 
@@ -153,6 +176,7 @@ define(function (require, exports, module) {
      * Maps contextMenuID's to ContextMenu objects
      * @type {Object} contextMenuMap
      * @property {Object.<string, ContextMenu>} contextMenuID - A map of ContextMenu IDs to ContextMenu objects.
+     * @private
      */
     let contextMenuMap = {};
 
@@ -160,6 +184,7 @@ define(function (require, exports, module) {
      * Maps menuItemID's to MenuItem object
      * @type {Object} menuItemMap
      * @property {Object.<string, MenuItem>} menuItemID - A map of MenuItem IDs to MenuItem objects.
+     * @private
      */
     let menuItemMap = {};
 
@@ -167,6 +192,7 @@ define(function (require, exports, module) {
      * Maps menuItemID's to ContextMenu objects
      * @type {Object} subMenuItemMap
      * @property {Object.<string, ContextMenu>} menuItemId - A map of MenuItem IDs to ContextMenu objects.
+     * @private
      */
     let subMenuItemMap = {};
 
@@ -316,7 +342,6 @@ define(function (require, exports, module) {
      * name, enabled, and checked state of a MenuItem. The MenuItem will update automatically
      *
      * @constructor
-     * @private
      *
      * @param {string} id
      * @param {string|Command} command - the Command this MenuItem will reflect.
@@ -358,7 +383,6 @@ define(function (require, exports, module) {
      * the Menu API to query and modify menus.
      *
      * @constructor
-     * @private
      *
      * @param {string} id
      */
@@ -374,6 +398,7 @@ define(function (require, exports, module) {
      * Determine MenuItem in this Menu, that has the specified command
      *
      * @param {Command} command - the command to search for.
+     * @private
      * @return {?HTMLLIElement} menu item list element
      */
     Menu.prototype._getMenuItemForCommand = function (command) {
@@ -393,6 +418,7 @@ define(function (require, exports, module) {
      * @param {?string} relativeID - id of command (future: sub-menu).
      * @param {?string} position - only needed when relativeID is a MenuSection
      * @return {?HTMLLIElement} menu item list element
+     * @private
      */
     Menu.prototype._getRelativeMenuItem = function (relativeID, position) {
         let $relativeElement;
@@ -950,6 +976,7 @@ define(function (require, exports, module) {
 
     /**
      * Synchronizes MenuItem checked state with underlying Command checked state
+     * @private
      */
     MenuItem.prototype._checkedChanged = function () {
         let checked = !!this._command.getChecked();
@@ -968,6 +995,7 @@ define(function (require, exports, module) {
 
     /**
      * Synchronizes MenuItem enabled state with underlying Command enabled state
+     * @private
      */
     MenuItem.prototype._enabledChanged = function () {
         if (this.isNative) {
@@ -989,6 +1017,7 @@ define(function (require, exports, module) {
 
     /**
      * Synchronizes MenuItem name with underlying Command name
+     * @private
      */
     MenuItem.prototype._nameChanged = function () {
         if (this.isNative) {
@@ -1068,6 +1097,11 @@ define(function (require, exports, module) {
         }
     }
 
+    /**
+     * Opens a menu with the given id
+     * @param id
+     * @returns {null}
+     */
     function openMenu(id) {
         if (!id) {
             id = lastOpenedMenuID;

--- a/src/extensionsIntegrated/Phoenix/guided-tour.js
+++ b/src/extensionsIntegrated/Phoenix/guided-tour.js
@@ -37,7 +37,7 @@ define(function (require, exports, module) {
 
     // All popup notifications will show immediately on boot, we don't want to interrupt user amidst his work
     // by showing it at a later point in time.
-    const GENERAL_SURVEY_TIME = 600000, // 10 min
+    const GENERAL_SURVEY_TIME = 1200000, // 20 min
         POWER_USER_SURVEY_TIME = 10000, // 10 seconds to allow the survey to preload, but not
         // enough time to break user workflow
         ONE_MONTH_IN_DAYS = 30,


### PR DESCRIPTION
The new doc infrastructure does not work the same as the old docs framework, so made the following changes:

1. All APIS declared `exports.*` is the public API and it should come in the docs.
2. All APIs starting with an _ is a private api, even if its exported, and added `@private` tag to make it not appear in API docs. 
3. Exported module EVENT_NAME constants should appear in docs.
4. ENUM declaration for exported named constants to appear in docs.
5. Some public APIs wont come up in docs if it doesnt have a jsdoc declaration, Eg. see `openMenu` api in this PR. so added a jsdoc section to missing public APIs to appear in docs.