### PR TITLE
chore: move line:col status to right to accommodate plugin status bar tab panels

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -854,10 +854,6 @@
         <!-- View Panes are programatically created here -->
         </div>
         <div id="status-bar" class="statusbar no-focus">
-            <div id="status-info" class="info" >
-                <div id="status-cursor"></div>
-                <div id="status-file"></div>
-            </div>
             <div id="status-indicators" class="indicators">
                 <div id="status-indent">
                     <div id="indent-type"></div>
@@ -868,6 +864,10 @@
                 <div id="status-language"></div>
                 <div id="status-encoding"></div>
                 <div id="status-overwrite"></div>
+                <div id="status-info" class="info" >
+                    <div id="status-cursor"></div>
+                    <div id="status-file"></div>
+                </div>
                 <div id="status-tasks" class="forced-hidden global-indicator">
                     <div class="spinner spin"></div>
                 </div>

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -389,11 +389,15 @@ define({
      * StatusBar strings
      */
     "STATUSBAR_CURSOR_POSITION": "Line {0}, Column {1}",
+    "STATUSBAR_CURSOR_POSITION_SHORT": "{0} : {1}",
+    "STATUSBAR_CURSOR_GOTO": "Click to Go To another :Line",
+    "STATUSBAR_SELECTION_SHORT": " \u2014 Sel {0}",
     "STATUSBAR_SELECTION_CH_SINGULAR": " \u2014 Selected {0} column",
     "STATUSBAR_SELECTION_CH_PLURAL": " \u2014 Selected {0} columns",
     "STATUSBAR_SELECTION_LINE_SINGULAR": " \u2014 Selected {0} line",
     "STATUSBAR_SELECTION_LINE_PLURAL": " \u2014 Selected {0} lines",
-    "STATUSBAR_SELECTION_MULTIPLE": " \u2014 {0} selections",
+    "STATUSBAR_SELECTION_MULTIPLE": " \u2014 {0} Multi Cursor selections",
+    "STATUSBAR_SELECTION_MULTIPLE_SHORT": " \u2014 Mul {0}",
     "STATUSBAR_INDENT_TOOLTIP_SPACES": "Click to switch indentation to spaces",
     "STATUSBAR_INDENT_TOOLTIP_TABS": "Click to switch indentation to tabs",
     "STATUSBAR_INDENT_SIZE_TOOLTIP_SPACES": "Click to change number of spaces used when indenting",

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -303,8 +303,6 @@ a, img {
 
 #status-info {
     color: @bc-text;
-    left: 10px;
-    position: absolute;
     white-space: nowrap;
 
     .dark & {


### PR DESCRIPTION
### Default
![image](https://github.com/user-attachments/assets/a0fe33da-a7ce-481c-8fb7-960d029ef941)
### Hover to get detailed description instead of shorthand
* also added functionality so that on clicking the section, the goto line command is triggered now.
![image](https://github.com/user-attachments/assets/2c2d1b5a-27ab-4c76-8b37-c12170c0ae93)
### When some lines are selected
![image](https://github.com/user-attachments/assets/a61eb320-8e4a-450c-85de-151d08467de6)
### When there are multiple cursors
![image](https://github.com/user-attachments/assets/13dfad5a-7bd7-40d9-97a8-4ef13be3ab91)
