### PR TITLE
docs: refine API docs for files in Document dir

### DIFF
--- a/docs/API-Reference/document/Document.md
+++ b/docs/API-Reference/document/Document.md
@@ -11,7 +11,6 @@ const Document = brackets.getModule("document/Document")
 * [Document](#Document)
     * [new Document(file, initialTimestamp, rawText)](#new_Document_new)
     * _instance_
-        * [._refCount](#Document+_refCount)
         * [.file](#Document+file) : <code>File</code>
         * [.language](#Document+language) : <code>Language</code>
         * [.isDirty](#Document+isDirty) : <code>boolean</code>
@@ -19,19 +18,8 @@ const Document = brackets.getModule("document/Document")
         * [.diskTimestamp](#Document+diskTimestamp) : <code>Date</code>
         * [.lastChangeTimestamp](#Document+lastChangeTimestamp) : <code>number</code>
         * [.keepChangesTime](#Document+keepChangesTime) : <code>Number</code>
-        * [._refreshInProgress](#Document+_refreshInProgress) : <code>boolean</code>
-        * [._text](#Document+_text) : <code>string</code>
-        * [._masterEditor](#Document+_masterEditor) : <code>Editor</code>
-        * [._lineEndings](#Document+_lineEndings) : <code>FileUtils.LINE\_ENDINGS\_CRLF</code> \| <code>FileUtils.LINE\_ENDINGS\_LF</code>
         * [.addRef()](#Document+addRef)
         * [.releaseRef()](#Document+releaseRef)
-        * [._makeEditable(masterEditor)](#Document+_makeEditable)
-        * [._makeNonEditable()](#Document+_makeNonEditable)
-        * [._toggleMasterEditor()](#Document+_toggleMasterEditor)
-        * [._checkAssociatedEditorForPane(paneId)](#Document+_checkAssociatedEditorForPane) ⇒ <code>Editor</code>
-        * [._disassociateEditor()](#Document+_disassociateEditor)
-        * [._associateEditor()](#Document+_associateEditor)
-        * [._ensureMasterEditor()](#Document+_ensureMasterEditor)
         * [.getText([useOriginalLineEndings])](#Document+getText) ⇒ <code>string</code>
         * [.getSelectedText([useOriginalLineEndings], [allSelections])](#Document+getSelectedText) ⇒ <code>string</code> \| <code>null</code>
         * [.setText(text)](#Document+setText)
@@ -44,8 +32,6 @@ const Document = brackets.getModule("document/Document")
         * [.adjustPosForChange(pos, textLines, start, end)](#Document+adjustPosForChange) ⇒ <code>Object</code>
         * [.doMultipleEdits(edits, origin)](#Document+doMultipleEdits) ⇒ <code>Object</code>
         * [.getLanguage()](#Document+getLanguage) ⇒ <code>Language</code>
-        * [._updateLanguage()](#Document+_updateLanguage)
-        * [._notifyFilePathChanged()](#Document+_notifyFilePathChanged)
         * [.isUntitled()](#Document+isUntitled) ⇒ <code>boolean</code>
         * [.reload()](#Document+reload) ⇒ <code>promise</code>
     * _static_
@@ -93,13 +79,6 @@ __languageChanged__ -- When the value of getLanguage() has changed. 2nd argument
 | initialTimestamp | <code>Date</code> | File's timestamp when we read it off disk. |
 | rawText | <code>string</code> | Text content of the file. |
 
-<a name="Document+_refCount"></a>
-
-### document.\_refCount
-Number of clients who want this Document to stay alive. The Document is listed in
-DocumentManager._openDocuments whenever refCount > 0.
-
-**Kind**: instance property of [<code>Document</code>](#Document)  
 <a name="Document+file"></a>
 
 ### document.file : <code>File</code>
@@ -150,33 +129,6 @@ keep changes.
 Note that this is a time as returned by Date.getTime(), not a Date object.
 
 **Kind**: instance property of [<code>Document</code>](#Document)  
-<a name="Document+_refreshInProgress"></a>
-
-### document.\_refreshInProgress : <code>boolean</code>
-True while refreshText() is in progress and change notifications shouldn't trip the dirty flag.
-
-**Kind**: instance property of [<code>Document</code>](#Document)  
-<a name="Document+_text"></a>
-
-### document.\_text : <code>string</code>
-The text contents of the file, or null if our backing model is _masterEditor.
-
-**Kind**: instance property of [<code>Document</code>](#Document)  
-<a name="Document+_masterEditor"></a>
-
-### document.\_masterEditor : <code>Editor</code>
-Editor object representing the full-size editor UI for this document. May be null if Document
-has not yet been modified or been the currentDocument; in that case, our backing model is the
-string _text.
-
-**Kind**: instance property of [<code>Document</code>](#Document)  
-<a name="Document+_lineEndings"></a>
-
-### document.\_lineEndings : <code>FileUtils.LINE\_ENDINGS\_CRLF</code> \| <code>FileUtils.LINE\_ENDINGS\_LF</code>
-The content's line-endings style. If a Document is created on empty text, or text with
-inconsistent line endings, defaults to the current platform's standard endings.
-
-**Kind**: instance property of [<code>Document</code>](#Document)  
 <a name="Document+addRef"></a>
 
 ### document.addRef()
@@ -187,68 +139,6 @@ Add a ref to keep this Document alive
 
 ### document.releaseRef()
 Remove a ref that was keeping this Document alive
-
-**Kind**: instance method of [<code>Document</code>](#Document)  
-<a name="Document+_makeEditable"></a>
-
-### document.\_makeEditable(masterEditor)
-Attach a backing Editor to the Document, enabling setText() to be called. Assumes Editor has
-already been initialized with the value of getText(). ONLY Editor should call this (and only
-when EditorManager has told it to act as the master editor).
-
-**Kind**: instance method of [<code>Document</code>](#Document)  
-
-| Param | Type |
-| --- | --- |
-| masterEditor | <code>Editor</code> | 
-
-<a name="Document+_makeNonEditable"></a>
-
-### document.\_makeNonEditable()
-Detach the backing Editor from the Document, disallowing setText(). The text content is
-stored back onto _text so other Document clients continue to have read-only access. ONLY
-Editor.destroy() should call this.
-
-**Kind**: instance method of [<code>Document</code>](#Document)  
-<a name="Document+_toggleMasterEditor"></a>
-
-### document.\_toggleMasterEditor()
-Toggles the master editor which has gained focus from a pool of full editors
-To be used internally by Editor only
-
-**Kind**: instance method of [<code>Document</code>](#Document)  
-<a name="Document+_checkAssociatedEditorForPane"></a>
-
-### document.\_checkAssociatedEditorForPane(paneId) ⇒ <code>Editor</code>
-Checks and returns if a full editor exists for the provided pane attached to this document
-
-**Kind**: instance method of [<code>Document</code>](#Document)  
-**Returns**: <code>Editor</code> - Attached editor bound to the provided pane id  
-
-| Param | Type |
-| --- | --- |
-| paneId | <code>String</code> | 
-
-<a name="Document+_disassociateEditor"></a>
-
-### document.\_disassociateEditor()
-Disassociates an editor from this document if present in the associated editor list
-To be used internally by Editor only when destroyed and not the current master editor for the document
-
-**Kind**: instance method of [<code>Document</code>](#Document)  
-<a name="Document+_associateEditor"></a>
-
-### document.\_associateEditor()
-Aassociates a full editor to this document
-To be used internally by Editor only when pane marking happens
-
-**Kind**: instance method of [<code>Document</code>](#Document)  
-<a name="Document+_ensureMasterEditor"></a>
-
-### document.\_ensureMasterEditor()
-Guarantees that _masterEditor is non-null. If needed, asks EditorManager to create a new master
-editor bound to this Document (which in turn causes Document._makeEditable() to be called).
-Should ONLY be called by Editor and Document.
 
 **Kind**: instance method of [<code>Document</code>](#Document)  
 <a name="Document+getText"></a>
@@ -423,18 +313,6 @@ The language returned is based on the file extension.
 
 **Kind**: instance method of [<code>Document</code>](#Document)  
 **Returns**: <code>Language</code> - An object describing the language used in this document  
-<a name="Document+_updateLanguage"></a>
-
-### document.\_updateLanguage()
-Updates the language to match the current mapping given by LanguageManager
-
-**Kind**: instance method of [<code>Document</code>](#Document)  
-<a name="Document+_notifyFilePathChanged"></a>
-
-### document.\_notifyFilePathChanged()
-Called when Document.file has been modified (due to a rename)
-
-**Kind**: instance method of [<code>Document</code>](#Document)  
 <a name="Document+isUntitled"></a>
 
 ### document.isUntitled() ⇒ <code>boolean</code>
@@ -455,10 +333,3 @@ Reloads the document from FileSystem
 Normalizes line endings the same way CodeMirror would
 
 **Kind**: static method of [<code>Document</code>](#Document)  
-<a name="oneOrEach"></a>
-
-## oneOrEach()
-Like _.each(), but if given a single item not in an array, acts as
-if it were an array containing just that item.
-
-**Kind**: global function  

--- a/docs/API-Reference/document/DocumentManager.md
+++ b/docs/API-Reference/document/DocumentManager.md
@@ -6,43 +6,109 @@ const DocumentManager = brackets.getModule("document/DocumentManager")
 <a name="_"></a>
 
 ## \_
-DocumentManager maintains a list of currently 'open' Documents. The DocumentManager is responsiblefor coordinating document operations and dispatching certain document events.Document is the model for a file's contents; it dispatches events whenever those contents change.To transiently inspect a file's content, simply get a Document and call getText() on it. However,to be notified of Document changes or to modify a Document, you MUST call addRef() to ensure theDocument instance 'stays alive' and is shared by all other who read/modify that file. ('Open'Documents are all Documents that are 'kept alive', i.e. have ref count > 0).To get a Document, call getDocumentForPath(); never new up a Document yourself.Secretly, a Document may use an Editor instance to act as the model for its internal state. (Thisis unavoidable because CodeMirror does not separate its model from its UI). Documents are notmodifiable until they have a backing 'master Editor'. Creation of the backing Editor is owned byEditorManager. A Document only gets a backing Editor if it opened in an editor.A non-modifiable Document may still dispatch change notifications, if the Document was changedexternally on disk.Aside from the text content, Document tracks a few pieces of metadata - notably, whether there areany unsaved changes.This module dispatches several events:   - dirtyFlagChange -- When any Document's isDirty flag changes. The 2nd arg to the listener is the     Document whose flag changed.   - documentSaved -- When a Document's changes have been saved. The 2nd arg to the listener is the     Document that has been saved.   - documentRefreshed -- When a Document's contents have been reloaded from disk. The 2nd arg to the     listener is the Document that has been refreshed.NOTE: WorkingSet APIs have been deprecated and have moved to MainViewManager as WorkingSet APIs      Some WorkingSet APIs that have been identified as being used by 3rd party extensions will      emit deprecation warnings and call the WorkingSet APIS to maintain backwards compatibility   - currentDocumentChange -- Deprecated: use EditorManager activeEditorChange (which covers all editors,     not just full-sized editors) or MainViewManager currentFileChange (which covers full-sized views     only, but is also triggered for non-editor views e.g. image files).   - fileNameChange -- When the name of a file or folder has changed. The 2nd arg is the old name.     The 3rd arg is the new name.  Generally, however, file objects have already been changed by the     time this event is dispatched so code that relies on matching the filename to a file object     will need to compare the newname.   - pathDeleted -- When a file or folder has been deleted. The 2nd arg is the path that was deleted.To listen for events, do something like this: (see EventDispatcher for details on this pattern)   DocumentManager.on("eventname", handler);Document objects themselves also dispatch some events - see Document docs for details.
+DocumentManager maintains a list of currently 'open' Documents. The DocumentManager is responsible
+for coordinating document operations and dispatching certain document events.
+
+Document is the model for a file's contents; it dispatches events whenever those contents change.
+To transiently inspect a file's content, simply get a Document and call getText() on it. However,
+to be notified of Document changes or to modify a Document, you MUST call addRef() to ensure the
+Document instance 'stays alive' and is shared by all other who read/modify that file. ('Open'
+Documents are all Documents that are 'kept alive', i.e. have ref count > 0).
+
+To get a Document, call getDocumentForPath(); never new up a Document yourself.
+
+Secretly, a Document may use an Editor instance to act as the model for its internal state. (This
+is unavoidable because CodeMirror does not separate its model from its UI). Documents are not
+modifiable until they have a backing 'master Editor'. Creation of the backing Editor is owned by
+EditorManager. A Document only gets a backing Editor if it opened in an editor.
+
+A non-modifiable Document may still dispatch change notifications, if the Document was changed
+externally on disk.
+
+Aside from the text content, Document tracks a few pieces of metadata - notably, whether there are
+any unsaved changes.
+
+This module dispatches several events:
+
+   - dirtyFlagChange -- When any Document's isDirty flag changes. The 2nd arg to the listener is the
+     Document whose flag changed.
+   - documentSaved -- When a Document's changes have been saved. The 2nd arg to the listener is the
+     Document that has been saved.
+   - documentRefreshed -- When a Document's contents have been reloaded from disk. The 2nd arg to the
+     listener is the Document that has been refreshed.
+
+NOTE: WorkingSet APIs have been deprecated and have moved to MainViewManager as WorkingSet APIs
+      Some WorkingSet APIs that have been identified as being used by 3rd party extensions will
+      emit deprecation warnings and call the WorkingSet APIS to maintain backwards compatibility
+
+   - currentDocumentChange -- Deprecated: use EditorManager activeEditorChange (which covers all editors,
+     not just full-sized editors) or MainViewManager currentFileChange (which covers full-sized views
+     only, but is also triggered for non-editor views e.g. image files).
+
+   - fileNameChange -- When the name of a file or folder has changed. The 2nd arg is the old name.
+     The 3rd arg is the new name.  Generally, however, file objects have already been changed by the
+     time this event is dispatched so code that relies on matching the filename to a file object
+     will need to compare the newname.
+
+   - pathDeleted -- When a file or folder has been deleted. The 2nd arg is the path that was deleted.
+
+To listen for events, do something like this: (see EventDispatcher for details on this pattern)
+   DocumentManager.on("eventname", handler);
+
+Document objects themselves also dispatch some events - see Document docs for details.
 
 **Kind**: global variable  
+<a name="EVENT_AFTER_DOCUMENT_CREATE"></a>
+
+## EVENT\_AFTER\_DOCUMENT\_CREATE : <code>string</code>
+Event triggered after a document is created.
+
+**Kind**: global constant  
+<a name="EVENT_PATH_DELETED"></a>
+
+## EVENT\_PATH\_DELETED : <code>string</code>
+Event triggered when a file or folder path is deleted.
+
+**Kind**: global constant  
+<a name="EVENT_FILE_NAME_CHANGE"></a>
+
+## EVENT\_FILE\_NAME\_CHANGE : <code>string</code>
+Event triggered when a file's name changes.
+
+**Kind**: global constant  
+<a name="EVENT_BEFORE_DOCUMENT_DELETE"></a>
+
+## EVENT\_BEFORE\_DOCUMENT\_DELETE : <code>string</code>
+Event triggered before a document is deleted.
+
+**Kind**: global constant  
+<a name="EVENT_DOCUMENT_REFRESHED"></a>
+
+## EVENT\_DOCUMENT\_REFRESHED : <code>string</code>
+Event triggered when a document is refreshed.
+
+**Kind**: global constant  
+<a name="EVENT_DOCUMENT_CHANGE"></a>
+
+## EVENT\_DOCUMENT\_CHANGE : <code>string</code>
+Event triggered when a document's content changes.
+
+**Kind**: global constant  
+<a name="EVENT_DIRTY_FLAG_CHANGED"></a>
+
+## EVENT\_DIRTY\_FLAG\_CHANGED : <code>string</code>
+Event triggered when the document's dirty flag changes,
+indicating if the document has unsaved changes.
+
+**Kind**: global constant  
 <a name="getOpenDocumentForPath"></a>
 
 ## getOpenDocumentForPath(fullPath) ⇒ <code>Document</code>
-Returns the existing open Document for the given file, or null if the file is not open ('open'means referenced by the UI somewhere). If you will hang onto the Document, you must addRef()it; see [#getDocumentForPath](#getDocumentForPath) for details.
+Returns the existing open Document for the given file, or null if the file is not open ('open'
+means referenced by the UI somewhere). If you will hang onto the Document, you must addRef()
+it; see [#getDocumentForPath](#getDocumentForPath) for details.
 
 **Kind**: global function  
-
-| Param | Type |
-| --- | --- |
-| fullPath | <code>string</code> | 
-
-<a name="getCurrentDocument"></a>
-
-## getCurrentDocument() ⇒ <code>Document</code>
-Returns the Document that is currently open in the editor UI. May be null.
-
-**Kind**: global function  
-<a name="getWorkingSet"></a>
-
-## ..getWorkingSet() ⇒ <code>Array.&lt;File&gt;</code>..
-***Deprecated***
-
-Returns a list of items in the working set in UI list order. May be 0-length, but never null.
-
-**Kind**: global function  
-<a name="findInWorkingSet"></a>
-
-## ..findInWorkingSet(fullPath) ⇒ <code>number</code>..
-***Deprecated***
-
-Returns the index of the file matching fullPath in the working set.
-
-**Kind**: global function  
-**Returns**: <code>number</code> - index, -1 if not found  
 
 | Param | Type |
 | --- | --- |
@@ -51,119 +117,29 @@ Returns the index of the file matching fullPath in the working set.
 <a name="getAllOpenDocuments"></a>
 
 ## getAllOpenDocuments() ⇒ <code>Array.&lt;Document&gt;</code>
-Returns all Documents that are 'open' in the UI somewhere (for now, this means open in aninline editor and/or a full-size editor). Only these Documents can be modified, and onlythese Documents are synced with external changes on disk.
-
-**Kind**: global function  
-<a name="addToWorkingSet"></a>
-
-## ..addToWorkingSet(file, [index], [forceRedraw])..
-***Deprecated***
-
-Adds the given file to the end of the working set list.
-
-**Kind**: global function  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| file | <code>File</code> |  |
-| [index] | <code>number</code> | Position to add to list (defaults to last); -1 is ignored |
-| [forceRedraw] | <code>boolean</code> | If true, a working set change notification is always sent    (useful if suppressRedraw was used with removeFromWorkingSet() earlier) |
-
-<a name="addListToWorkingSet"></a>
-
-## ..addListToWorkingSet(fileList)..
-***Deprecated***
-
-**Kind**: global function  
-
-| Param | Type |
-| --- | --- |
-| fileList | <code>Array.&lt;File&gt;</code> | 
-
-<a name="removeListFromWorkingSet"></a>
-
-## ..removeListFromWorkingSet(list)..
-***Deprecated***
-
-closes a list of files
-
-**Kind**: global function  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| list | <code>Array.&lt;File&gt;</code> | list of File objectgs to close |
-
-<a name="closeAll"></a>
-
-## ..closeAll()..
-***Deprecated***
-
-closes all open files
-
-**Kind**: global function  
-<a name="closeFullEditor"></a>
-
-## ..closeFullEditor(file)..
-***Deprecated***
-
-closes the specified file file
-
-**Kind**: global function  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| file | <code>File</code> | the file to close |
-
-<a name="setCurrentDocument"></a>
-
-## ..setCurrentDocument(document)..
-***Deprecated***
-
-opens the specified document for editing in the currently active pane
-
-**Kind**: global function  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| document | <code>Document</code> | The Document to make current. |
-
-<a name="beginDocumentNavigation"></a>
-
-## ..beginDocumentNavigation()..
-***Deprecated***
-
-freezes the Working Set MRU list
-
-**Kind**: global function  
-<a name="finalizeDocumentNavigation"></a>
-
-## ..finalizeDocumentNavigation()..
-***Deprecated***
-
-ends document navigation and moves the current file to the front of the MRU list in the Working Set
-
-**Kind**: global function  
-<a name="getNextPrevFile"></a>
-
-## ..getNextPrevFile()..
-***Deprecated***
-
-Get the next or previous file in the working set, in MRU order (relative to currentDocument). Mayreturn currentDocument itself if working set is length 1.
-
-**Kind**: global function  
-<a name="_gcDocuments"></a>
-
-## \_gcDocuments()
-Cleans up any loose Documents whose only ref is its own master Editor, and that Editor is notrooted in the UI anywhere. This can happen if the Editor is auto-created via Document APIs thattrigger _ensureMasterEditor() without making it dirty. E.g. a command invoked on the focusedinline editor makes no-op edits or does a read-only operation.
+Returns all Documents that are 'open' in the UI somewhere (for now, this means open in an
+inline editor and/or a full-size editor). Only these Documents can be modified, and only
+these Documents are synced with external changes on disk.
 
 **Kind**: global function  
 <a name="getDocumentForPath"></a>
 
 ## getDocumentForPath(fullPath, fileObj) ⇒ <code>$.Promise</code>
-Gets an existing open Document for the given file, or creates a new one if the Document isnot currently open ('open' means referenced by the UI somewhere). Always use this method toget Documents; do not call the Document constructor directly. This method is safe to callin parallel.If you are going to hang onto the Document for more than just the duration of a command - e.g.if you are going to display its contents in a piece of UI - then you must addRef() the Documentand listen for changes on it. (Note: opening the Document in an Editor automatically managesrefs and listeners for that Editor UI).If all you need is the Document's getText() value, use the faster getDocumentText() instead.
+Gets an existing open Document for the given file, or creates a new one if the Document is
+not currently open ('open' means referenced by the UI somewhere). Always use this method to
+get Documents; do not call the Document constructor directly. This method is safe to call
+in parallel.
+
+If you are going to hang onto the Document for more than just the duration of a command - e.g.
+if you are going to display its contents in a piece of UI - then you must addRef() the Document
+and listen for changes on it. (Note: opening the Document in an Editor automatically manages
+refs and listeners for that Editor UI).
+
+If all you need is the Document's getText() value, use the faster getDocumentText() instead.
 
 **Kind**: global function  
-**Returns**: <code>$.Promise</code> - A promise object that will be resolved with the Document, or rejected     with a FileSystemError if the file is not yet open and can't be read from disk.  
+**Returns**: <code>$.Promise</code> - A promise object that will be resolved with the Document, or rejected
+     with a FileSystemError if the file is not yet open and can't be read from disk.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -173,10 +149,22 @@ Gets an existing open Document for the given file, or creates a new one if the D
 <a name="getDocumentText"></a>
 
 ## getDocumentText(file, [checkLineEndings]) ⇒ <code>$.Promise</code>
-Gets the text of a Document (including any unsaved changes), or would-be Document if thefile is not actually open. More efficient than getDocumentForPath(). Use when you're readingdocument(s) but don't need to hang onto a Document object.If the file is open this is equivalent to calling getOpenDocumentForPath().getText(). If thefile is NOT open, this is like calling getDocumentForPath()...getText() but more efficient.Differs from plain FileUtils.readAsText() in two ways: (a) line endings are still normalizedas in Document.getText(); (b) unsaved changes are returned if there are any.
+Gets the text of a Document (including any unsaved changes), or would-be Document if the
+file is not actually open. More efficient than getDocumentForPath(). Use when you're reading
+document(s) but don't need to hang onto a Document object.
+
+If the file is open this is equivalent to calling getOpenDocumentForPath().getText(). If the
+file is NOT open, this is like calling getDocumentForPath()...getText() but more efficient.
+Differs from plain FileUtils.readAsText() in two ways: (a) line endings are still normalized
+as in Document.getText(); (b) unsaved changes are returned if there are any.
 
 **Kind**: global function  
-**Returns**: <code>$.Promise</code> - A promise that is resolved with three parameters:         contents - string: the document's text         timestamp - Date: the last time the document was changed on disk (might not be the same as the last time it was changed in memory)         lineEndings - string: the original line endings of the file, one of the FileUtils.LINE_ENDINGS_* constants;             will be null if checkLineEndings was false.    or rejected with a filesystem error.  
+**Returns**: <code>$.Promise</code> - A promise that is resolved with three parameters:
+         contents - string: the document's text
+         timestamp - Date: the last time the document was changed on disk (might not be the same as the last time it was changed in memory)
+         lineEndings - string: the original line endings of the file, one of the FileUtils.LINE_ENDINGS_* constants;
+             will be null if checkLineEndings was false.
+    or rejected with a filesystem error.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -186,7 +174,8 @@ Gets the text of a Document (including any unsaved changes), or would-be Documen
 <a name="createUntitledDocument"></a>
 
 ## createUntitledDocument(counter, fileExt) ⇒ <code>Document</code>
-Creates an untitled document. The associated File has a fullPath thatlooks like /some-random-string/Untitled-counter.fileExt.
+Creates an untitled document. The associated File has a fullPath that
+looks like /some-random-string/Untitled-counter.fileExt.
 
 **Kind**: global function  
 **Returns**: <code>Document</code> - - a new untitled Document  
@@ -195,38 +184,4 @@ Creates an untitled document. The associated File has a fullPath thatlooks like
 | --- | --- | --- |
 | counter | <code>number</code> | used in the name of the new Document's File |
 | fileExt | <code>string</code> | file extension of the new Document's File, including "." |
-
-<a name="notifyFileDeleted"></a>
-
-## notifyFileDeleted(file)
-Reacts to a file being deleted: if there is a Document for this file, causes it to dispatch a"deleted" event; ensures it's not the currentDocument; and removes this file from the workingset. These actions in turn cause all open editors for this file to close. Discards any unsavedchanges - it is expected that the UI has already confirmed with the user before calling.To simply close a main editor when the file hasn't been deleted, use closeFullEditor() or FILE_CLOSE.FUTURE: Instead of an explicit notify, we should eventually listen for deletion events on somesort of "project file model," making this just a private event handler.NOTE: This function is not for general consumption, is considered private and may be deprecated       without warning in a future release.
-
-**Kind**: global function  
-
-| Param | Type |
-| --- | --- |
-| file | <code>File</code> | 
-
-<a name="notifyPathDeleted"></a>
-
-## notifyPathDeleted(fullPath)
-Called after a file or folder has been deleted. This function is responsiblefor updating underlying model data and notifying all views of the change.
-
-**Kind**: global function  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| fullPath | <code>string</code> | The path of the file/folder that has been deleted |
-
-<a name="notifyPathNameChanged"></a>
-
-## notifyPathNameChanged(oldName, newName)
-Called after a file or folder name has changed. This function is responsiblefor updating underlying model data and notifying all views of the change.
-
-**Kind**: global function  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| oldName | <code>string</code> | The old name of the file/folder |
-| newName | <code>string</code> | The new name of the file/folder |
 

--- a/docs/API-Reference/document/TextRange.md
+++ b/docs/API-Reference/document/TextRange.md
@@ -14,13 +14,28 @@ const TextRange = brackets.getModule("document/TextRange")
     * [.startLine](#TextRange+startLine) : <code>number</code>
     * [.endLine](#TextRange+endLine) : <code>number</code>
     * [.dispose()](#TextRange+dispose)
-    * [._applySingleChangeToRange(change)](#TextRange+_applySingleChangeToRange) ⇒ <code>Object</code>
-    * [._applyChangesToRange()](#TextRange+_applyChangesToRange)
 
 <a name="new_TextRange_new"></a>
 
 ### new TextRange(document, startLine, endLine)
-Stores a range of lines that is automatically maintained as the Document changes. The rangeMAY drop out of sync with the Document in certain edge cases; startLine & endLine will becomenull when that happens.Important: you must dispose() a TextRange when you're done with it. Because TextRange addRef()sthe Document (in order to listen to it), you will leak Documents otherwise.TextRange dispatches these events: - change -- When the range boundary line numbers change (due to a Document change) - contentChange -- When the actual content of the range changes. This might or might not   be accompanied by a change in the boundary line numbers. - lostSync -- When the backing Document changes in such a way that the range can no longer   accurately be maintained. Generally, occurs whenever an edit spans a range boundary.   After this, startLine & endLine will be unusable (set to null).   Also occurs when the document is deleted, though startLine & endLine won't be modifiedThese events only ever occur in response to Document changes, so if you are already listeningto the Document, you could ignore the TextRange events and just read its updated value in yourown Document change handler.
+Stores a range of lines that is automatically maintained as the Document changes. The range
+MAY drop out of sync with the Document in certain edge cases; startLine & endLine will become
+null when that happens.
+
+Important: you must dispose() a TextRange when you're done with it. Because TextRange addRef()s
+the Document (in order to listen to it), you will leak Documents otherwise.
+
+TextRange dispatches these events:
+ - change -- When the range boundary line numbers change (due to a Document change)
+ - contentChange -- When the actual content of the range changes. This might or might not
+   be accompanied by a change in the boundary line numbers.
+ - lostSync -- When the backing Document changes in such a way that the range can no longer
+   accurately be maintained. Generally, occurs whenever an edit spans a range boundary.
+   After this, startLine & endLine will be unusable (set to null).
+   Also occurs when the document is deleted, though startLine & endLine won't be modified
+These events only ever occur in response to Document changes, so if you are already listening
+to the Document, you could ignore the TextRange events and just read its updated value in your
+own Document change handler.
 
 
 | Param | Type | Description |
@@ -51,24 +66,6 @@ Ending Line
 
 ### textRange.dispose()
 Detaches from the Document. The TextRange will no longer update or send change events
-
-**Kind**: instance method of [<code>TextRange</code>](#TextRange)  
-<a name="TextRange+_applySingleChangeToRange"></a>
-
-### textRange.\_applySingleChangeToRange(change) ⇒ <code>Object</code>
-Applies a single Document change object (out of the linked list of multiple such objects)to this range.
-
-**Kind**: instance method of [<code>TextRange</code>](#TextRange)  
-**Returns**: <code>Object</code> - Whether the range boundary    and/or content has changed.  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| change | <code>Object</code> | The CodeMirror change record. |
-
-<a name="TextRange+_applyChangesToRange"></a>
-
-### textRange.\_applyChangesToRange()
-Updates the range based on the changeList from a Document "change" event. Dispatches a"change" event if the range was adjusted at all. Dispatches a "lostSync" event instead if therange can no longer be accurately maintained.
 
 **Kind**: instance method of [<code>TextRange</code>](#TextRange)  
 <a name="EventDispatcher"></a>

--- a/src/document/Document.js
+++ b/src/document/Document.js
@@ -85,6 +85,7 @@ define(function (require, exports, module) {
     /**
      * Number of clients who want this Document to stay alive. The Document is listed in
      * DocumentManager._openDocuments whenever refCount > 0.
+     * @private
      */
     Document.prototype._refCount = 0;
 
@@ -140,12 +141,14 @@ define(function (require, exports, module) {
 
     /**
      * True while refreshText() is in progress and change notifications shouldn't trip the dirty flag.
+     * @private
      * @type {boolean}
      */
     Document.prototype._refreshInProgress = false;
 
     /**
      * The text contents of the file, or null if our backing model is _masterEditor.
+     * @private
      * @type {?string}
      */
     Document.prototype._text = null;
@@ -154,6 +157,7 @@ define(function (require, exports, module) {
      * Editor object representing the full-size editor UI for this document. May be null if Document
      * has not yet been modified or been the currentDocument; in that case, our backing model is the
      * string _text.
+     * @private
      * @type {?Editor}
      */
     Document.prototype._masterEditor = null;
@@ -161,6 +165,7 @@ define(function (require, exports, module) {
     /**
      * The content's line-endings style. If a Document is created on empty text, or text with
      * inconsistent line endings, defaults to the current platform's standard endings.
+     * @private
      * @type {FileUtils.LINE_ENDINGS_CRLF|FileUtils.LINE_ENDINGS_LF}
      */
     Document.prototype._lineEndings = null;
@@ -198,6 +203,7 @@ define(function (require, exports, module) {
      * Attach a backing Editor to the Document, enabling setText() to be called. Assumes Editor has
      * already been initialized with the value of getText(). ONLY Editor should call this (and only
      * when EditorManager has told it to act as the master editor).
+     * @private
      * @param {!Editor} masterEditor
      */
     Document.prototype._makeEditable = function (masterEditor) {
@@ -212,6 +218,7 @@ define(function (require, exports, module) {
      * Detach the backing Editor from the Document, disallowing setText(). The text content is
      * stored back onto _text so other Document clients continue to have read-only access. ONLY
      * Editor.destroy() should call this.
+     * @private
      */
     Document.prototype._makeNonEditable = function () {
         if (!this._masterEditor) {
@@ -233,6 +240,7 @@ define(function (require, exports, module) {
     /**
      * Toggles the master editor which has gained focus from a pool of full editors
      * To be used internally by Editor only
+     * @private
      */
     Document.prototype._toggleMasterEditor = function (masterEditor) {
         // Do a check before processing the request to ensure inline editors are not being set as master editor
@@ -244,6 +252,7 @@ define(function (require, exports, module) {
 
     /**
      * Checks and returns if a full editor exists for the provided pane attached to this document
+     * @private
      * @param {String} paneId
      * @return {Editor} Attached editor bound to the provided pane id
      */
@@ -262,6 +271,7 @@ define(function (require, exports, module) {
     /**
      * Disassociates an editor from this document if present in the associated editor list
      * To be used internally by Editor only when destroyed and not the current master editor for the document
+     * @private
      */
     Document.prototype._disassociateEditor = function (editor) {
         // Do a check before processing the request to ensure inline editors are not being handled
@@ -273,6 +283,7 @@ define(function (require, exports, module) {
     /**
      * Aassociates a full editor to this document
      * To be used internally by Editor only when pane marking happens
+     * @private
      */
     Document.prototype._associateEditor = function (editor) {
         // Do a check before processing the request to ensure inline editors are not being handled
@@ -285,6 +296,7 @@ define(function (require, exports, module) {
      * Guarantees that _masterEditor is non-null. If needed, asks EditorManager to create a new master
      * editor bound to this Document (which in turn causes Document._makeEditable() to be called).
      * Should ONLY be called by Editor and Document.
+     * @private
      */
     Document.prototype._ensureMasterEditor = function () {
         if (!this._masterEditor) {
@@ -600,6 +612,7 @@ define(function (require, exports, module) {
     /**
      * Like _.each(), but if given a single item not in an array, acts as
      * if it were an array containing just that item.
+     * @private
      */
     function oneOrEach(itemOrArr, cb) {
         if (Array.isArray(itemOrArr)) {
@@ -768,6 +781,7 @@ define(function (require, exports, module) {
 
     /**
      * Updates the language to match the current mapping given by LanguageManager
+     * @private
      */
     Document.prototype._updateLanguage = function () {
         var oldLanguage = this.language;
@@ -777,7 +791,10 @@ define(function (require, exports, module) {
         }
     };
 
-    /** Called when Document.file has been modified (due to a rename) */
+    /**
+     * Called when Document.file has been modified (due to a rename)
+     * @private
+     */
     Document.prototype._notifyFilePathChanged = function () {
         // File extension may have changed
         this._updateLanguage();

--- a/src/document/DocumentManager.js
+++ b/src/document/DocumentManager.js
@@ -96,13 +96,50 @@ define(function (require, exports, module) {
         ProjectManager      = require("project/ProjectManager"),
         Strings             = require("strings");
 
-    const EVENT_AFTER_DOCUMENT_CREATE = "afterDocumentCreate",
-        EVENT_PATH_DELETED = "pathDeleted",
-        EVENT_FILE_NAME_CHANGE = "fileNameChange",
-        EVENT_BEFORE_DOCUMENT_DELETE = "beforeDocumentDelete",
-        EVENT_DOCUMENT_REFRESHED = "documentRefreshed",
-        EVENT_DOCUMENT_CHANGE = "documentChange",
-        EVENT_DIRTY_FLAG_CHANGED = "dirtyFlagChange";
+    /**
+     * Event triggered after a document is created.
+     * @constant {string}
+     */
+    const EVENT_AFTER_DOCUMENT_CREATE = "afterDocumentCreate";
+
+    /**
+     * Event triggered when a file or folder path is deleted.
+     * @constant {string}
+     */
+    const EVENT_PATH_DELETED = "pathDeleted";
+
+    /**
+     * Event triggered when a file's name changes.
+     * @constant {string}
+     */
+    const EVENT_FILE_NAME_CHANGE = "fileNameChange";
+
+    /**
+     * Event triggered before a document is deleted.
+     * @constant {string}
+     */
+    const EVENT_BEFORE_DOCUMENT_DELETE = "beforeDocumentDelete";
+
+    /**
+     * Event triggered when a document is refreshed.
+     * @constant {string}
+     */
+    const EVENT_DOCUMENT_REFRESHED = "documentRefreshed";
+
+    /**
+     * Event triggered when a document's content changes.
+     * @constant {string}
+     */
+    const EVENT_DOCUMENT_CHANGE = "documentChange";
+
+    /**
+     * Event triggered when the document's dirty flag changes,
+     * indicating if the document has unsaved changes.
+     * @constant {string}
+     */
+    const EVENT_DIRTY_FLAG_CHANGED = "dirtyFlagChange";
+
+
 
 
     /**
@@ -143,6 +180,8 @@ define(function (require, exports, module) {
 
     /**
      * Returns the Document that is currently open in the editor UI. May be null.
+     * @private
+     * @deprecated
      * @return {?Document}
      */
     function getCurrentDocument() {
@@ -158,6 +197,7 @@ define(function (require, exports, module) {
 
     /**
      * Returns a list of items in the working set in UI list order. May be 0-length, but never null.
+     * @private
      * @deprecated Use MainViewManager.getWorkingSet() instead
      * @return {Array.<File>}
      */
@@ -172,6 +212,7 @@ define(function (require, exports, module) {
 
     /**
      * Returns the index of the file matching fullPath in the working set.
+     * @private
      * @deprecated Use MainViewManager.findInWorkingSet() instead
      * @param {!string} fullPath
      * @return {number} index, -1 if not found
@@ -201,6 +242,7 @@ define(function (require, exports, module) {
 
     /**
      * Adds the given file to the end of the working set list.
+     * @private
      * @deprecated Use MainViewManager.addToWorkingSet() instead
      * @param {!File} file
      * @param {number=} index  Position to add to list (defaults to last); -1 is ignored
@@ -213,6 +255,7 @@ define(function (require, exports, module) {
     }
 
     /**
+     * @private
      * @deprecated Use MainViewManager.addListToWorkingSet() instead
      * Adds the given file list to the end of the working set list.
      * If a file in the list has its own custom viewer, then it
@@ -230,6 +273,7 @@ define(function (require, exports, module) {
 
     /**
      * closes a list of files
+     * @private
      * @deprecated Use CommandManager.execute(Commands.FILE_CLOSE_LIST) instead
      * @param {!Array.<File>} list - list of File objectgs to close
      */
@@ -240,6 +284,7 @@ define(function (require, exports, module) {
 
     /**
      * closes all open files
+     * @private
      * @deprecated CommandManager.execute(Commands.FILE_CLOSE_ALL) instead
      */
     function closeAll() {
@@ -249,6 +294,7 @@ define(function (require, exports, module) {
 
     /**
      * closes the specified file file
+     * @private
      * @deprecated use CommandManager.execute(Commands.FILE_CLOSE, {File: file}) instead
      * @param {!File} file - the file to close
      */
@@ -259,6 +305,7 @@ define(function (require, exports, module) {
 
     /**
      * opens the specified document for editing in the currently active pane
+     * @private
      * @deprecated use CommandManager.execute(Commands.CMD_OPEN, {fullPath: doc.file.fullPath}) instead
      * @param {!Document} document  The Document to make current.
      */
@@ -270,6 +317,7 @@ define(function (require, exports, module) {
 
     /**
      * freezes the Working Set MRU list
+     * @private
      * @deprecated use MainViewManager.beginTraversal() instead
      */
     function beginDocumentNavigation() {
@@ -279,6 +327,7 @@ define(function (require, exports, module) {
 
     /**
      * ends document navigation and moves the current file to the front of the MRU list in the Working Set
+     * @private
      * @deprecated use MainViewManager.endTraversal() instead
      */
     function finalizeDocumentNavigation() {
@@ -289,6 +338,7 @@ define(function (require, exports, module) {
     /**
      * Get the next or previous file in the working set, in MRU order (relative to currentDocument). May
      * return currentDocument itself if working set is length 1.
+     * @private
      * @deprecated use MainViewManager.traverseToNextViewByMRU() instead
      */
     function getNextPrevFile(inc) {
@@ -305,6 +355,7 @@ define(function (require, exports, module) {
      * rooted in the UI anywhere. This can happen if the Editor is auto-created via Document APIs that
      * trigger _ensureMasterEditor() without making it dirty. E.g. a command invoked on the focused
      * inline editor makes no-op edits or does a read-only operation.
+     * @private
      */
     function _gcDocuments() {
         getAllOpenDocuments().forEach(function (doc) {
@@ -479,6 +530,7 @@ define(function (require, exports, module) {
      *        without warning in a future release.
      *
      * @param {!File} file
+     * @private
      */
     function notifyFileDeleted(file) {
         // Notify all editors to close as well
@@ -501,6 +553,7 @@ define(function (require, exports, module) {
      * for updating underlying model data and notifying all views of the change.
      *
      * @param {string} fullPath The path of the file/folder that has been deleted
+     * @private
      */
     function notifyPathDeleted(fullPath) {
         // FileSyncManager.syncOpenDocuments() does all the work prompting
@@ -527,6 +580,7 @@ define(function (require, exports, module) {
      *
      * @param {string} oldName The old name of the file/folder
      * @param {string} newName The new name of the file/folder
+     * @private
      */
     function notifyPathNameChanged(oldName, newName) {
         // Notify all open documents

--- a/src/document/TextRange.js
+++ b/src/document/TextRange.js
@@ -101,6 +101,7 @@ define(function (require, exports, module) {
     /**
      * Applies a single Document change object (out of the linked list of multiple such objects)
      * to this range.
+     * @private
      * @param {Object} change The CodeMirror change record.
      * @return {{hasChanged: boolean, hasContentChanged: boolean}} Whether the range boundary
      *     and/or content has changed.
@@ -170,6 +171,7 @@ define(function (require, exports, module) {
      * Updates the range based on the changeList from a Document "change" event. Dispatches a
      * "change" event if the range was adjusted at all. Dispatches a "lostSync" event instead if the
      * range can no longer be accurately maintained.
+     * @private
      */
     TextRange.prototype._applyChangesToRange = function (changeList) {
         var hasChanged = false, hasContentChanged = false;


### PR DESCRIPTION
Refine the API docs to remove the internal APIs from docs.

Also, now the `deprecated` methods are made `private`, So they don't appear in API docs.