### PR TITLE
docs: refine API docs for files in Editor dir

### DIFF
--- a/docs/API-Reference/editor/CodeHintManager.md
+++ b/docs/API-Reference/editor/CodeHintManager.md
@@ -3,16 +3,11 @@
 const CodeHintManager = brackets.getModule("editor/CodeHintManager")
 ```
 
-<a name="_providerSort"></a>
-
-## \_providerSort()
-Comparator to sort providers from high to low priority
-
-**Kind**: global function  
 <a name="registerHintProvider"></a>
 
 ## registerHintProvider(provider, languageIds, priority)
-The method by which a CodeHintProvider registers its willingness toproviding hints for editors in a given language.
+The method by which a CodeHintProvider registers its willingness to
+providing hints for editors in a given language.
 
 **Kind**: global function  
 
@@ -22,97 +17,14 @@ The method by which a CodeHintProvider registers its willingness toproviding hi
 | languageIds | <code>Array.&lt;string&gt;</code> | The set of language ids for which the provider is capable of providing hints. If the special language id name "all" is included then the provider may be called for any language. |
 | priority | <code>number</code> | Used to break ties among hint providers for a particular language. Providers with a higher number will be asked for hints before those with a lower priority value. Defaults to zero. |
 
-<a name="_getProvidersForLanguageId"></a>
-
-## \_getProvidersForLanguageId(languageId) ⇒ <code>Object</code>
-Return the array of hint providers for the given language id. This gets called (potentially) on every keypress. So, it should be fast.
-
-**Kind**: global function  
-
-| Param | Type |
-| --- | --- |
-| languageId | <code>string</code> | 
-
-<a name="_endSession"></a>
-
-## \_endSession()
-End the current hinting session
-
-**Kind**: global function  
-<a name="_inSession"></a>
-
-## \_inSession(editor) ⇒
-Is there a hinting session active for a given editor?NOTE: the sessionEditor, sessionProvider and hintList objects areonly guaranteed to be initialized during an active session.
-
-**Kind**: global function  
-**Returns**: boolean  
-
-| Param | Type |
-| --- | --- |
-| editor | <code>Editor</code> | 
-
-<a name="_updateHintList"></a>
-
-## \_updateHintList()
-From an active hinting session, get hints from the current provider andrender the hint list window.Assumes that it is called when a session is active (i.e. sessionProvider is not null).
-
-**Kind**: global function  
-<a name="_beginSession"></a>
-
-## \_beginSession(editor)
-Try to begin a new hinting session.
-
-**Kind**: global function  
-
-| Param | Type |
-| --- | --- |
-| editor | <code>Editor</code> | 
-
-<a name="_handleKeydownEvent"></a>
-
-## \_handleKeydownEvent(jqEvent, editor, event)
-Handles keys related to displaying, searching, and navigating the hint list.This gets called before handleChange.TODO: Ideally, we'd get a more semantic event from the editor that told uswhat changed so that we could do all of this logic without looking atkey events. Then, the purposes of handleKeyEvent and handleChange could becombined. Doing this well requires changing CodeMirror.
-
-**Kind**: global function  
-
-| Param | Type |
-| --- | --- |
-| jqEvent | <code>Event</code> | 
-| editor | <code>Editor</code> | 
-| event | <code>KeyboardEvent</code> | 
-
-<a name="_handleCursorActivity"></a>
-
-## \_handleCursorActivity(event, editor)
-Handle a selection change event in the editor. If the selection becomes amultiple selection, end our current session.
-
-**Kind**: global function  
-
-| Param | Type |
-| --- | --- |
-| event | <code>BracketsEvent</code> | 
-| editor | <code>Editor</code> | 
-
-<a name="_handleChange"></a>
-
-## \_handleChange(event, editor, changeList)
-Start a new implicit hinting session, or update the existing hint list.Called by the editor after handleKeyEvent, which is responsible for settingthe lastChar.
-
-**Kind**: global function  
-
-| Param | Type |
-| --- | --- |
-| event | <code>Event</code> | 
-| editor | <code>Editor</code> | 
-| changeList | <code>Object</code> | 
-
 <a name="hasValidExclusion"></a>
 
 ## hasValidExclusion(exclusion, textAfterCursor) ⇒ <code>boolean</code>
 Test whether the provider has an exclusion that is still the same as text after the cursor.
 
 **Kind**: global function  
-**Returns**: <code>boolean</code> - true if the exclusion is not null and is exactly the same as textAfterCursor,false otherwise.  
+**Returns**: <code>boolean</code> - true if the exclusion is not null and is exactly the same as textAfterCursor,
+false otherwise.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -126,20 +38,3 @@ Test if a hint popup is open.
 
 **Kind**: global function  
 **Returns**: <code>boolean</code> - - true if the hints are open, false otherwise.  
-<a name="_startNewSession"></a>
-
-## \_startNewSession(editor)
-Explicitly start a new session. If we have an existing session,then close the current one and restart a new one.
-
-**Kind**: global function  
-
-| Param | Type |
-| --- | --- |
-| editor | <code>Editor</code> | 
-
-<a name="_getCodeHintList"></a>
-
-## \_getCodeHintList()
-Expose CodeHintList for unit testing
-
-**Kind**: global function  

--- a/docs/API-Reference/editor/Editor.md
+++ b/docs/API-Reference/editor/Editor.md
@@ -1655,19 +1655,19 @@ To listen for events, do something like this: (see EventDispatcher for details o
 ## BOUNDARY\_CHECK\_NORMAL : <code>number</code>
 Constant: Normal boundary check when centering text.
 
-**Kind**: global variable  
+**Kind**: global constant  
 <a name="BOUNDARY_IGNORE_TOP"></a>
 
 ## BOUNDARY\_IGNORE\_TOP : <code>number</code>
 Constant: Ignore the upper boundary when centering text.
 
-**Kind**: global variable  
+**Kind**: global constant  
 <a name="BOUNDARY_BULLSEYE"></a>
 
 ## BOUNDARY\_BULLSEYE : <code>number</code>
 Constant: Bulls-eye mode, strictly center the text always.
 
-**Kind**: global variable  
+**Kind**: global constant  
 <a name="CENTERING_MARGIN"></a>
 
 ## CENTERING\_MARGIN

--- a/docs/API-Reference/editor/EditorCommandHandlers.md
+++ b/docs/API-Reference/editor/EditorCommandHandlers.md
@@ -1,149 +1,0 @@
-### Import :
-```js
-const EditorCommandHandlers = brackets.getModule("editor/EditorCommandHandlers")
-```
-
-<a name="DIRECTION_UP"></a>
-
-## DIRECTION\_UP
-List of constants
-
-**Kind**: global variable  
-<a name="_getBlockCommentPrefixSuffixEdit"></a>
-
-## \_getBlockCommentPrefixSuffixEdit(editor, prefix, suffix, linePrefixes, sel, selectionsToTrack, command) ⇒ <code>Object</code> \| <code>Object</code> \| <code>null</code>
-Generates an edit that adds or removes block-comment tokens to the selection, preserving selectionand cursor position. Applies to the currently focused Editor.If the selection is inside a block-comment or one block-comment is inside or partially inside the selection,it will uncomment; otherwise, it will comment out, unless there are multiple block comments inside the selection,in which case it does nothing.Commenting out adds the prefix before the selection and the suffix after.Uncommenting removes them.If all the lines inside the selection are line-commented and the selection is not inside a block-comment, it willline uncomment all the lines; otherwise, it will block comment/uncomment. In the first case, we return null toindicate to the caller that it needs to handle this selection as a line comment.
-
-**Kind**: global function  
-**Returns**: <code>Object</code> \| <code>Object</code> \| <code>null</code> - An edit description suitable for including in the edits array passed to `Document.doMultipleEdits()`, or `null`     if line commenting should be handled by the caller.  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| editor | <code>Editor</code> | The editor instance where the operation will occur. |
-| prefix | <code>string</code> | The block comment prefix, e.g., "< !--". |
-| suffix | <code>string</code> | The block comment suffix, e.g., "-->". |
-| linePrefixes | <code>Array.&lt;string&gt;</code> | The possible line comment prefixes, e.g., ["//"]. |
-| sel | <code>Object</code> | The selection to block comment/uncomment. |
-| selectionsToTrack | <code>Object</code> | An array of selections that should be tracked through this edit, if any. |
-| command | <code>string</code> | The command being executed, can be "line" or "block". |
-
-<a name="_getLineCommentPrefixSuffixEdit"></a>
-
-## \_getLineCommentPrefixSuffixEdit(editor, prefix, suffix, lineSel, command) ⇒ <code>Object</code>
-Generates an edit that adds or removes block-comment tokens to the selection, preserving selectionand cursor position. Applies to the currently focused Editor. The selection must already be aline selection in the form returned by `Editor.convertToLineSelections()`.The implementation uses blockCommentPrefixSuffix, with the exception of the case wherethere is no selection on an uncommented and not empty line. In this case, the whole line getscommented in a block-comment.
-
-**Kind**: global function  
-**Returns**: <code>Object</code> - An edit description suitable for including in the edits array passed to `Document.doMultipleEdits()`.  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| editor | <code>Editor</code> | The editor instance where the operation will occur. |
-| prefix | <code>string</code> | The block comment prefix, e.g., "< !--". |
-| suffix | <code>string</code> | The block comment suffix, e.g., "-->". |
-| lineSel | <code>Object</code> | A line selection as returned from `Editor.convertToLineSelections()`. `selectionForEdit` is the selection to perform      the line comment operation on, and `selectionsToTrack` are a set of selections associated with this line that need to be      tracked through the edit. |
-| command | <code>string</code> | The command being executed, can be "line" or "block". |
-
-<a name="lineComment"></a>
-
-## lineComment(editor)
-Invokes a language-specific line-comment/uncomment handler
-
-**Kind**: global function  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| editor | <code>Editor</code> | If unspecified, applies to the currently focused editor |
-
-<a name="blockComment"></a>
-
-## blockComment(editor)
-Invokes a language-specific block-comment/uncomment handler
-
-**Kind**: global function  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| editor | <code>Editor</code> | If unspecified, applies to the currently focused editor |
-
-<a name="duplicateText"></a>
-
-## duplicateText()
-Duplicates the selected text, or current line if no selection. The cursor/selection is lefton the second copy.
-
-**Kind**: global function  
-<a name="deleteCurrentLines"></a>
-
-## deleteCurrentLines()
-Deletes the current line if there is no selection or the lines for the selection(removing the end of line too)
-
-**Kind**: global function  
-<a name="moveLine"></a>
-
-## moveLine(editor, direction)
-Moves the selected text, or current line if no selection. The cursor/selectionmoves with the line/lines.
-
-**Kind**: global function  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| editor | <code>Editor</code> | target editor |
-| direction | <code>Number</code> | direction of the move (-1,+1) => (Up,Down) |
-
-<a name="moveLineUp"></a>
-
-## moveLineUp()
-Moves the selected text, or current line if no selection, one line up. The cursor/selectionmoves with the line/lines.
-
-**Kind**: global function  
-<a name="moveLineDown"></a>
-
-## moveLineDown()
-Moves the selected text, or current line if no selection, one line down. The cursor/selectionmoves with the line/lines.
-
-**Kind**: global function  
-<a name="openLine"></a>
-
-## openLine(editor, direction)
-Inserts a new and smart indented line above/below the selected text, or current line if no selection.The cursor is moved in the new line.
-
-**Kind**: global function  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| editor | <code>Editor</code> | target editor |
-| direction | <code>Number</code> | direction where to place the new line (-1,+1) => (Up,Down) |
-
-<a name="openLineAbove"></a>
-
-## openLineAbove(editor)
-Inserts a new and smart indented line above the selected text, or current line if no selection.The cursor is moved in the new line.
-
-**Kind**: global function  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| editor | <code>Editor</code> | target editor |
-
-<a name="openLineBelow"></a>
-
-## openLineBelow(editor)
-Inserts a new and smart indented line below the selected text, or current line if no selection.The cursor is moved in the new line.
-
-**Kind**: global function  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| editor | <code>Editor</code> | target editor |
-
-<a name="indentText"></a>
-
-## indentText()
-Indent a line of text if no selection. Otherwise, indent all lines in selection.
-
-**Kind**: global function  
-<a name="unindentText"></a>
-
-## unindentText()
-Unindent a line of text if no selection. Otherwise, unindent all lines in selection.
-
-**Kind**: global function  

--- a/docs/API-Reference/editor/EditorManager.md
+++ b/docs/API-Reference/editor/EditorManager.md
@@ -10,34 +10,11 @@ Retrieves the visible full-size Editor for the currently opened file in the ACTI
 
 **Kind**: global function  
 **Returns**: <code>Editor</code> - editor of the current view or null  
-<a name="_toggleInlineWidget"></a>
-
-## \_toggleInlineWidget(array, [errorMsg]) ⇒ <code>Promise</code>
-Closes any focused inline widget. Else, asynchronously asks providers to create one.
-
-**Kind**: global function  
-**Returns**: <code>Promise</code> - A promise resolved with true if an inline widget is opened or false  when closed. Rejected if there is neither an existing widget to close nor a provider  willing to create a widget (or if no editor is open).  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| array | <code>Object</code> | providers   prioritized list of providers |
-| [errorMsg] | <code>string</code> | Default message to display if no providers return non-null |
-
-<a name="_createUnattachedMasterEditor"></a>
-
-## \_createUnattachedMasterEditor(doc)
-Creates a hidden, unattached master editor that is needed when a document is created for thesole purpose of creating an inline editor so operations that require a master editor can be performedOnly called from Document._ensureMasterEditor()The editor view is placed in a hidden part of the DOM but can later be moved to a visible panewhen the document is opened using pane.addView()
-
-**Kind**: global function  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| doc | <code>Document</code> | document to create a hidden editor for |
-
 <a name="closeInlineWidget"></a>
 
 ## closeInlineWidget(hostEditor, inlineWidget) ⇒ <code>$.Promise</code>
-Removes the given widget UI from the given hostEditor (agnostic of what the widget's contentis). The widget's onClosed() callback will be run as a result.
+Removes the given widget UI from the given hostEditor (agnostic of what the widget's content
+is). The widget's onClosed() callback will be run as a result.
 
 **Kind**: global function  
 **Returns**: <code>$.Promise</code> - A promise that's resolved when the widget is fully closed.  
@@ -50,7 +27,10 @@ Removes the given widget UI from the given hostEditor (agnostic of what the widg
 <a name="registerInlineEditProvider"></a>
 
 ## registerInlineEditProvider(provider, [priority])
-Registers a new inline editor provider. When Quick Edit is invoked each registered provider isasked if it wants to provide an inline editor given the current editor and cursor location.An optional priority parameter is used to give providers with higher priority an opportunityto provide an inline editor before providers with lower priority.
+Registers a new inline editor provider. When Quick Edit is invoked each registered provider is
+asked if it wants to provide an inline editor given the current editor and cursor location.
+An optional priority parameter is used to give providers with higher priority an opportunity
+to provide an inline editor before providers with lower priority.
 
 **Kind**: global function  
 
@@ -62,7 +42,10 @@ Registers a new inline editor provider. When Quick Edit is invoked each register
 <a name="registerInlineDocsProvider"></a>
 
 ## registerInlineDocsProvider(provider, [priority])
-Registers a new inline docs provider. When Quick Docs is invoked each registered provider isasked if it wants to provide inline docs given the current editor and cursor location.An optional priority parameter is used to give providers with higher priority an opportunityto provide an inline editor before providers with lower priority.
+Registers a new inline docs provider. When Quick Docs is invoked each registered provider is
+asked if it wants to provide inline docs given the current editor and cursor location.
+An optional priority parameter is used to give providers with higher priority an opportunity
+to provide an inline editor before providers with lower priority.
 
 **Kind**: global function  
 
@@ -71,10 +54,23 @@ Registers a new inline docs provider. When Quick Docs is invoked each registered
 | provider | <code>function</code> |  |
 | [priority] | <code>number</code> | The provider returns a promise that will be resolved with an InlineWidget, or returns a string indicating why the provider cannot respond to this case (or returns null to indicate no reason). |
 
+<a name="getInlineEditors"></a>
+
+## getInlineEditors(hostEditor) ⇒ <code>Array.&lt;Editor&gt;</code>
+Given a host editor, return a list of all Editors in all its open inline widgets. (Ignoring
+any other inline widgets that might be open but don't contain Editors).
+
+**Kind**: global function  
+
+| Param | Type |
+| --- | --- |
+| hostEditor | <code>Editor</code> | 
+
 <a name="createInlineEditorForDocument"></a>
 
 ## createInlineEditorForDocument(doc, range, inlineContent, closeThisInline) ⇒ <code>Object</code>
-Creates a new inline Editor instance for the given Document.The editor is not yet visible or attached to a host editor.
+Creates a new inline Editor instance for the given Document.
+The editor is not yet visible or attached to a host editor.
 
 **Kind**: global function  
 
@@ -88,35 +84,11 @@ Creates a new inline Editor instance for the given Document.The editor is not y
 <a name="focusEditor"></a>
 
 ## focusEditor()
-Returns focus to the last visible editor that had focus. If no editor visible, does nothing.This function should be called to restore editor focus after it has been temporarilyremoved. For example, after a dialog with editable text is closed.
+Returns focus to the last visible editor that had focus. If no editor visible, does nothing.
+This function should be called to restore editor focus after it has been temporarily
+removed. For example, after a dialog with editable text is closed.
 
 **Kind**: global function  
-<a name="resizeEditor"></a>
-
-## ..resizeEditor()..
-***Deprecated***
-
-**Kind**: global function  
-<a name="getCurrentlyViewedPath"></a>
-
-## ..getCurrentlyViewedPath() ⇒ <code>string</code>..
-***Deprecated***
-
-**Kind**: global function  
-**Returns**: <code>string</code> - path of the file currently viewed in the active, full sized editor or null when there is no active editor  
-<a name="setEditorHolder"></a>
-
-## ..setEditorHolder()..
-***Deprecated***
-
-**Kind**: global function  
-<a name="registerCustomViewer"></a>
-
-## ..registerCustomViewer()..
-***Deprecated***
-
-**Kind**: global function  
-**See**: MainViewFactory::#registerViewFactory  
 <a name="canOpenPath"></a>
 
 ## canOpenPath(fullPath) ⇒ <code>boolean</code>
@@ -158,36 +130,33 @@ Returns the focused Editor within an inline text editor, or null if something el
 <a name="getFocusedEditor"></a>
 
 ## getFocusedEditor() ⇒ <code>Editor</code>
-Returns the currently focused editor instance (full-sized OR inline editor).This function is similar to getActiveEditor(), with one main difference: thisfunction will only return editors that currently have focus, whereasgetActiveEditor() will return the last visible editor that was given focus (butmay not currently have focus because, for example, a dialog with editable textis open).
+Returns the currently focused editor instance (full-sized OR inline editor).
+This function is similar to getActiveEditor(), with one main difference: this
+function will only return editors that currently have focus, whereas
+getActiveEditor() will return the last visible editor that was given focus (but
+may not currently have focus because, for example, a dialog with editable text
+is open).
 
 **Kind**: global function  
 <a name="getActiveEditor"></a>
 
 ## getActiveEditor() ⇒ <code>Editor</code>
-Returns the current active editor (full-sized OR inline editor). This editor may nothave focus at the moment, but it is visible and was the last editor that was givenfocus. Returns null if no editors are active.
+Returns the current active editor (full-sized OR inline editor). This editor may not
+have focus at the moment, but it is visible and was the last editor that was given
+focus. Returns null if no editors are active.
 
 **Kind**: global function  
 **See**: #getFocusedEditor  
 <a name="getHoveredEditor"></a>
 
 ## getHoveredEditor(mousePos) ⇒ <code>Editor</code>
-Returns the editor/inline editor under given mouse cursor coordinates specified. The coordinates can be usuallyfetched from the `document.onmousemove` dom event handler or any dom events.https://stackoverflow.com/questions/7790725/javascript-track-mouse-position
+Returns the editor/inline editor under given mouse cursor coordinates specified. The coordinates can be usually
+fetched from the `document.onmousemove` dom event handler or any dom events.
+https://stackoverflow.com/questions/7790725/javascript-track-mouse-position
 
 **Kind**: global function  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | mousePos | <code>Object</code> | The mouse position(or the js event with mouse position). |
-
-<a name="_handleRemoveFromPaneView"></a>
-
-## \_handleRemoveFromPaneView(e, removedFiles)
-file removed from pane handler.
-
-**Kind**: global function  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| e | <code>jQuery.Event</code> |  |
-| removedFiles | <code>File</code> \| <code>Array.&lt;File&gt;</code> | file, path or array of files or paths that are being removed |
 

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -267,6 +267,7 @@ define(function (require, exports, module) {
 
     /**
      * Comparator to sort providers from high to low priority
+     * @private
      */
     function _providerSort(a, b) {
         return b.priority - a.priority;
@@ -351,7 +352,7 @@ define(function (require, exports, module) {
     /**
      *  Return the array of hint providers for the given language id.
      *  This gets called (potentially) on every keypress. So, it should be fast.
-     *
+     * @private
      * @param {!string} languageId
      * @return {?{provider: Object, priority: number[]}}
      */
@@ -370,6 +371,7 @@ define(function (require, exports, module) {
     var _beginSession;
 
     /**
+     * @private
      * End the current hinting session
      */
     function _endSession() {
@@ -393,7 +395,7 @@ define(function (require, exports, module) {
      *
      * NOTE: the sessionEditor, sessionProvider and hintList objects are
      * only guaranteed to be initialized during an active session.
-     *
+     * @private
      * @param {Editor} editor
      * @return boolean
      */
@@ -415,6 +417,7 @@ define(function (require, exports, module) {
      * render the hint list window.
      *
      * Assumes that it is called when a session is active (i.e. sessionProvider is not null).
+     * @private
      */
     function _updateHintList(callMoveUpEvent) {
 
@@ -473,6 +476,7 @@ define(function (require, exports, module) {
 
     /**
      * Try to begin a new hinting session.
+     * @private
      * @param {Editor} editor
      */
     _beginSession = function (editor) {
@@ -553,7 +557,7 @@ define(function (require, exports, module) {
      * what changed so that we could do all of this logic without looking at
      * key events. Then, the purposes of handleKeyEvent and handleChange could be
      * combined. Doing this well requires changing CodeMirror.
-     *
+     * @private
      * @param {Event} jqEvent
      * @param {Editor} editor
      * @param {KeyboardEvent} event
@@ -600,6 +604,7 @@ define(function (require, exports, module) {
     /**
      * Handle a selection change event in the editor. If the selection becomes a
      * multiple selection, end our current session.
+     * @private
      * @param {BracketsEvent} event
      * @param {Editor} editor
      */
@@ -615,7 +620,7 @@ define(function (require, exports, module) {
      * Start a new implicit hinting session, or update the existing hint list.
      * Called by the editor after handleKeyEvent, which is responsible for setting
      * the lastChar.
-     *
+     * @private
      * @param {Event} event
      * @param {Editor} editor
      * @param {{from: Pos, to: Pos, text: Array, origin: string}} changeList
@@ -669,7 +674,7 @@ define(function (require, exports, module) {
     }
 
     /**
-     *  Test if a hint popup is open.
+     * Test if a hint popup is open.
      *
      * @return {boolean} - true if the hints are open, false otherwise.
      */
@@ -680,6 +685,7 @@ define(function (require, exports, module) {
     /**
      * Explicitly start a new session. If we have an existing session,
      * then close the current one and restart a new one.
+     * @private
      * @param {Editor} editor
      */
     function _startNewSession(editor) {
@@ -705,6 +711,7 @@ define(function (require, exports, module) {
 
     /**
      * Expose CodeHintList for unit testing
+     * @private
      */
     function _getCodeHintList() {
         return hintList;

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -90,7 +90,7 @@ define(function (require, exports, module) {
 
     const tabSpacesStateManager = StateManager._createInternalStateManager(StateManager._INTERNAL_STATES.TAB_SPACES);
 
-    /** Editor helpers */
+    /* Editor helpers */
 
     let IndentHelper = require("./EditorHelper/IndentHelper"),
         EditorPreferences = require("./EditorHelper/EditorPreferences"),
@@ -98,11 +98,12 @@ define(function (require, exports, module) {
         ErrorPopupHelper = require("./EditorHelper/ErrorPopupHelper"),
         InlineWidgetHelper = require("./EditorHelper/InlineWidgetHelper");
 
-    /** Editor preferences */
+    /* Editor preferences */
 
     /**
      * A list of gutter name and priorities currently registered for editors.
      * The line number gutter is defined as \{ name: LINE_NUMBER_GUTTER, priority: 100 }
+     * @private
      * @type {Array<Object>} items - An array of objects, where each object contains the following properties:
      * @property {string} name - The name of the item.
      * @property {number} priority - The priority of the item.
@@ -138,22 +139,33 @@ define(function (require, exports, module) {
 
     let editorOptions = [...Object.keys(cmOptions), AUTO_TAB_SPACES];
 
-    /** Editor preferences */
+    /* Editor preferences */
 
     /**
      * Guard flag to prevent focus() reentrancy (via blur handlers), even across Editors
+     * @private
      * @type {boolean}
      */
     var _duringFocus = false;
 
     /**
-     * Constant: ignore upper boundary when centering text
-     * Constant: bulls-eye = strictly centre always
+     * Constant: Normal boundary check when centering text.
      * @type {number}
      */
-    var BOUNDARY_CHECK_NORMAL = 0,
-        BOUNDARY_IGNORE_TOP = 1,
-        BOUNDARY_BULLSEYE = 2;
+    var BOUNDARY_CHECK_NORMAL = 0;
+
+    /**
+     * Constant: Ignore the upper boundary when centering text.
+     * @type {number}
+     */
+    var BOUNDARY_IGNORE_TOP = 1;
+
+    /**
+     * Constant: Bulls-eye mode, strictly center the text always.
+     * @type {number}
+     */
+    var BOUNDARY_BULLSEYE = 2;
+
 
     /**
      * @private
@@ -167,6 +179,7 @@ define(function (require, exports, module) {
 
     /**
      * Helper functions to check options.
+     * @private
      * @param {number} options BOUNDARY_CHECK_NORMAL or BOUNDARY_IGNORE_TOP
      */
     function _checkTopBoundary(options) {
@@ -180,7 +193,7 @@ define(function (require, exports, module) {
     /**
      * Helper function to build preferences context based on the full path of
      * the file.
-     *
+     * @private
      * @param {string} fullPath Full path of the file
      *
      * @return {*} A context for the specified file name
@@ -193,6 +206,7 @@ define(function (require, exports, module) {
     /**
      * List of all current (non-destroy()ed) Editor instances. Needed when changing global preferences
      * that affect all editors, e.g. tabbing or color scheme settings.
+     * @private
      * @type {Array.<Editor>}
      */
     var _instances = [];
@@ -559,6 +573,7 @@ define(function (require, exports, module) {
     /**
      * Determine the mode to use from the document's language
      * Uses "text/plain" if the language does not define a mode
+     * @private
      * @return {string} The mode to use
      */
     Editor.prototype._getModeFromDocument = function () {
@@ -594,6 +609,7 @@ define(function (require, exports, module) {
     /**
      * Ensures that the lines that are actually hidden in the inline editor correspond to
      * the desired visible range.
+     * @private
      */
     Editor.prototype._updateHiddenLines = function () {
         if (this._visibleRange) {
@@ -615,6 +631,7 @@ define(function (require, exports, module) {
     /**
      * Sets the contents of the editor, clears the undo/redo history and marks the document clean. Dispatches a change event.
      * Semi-private: only Document should call this.
+     * @private
      * @param {!string} text
      */
     Editor.prototype._resetText = function (text) {
@@ -1245,14 +1262,38 @@ define(function (require, exports, module) {
     }
 
     /**
-     * Mark options to use with API with Editor.markText or Editor.markToken.
+     * Mark option to underline errors.
      */
     Editor.getMarkOptionUnderlineError = getMarkOptionUnderlineError;
+
+    /**
+     * Mark option to underline warnings.
+     */
     Editor.getMarkOptionUnderlineWarn = getMarkOptionUnderlineWarn;
+
+    /**
+     * Mark option to underline informational text.
+     */
     Editor.getMarkOptionUnderlineInfo = getMarkOptionUnderlineInfo;
+
+    /**
+     * Mark option to underline spelling errors.
+     */
     Editor.getMarkOptionUnderlineSpellcheck = getMarkOptionUnderlineSpellcheck;
+
+    /**
+     * Mark option to highlight hyperlinks.
+     */
     Editor.getMarkOptionHyperlinkText = getMarkOptionHyperlinkText;
+
+    /**
+     * Mark option for matching references.
+     */
     Editor.getMarkOptionMatchingRefs = getMarkOptionMatchingRefs;
+
+    /**
+     * Mark option for renaming outlines.
+     */
     Editor.getMarkOptionRenameOutline = getMarkOptionRenameOutline;
 
     /**
@@ -1471,6 +1512,7 @@ define(function (require, exports, module) {
     /**
      * Creates a named restore point in undo history. this can be later be restored to undo all
      * changed till the named restore point in one go.
+     * @param {string} restorePointName - The name of the restore point to revert to.
      */
     Editor.prototype.createHistoryRestorePoint = function (restorePointName) {
         const history = this.getHistory();
@@ -1483,6 +1525,12 @@ define(function (require, exports, module) {
         this._codeMirror.changeGeneration(true);
     };
 
+    /**
+     * To restore the editor to a named restore point
+     * if the restore point is found, it reverts all changes made after that point.
+     *
+     * @param {string} restorePointName - The name of the restore point to revert to.
+     */
     Editor.prototype.restoreHistoryPoint = function (restorePointName) {
         const history = this.getHistory();
         if (!history.done && !history.done.length) {
@@ -1672,6 +1720,12 @@ define(function (require, exports, module) {
         this.setSelection(word.anchor, word.head);
     };
 
+    /**
+     * To get the text between the starting position and the ending position
+     * @param {!{line:number, ch:number}} startPos | The starting position
+     * @param {!{line:number, ch:number}} endPos | The ending position
+     * @returns {string} The text between the starting position and the ending position
+     */
     Editor.prototype.getTextBetween = function (startPos, endPos) {
         const text = this._codeMirror.getRange(startPos, endPos);
         return text;
@@ -1795,7 +1849,9 @@ define(function (require, exports, module) {
         return (this._visibleRange ? this._visibleRange.endLine : this.lineCount() - 1);
     };
 
-    /* Hides the specified line number in the editor
+    /**
+     * Hides the specified line number in the editor
+     * @private
      * @param {!from} line to start hiding from (inclusive)
      * @param {!to} line to end hiding at (exclusive)
      * @return {TextMarker} The CodeMirror mark object that's hiding the lines
@@ -1847,6 +1903,7 @@ define(function (require, exports, module) {
      * Gets the lineSpace element within the editor (the container around the individual lines of code).
      * FUTURE: This is fairly CodeMirror-specific. Logic that depends on this may break if we switch
      * editors.
+     * @private
      * @return {!HTMLDivElement} The editor's lineSpace element.
      */
     Editor.prototype._getLineSpaceElement = function () {
@@ -1880,7 +1937,7 @@ define(function (require, exports, module) {
         this._codeMirror.scrollTo(x, y);
     };
 
-    /*
+    /**
      * Returns the current text height of the editor.
      * @return {number} Height of the text in pixels
      */
@@ -1995,7 +2052,7 @@ define(function (require, exports, module) {
      * @typedef {scrollPos:{x:number, y:number},{start:{line:number, ch:number},end:{line:number, ch:number}}} EditorViewState
      */
 
-    /*
+    /**
      * returns the view state for the editor
      * @return {!EditorViewState}
      */
@@ -2233,6 +2290,7 @@ define(function (require, exports, module) {
      * The Editor's last known width.
      * Used in conjunction with updateLayout to recompute the layout
      * if the parent container changes its size since our last layout update.
+     * @private
      * @type {?number}
      */
     Editor.prototype._lastEditorWidth = null;
@@ -2241,6 +2299,7 @@ define(function (require, exports, module) {
     /**
      * If true, we're in the middle of syncing to/from the Document. Used to ignore spurious change
      * events caused by us (vs. change events caused by others, which we need to pay attention to).
+     * @private
      * @type {!boolean}
      */
     Editor.prototype._duringSync = false;
@@ -2948,6 +3007,7 @@ define(function (require, exports, module) {
     Editor.CODE_FOLDING_GUTTER_PRIORITY = CODE_FOLDING_GUTTER_PRIORITY;
 
     /**
+     * @private
      * Each Editor instance object dispatches the following events:
      *    - keydown, keypress, keyup -- When any key event happens in the editor (whether it changes the
      *      text or not). Handlers are passed `(BracketsEvent, Editor, KeyboardEvent)`. The 3nd arg is the

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -152,19 +152,19 @@ define(function (require, exports, module) {
      * Constant: Normal boundary check when centering text.
      * @type {number}
      */
-    var BOUNDARY_CHECK_NORMAL = 0;
+    const BOUNDARY_CHECK_NORMAL = 0;
 
     /**
      * Constant: Ignore the upper boundary when centering text.
      * @type {number}
      */
-    var BOUNDARY_IGNORE_TOP = 1;
+    const BOUNDARY_IGNORE_TOP = 1;
 
     /**
      * Constant: Bulls-eye mode, strictly center the text always.
      * @type {number}
      */
-    var BOUNDARY_BULLSEYE = 2;
+    const BOUNDARY_BULLSEYE = 2;
 
 
     /**

--- a/src/editor/EditorCommandHandlers.js
+++ b/src/editor/EditorCommandHandlers.js
@@ -21,8 +21,6 @@
 
 /*global Phoenix*/
 
-// @INCLUDE_IN_API_DOCS
-
 /**
  * Text-editing commands that apply to whichever Editor is currently focused
  */

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -274,7 +274,7 @@ define(function (require, exports, module) {
 
     /**
      * Closes any focused inline widget. Else, asynchronously asks providers to create one.
-     *
+     * @private
      * @param {{priority:number, provider:function(...)}} array providers
      *   prioritized list of providers
      * @param {string=} errorMsg Default message to display if no providers return non-null
@@ -344,6 +344,7 @@ define(function (require, exports, module) {
      * Only called from Document._ensureMasterEditor()
      * The editor view is placed in a hidden part of the DOM but can later be moved to a visible pane
      * when the document is opened using pane.addView()
+     * @private
      * @param {!Document} doc - document to create a hidden editor for
      */
     function _createUnattachedMasterEditor(doc) {
@@ -419,7 +420,6 @@ define(function (require, exports, module) {
 
 
     /**
-     * @private
      * Given a host editor, return a list of all Editors in all its open inline widgets. (Ignoring
      * any other inline widgets that might be open but don't contain Editors).
      * @param {!Editor} hostEditor
@@ -500,6 +500,7 @@ define(function (require, exports, module) {
     }
 
     /**
+     * @private
      * @deprecated
      * resizes the editor
      */
@@ -559,6 +560,7 @@ define(function (require, exports, module) {
     }
 
     /**
+     * @private
      * @deprecated use MainViewManager.getCurrentlyViewedFile() instead
      * @return {string=} path of the file currently viewed in the active, full sized editor or null when there is no active editor
      */
@@ -582,6 +584,7 @@ define(function (require, exports, module) {
     }
 
     /**
+     * @private
      * @deprecated There is no equivalent API moving forward.
      * Use MainViewManager._initialize() from a unit test to create a Main View attached to a specific DOM element
      */
@@ -590,6 +593,7 @@ define(function (require, exports, module) {
     }
 
     /**
+     * @private
      * @deprecated Register a View Factory instead
      * @see MainViewFactory::#registerViewFactory
      */
@@ -744,6 +748,7 @@ define(function (require, exports, module) {
 
     /**
      * file removed from pane handler.
+     * @private
      * @param {jQuery.Event} e
      * @param {File|Array.<File>} removedFiles - file, path or array of files or paths that are being removed
      */


### PR DESCRIPTION
The following changes are made :


Removed CommandHandler.md from the API docs
    – This file is removed from API docs, as this in an internal module.


Marked deprecated methods as `@private` in EditorManager.js
    – The deprecated methods are now marked as `@private` to remove them from API docs,


Tweaked jsdoc style comments in Editor.js where required
    – Changed `/** ... */` to `/* ... */` so they don’t show up in the API docs. Now, the comments stay in the code without cluttering the docs.