### PR TITLE
docs: refine API docs for files in JSUtils dir

### DIFF
--- a/docs/API-Reference/JSUtils/Preferences.md
+++ b/docs/API-Reference/JSUtils/Preferences.md
@@ -31,14 +31,16 @@ Constructor to create a default preference object.
 Get the regular expression for excluded directories.
 
 **Kind**: instance method of [<code>Preferences</code>](#Preferences)  
-**Returns**: <code>RegExp</code> - Regular expression matching the directories that shouldbe excluded. Returns null if no directories are excluded.  
+**Returns**: <code>RegExp</code> - Regular expression matching the directories that should
+be excluded. Returns null if no directories are excluded.  
 <a name="Preferences+getExcludedFiles"></a>
 
 ### preferences.getExcludedFiles() ⇒ <code>RegExp</code>
 Get the regular expression for excluded files.
 
 **Kind**: instance method of [<code>Preferences</code>](#Preferences)  
-**Returns**: <code>RegExp</code> - Regular expression matching the files that shouldbe excluded. Returns null if no files are excluded.  
+**Returns**: <code>RegExp</code> - Regular expression matching the files that should
+be excluded. Returns null if no files are excluded.  
 <a name="Preferences+getMaxFileCount"></a>
 
 ### preferences.getMaxFileCount() ⇒ <code>number</code>
@@ -48,20 +50,7 @@ Get the maximum number of files that will be analyzed.
 <a name="Preferences+getMaxFileSize"></a>
 
 ### preferences.getMaxFileSize() ⇒ <code>number</code>
-Get the maximum size of a file that will be analyzed. Files that arelarger will be ignored.
+Get the maximum size of a file that will be analyzed. Files that are
+larger will be ignored.
 
 **Kind**: instance method of [<code>Preferences</code>](#Preferences)  
-<a name="settingsToRegExp"></a>
-
-## settingsToRegExp(settings, baseRegExp, defaultRegExp) ⇒ <code>RegExp</code>
-Convert an array of strings with optional wildcards, to an equivalent regular expression.
-
-**Kind**: global function  
-**Returns**: <code>RegExp</code> - Regular expression that captures the array of stringwith optional wildcards.  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| settings | <code>Array.&lt;(string\|RegExp)&gt;</code> | from the file (note: this may be mutated by this function) |
-| baseRegExp | <code>RegExp</code> | base regular expression that is always used |
-| defaultRegExp | <code>RegExp</code> | additional regular expression that is only used if the user has not configured settings |
-

--- a/docs/API-Reference/JSUtils/ScopeManager.md
+++ b/docs/API-Reference/JSUtils/ScopeManager.md
@@ -10,87 +10,18 @@ An array of library names that contain JavaScript builtins definitions.
 
 **Kind**: global function  
 **Returns**: <code>Array.&lt;string&gt;</code> - - array of library  names.  
-<a name="initTernEnv"></a>
-
-## initTernEnv()
-Read in the json files that have type information for the builtins, dom,etc
-
-**Kind**: global function  
-<a name="initPreferences"></a>
-
-## initPreferences([projectRootPath])
-Init preferences from a file in the project root or builtin defaults if no file is found;
-
-**Kind**: global function  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| [projectRootPath] | <code>string</code> | new project root path. Only needed  for unit tests. |
-
-<a name="ensurePreferences"></a>
-
-## ensurePreferences()
-Will initialize preferences only if they do not exist.
-
-**Kind**: global function  
 <a name="postMessage"></a>
 
 ## postMessage()
-Send a message to the tern module - if the module is being initialized,the message will not be posted until initialization is complete
+Send a message to the tern module - if the module is being initialized,
+the message will not be posted until initialization is complete
 
 **Kind**: global function  
-<a name="isDirectoryExcluded"></a>
-
-## isDirectoryExcluded(path) ⇒ <code>boolean</code>
-Test if the directory should be excluded from analysis.
-
-**Kind**: global function  
-**Returns**: <code>boolean</code> - true if excluded, false otherwise.  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| path | <code>string</code> | full directory path. |
-
-<a name="isFileBeingEdited"></a>
-
-## isFileBeingEdited(filePath) ⇒ <code>boolean</code>
-Test if the file path is in current editor
-
-**Kind**: global function  
-**Returns**: <code>boolean</code> - true if in editor, false otherwise.  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| filePath | <code>string</code> | file path to test for exclusion. |
-
-<a name="isFileExcludedInternal"></a>
-
-## isFileExcludedInternal(path) ⇒ <code>boolean</code>
-Test if the file path is an internal exclusion.
-
-**Kind**: global function  
-**Returns**: <code>boolean</code> - true if excluded, false otherwise.  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| path | <code>string</code> | file path to test for exclusion. |
-
-<a name="isFileExcluded"></a>
-
-## isFileExcluded(file) ⇒ <code>boolean</code>
-Test if the file should be excluded from analysis.
-
-**Kind**: global function  
-**Returns**: <code>boolean</code> - true if excluded, false otherwise.  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| file | <code>File</code> | file to test for exclusion. |
-
 <a name="addPendingRequest"></a>
 
 ## addPendingRequest(file, offset, type) ⇒ <code>jQuery.Promise</code>
-Add a pending request waiting for the tern-module to complete.If file is a detected exclusion, then reject request.
+Add a pending request waiting for the tern-module to complete.
+If file is a detected exclusion, then reject request.
 
 **Kind**: global function  
 **Returns**: <code>jQuery.Promise</code> - - the promise for the request  
@@ -125,19 +56,6 @@ Get any pending $.Deferred object waiting on the specified file and request type
 | --- | --- | --- |
 | file | <code>string</code> | a relative path |
 
-<a name="getJumptoDef"></a>
-
-## getJumptoDef(fileInfo, offset) ⇒ <code>jQuery.Promise</code>
-Get a Promise for the definition from TernJS, for the file & offset passed in.
-
-**Kind**: global function  
-**Returns**: <code>jQuery.Promise</code> - - a promise that will resolve to definition when     it is done  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| fileInfo | <code>Object</code> | - type of update, name of file, and the text of the update. For "full" updates, the whole text of the file is present. For "part" updates, the changed portion of the text. For "empty" updates, the file has not been modified and the text is empty. |
-| offset | <code>Object</code> | the offset in the file the hints should be calculate at |
-
 <a name="filterText"></a>
 
 ## filterText(the) ⇒ <code>string</code>
@@ -150,36 +68,14 @@ check to see if the text we are sending to Tern is too long.
 | --- | --- | --- |
 | the | <code>string</code> | text to check |
 
-<a name="getTextFromDocument"></a>
-
-## getTextFromDocument(document) ⇒ <code>string</code>
-Get the text of a document, applying any size restrictionsif necessary
-
-**Kind**: global function  
-**Returns**: <code>string</code> - the text, or the empty text if the original was too long  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| document | <code>Document</code> | the document to get the text from |
-
-<a name="handleRename"></a>
-
-## handleRename(response)
-Handle the response from the tern node domain whenit responds with the references
-
-**Kind**: global function  
-
-| Param | Description |
-| --- | --- |
-| response | the response from the node domain |
-
 <a name="requestJumptoDef"></a>
 
 ## requestJumptoDef(session, document, offset) ⇒ <code>jQuery.Promise</code>
 Request Jump-To-Definition from Tern.
 
 **Kind**: global function  
-**Returns**: <code>jQuery.Promise</code> - - The promise will not complete until tern     has completed.  
+**Returns**: <code>jQuery.Promise</code> - - The promise will not complete until tern
+     has completed.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -187,35 +83,14 @@ Request Jump-To-Definition from Tern.
 | document | <code>Document</code> | the document |
 | offset | <code>Object</code> | the offset into the document |
 
-<a name="handleJumptoDef"></a>
-
-## handleJumptoDef(response)
-Handle the response from the tern node domain whenit responds with the definition
-
-**Kind**: global function  
-
-| Param | Description |
-| --- | --- |
-| response | the response from the node domain |
-
-<a name="handleScopeData"></a>
-
-## handleScopeData(response)
-Handle the response from the tern node domain whenit responds with the scope data
-
-**Kind**: global function  
-
-| Param | Description |
-| --- | --- |
-| response | the response from the node domain |
-
 <a name="getTernHints"></a>
 
 ## getTernHints(fileInfo, offset, isProperty) ⇒ <code>jQuery.Promise</code>
 Get a Promise for the completions from TernJS, for the file & offset passed in.
 
 **Kind**: global function  
-**Returns**: <code>jQuery.Promise</code> - - a promise that will resolve to an array of completions when     it is done  
+**Returns**: <code>jQuery.Promise</code> - - a promise that will resolve to an array of completions when
+     it is done  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -223,139 +98,34 @@ Get a Promise for the completions from TernJS, for the file & offset passed in.
 | offset | <code>Object</code> | the offset in the file the hints should be calculate at |
 | isProperty | <code>boolean</code> | true if getting a property hint, otherwise getting an identifier hint. |
 
-<a name="getTernFunctionType"></a>
-
-## getTernFunctionType(fileInfo, offset) ⇒ <code>jQuery.Promise</code>
-Get a Promise for the function type from TernJS.
-
-**Kind**: global function  
-**Returns**: <code>jQuery.Promise</code> - - a promise that will resolve to the function type of the function being called.  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| fileInfo | <code>Object</code> | - type of update, name of file, and the text of the update. For "full" updates, the whole text of the file is present. For "part" updates, the changed portion of the text. For "empty" updates, the file has not been modified and the text is empty. |
-| offset | <code>Object</code> | the line, column info for what we want the function type of. |
-
-<a name="getFragmentAround"></a>
-
-## getFragmentAround(session, start) ⇒ <code>Object</code>
-Given a starting and ending position, get a code fragment that is self contained enough to be compiled.
-
-**Kind**: global function  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| session | <code>Session</code> | the current session |
-| start | <code>Object</code> | the starting position of the changes |
-
-<a name="getFileInfo"></a>
-
-## getFileInfo(session, [preventPartialUpdates]) ⇒ <code>Object</code>
-Get an object that describes what tern needs to know about the updatedfile to produce a hint. As a side-effect of this calls the documentchanges are reset.
-
-**Kind**: global function  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| session | <code>Session</code> | the current session |
-| [preventPartialUpdates] | <code>boolean</code> | if true, disallow partial updates. Optional, defaults to false. |
-
-<a name="getOffset"></a>
-
-## getOffset(session, fileInfo, [offset]) ⇒ <code>Object</code>
-Get the current offset. The offset is adjusted for "part" updates.
-
-**Kind**: global function  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| session | <code>Session</code> | the current session |
-| fileInfo | <code>Object</code> | - type of update, name of file, and the text of the update. For "full" updates, the whole text of the file is present. For "part" updates, the changed portion of the text. For "empty" updates, the file has not been modified and the text is empty. |
-| [offset] | <code>Object</code> | the default offset (optional). Will use the cursor if not provided. |
-
 <a name="requestGuesses"></a>
 
 ## requestGuesses(session, document) ⇒ <code>jQuery.Promise</code>
-Get a Promise for all of the known properties from TernJS, for the directory and file.The properties will be used as guesses in tern.
+Get a Promise for all of the known properties from TernJS, for the directory and file.
+The properties will be used as guesses in tern.
 
 **Kind**: global function  
-**Returns**: <code>jQuery.Promise</code> - - The promise will not complete until the tern     request has completed.  
+**Returns**: <code>jQuery.Promise</code> - - The promise will not complete until the tern
+     request has completed.  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | session | <code>Session</code> | the active hinting session |
 | document | <code>Document</code> | the document for which scope info is      desired |
 
-<a name="handleTernCompletions"></a>
-
-## handleTernCompletions(response)
-Handle the response from the tern node domain whenit responds with the list of completions
-
-**Kind**: global function  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| response | <code>Object</code> | the response from node domain |
-
-<a name="handleGetGuesses"></a>
-
-## handleGetGuesses(response)
-Handle the response from the tern node domain whenit responds to the get guesses message.
-
-**Kind**: global function  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| response | <code>Object</code> | the response from node domain contains the guesses for a      property lookup. |
-
-<a name="handleUpdateFile"></a>
-
-## handleUpdateFile(response)
-Handle the response from the tern node domain whenit responds to the update file message.
-
-**Kind**: global function  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| response | <code>Object</code> | the response from node domain |
-
-<a name="handleTimedOut"></a>
-
-## handleTimedOut(response)
-Handle timed out inference
-
-**Kind**: global function  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| response | <code>Object</code> | the response from node domain |
-
 <a name="TernModule"></a>
 
 ## TernModule()
-Encapsulate all the logic to talk to the tern module.  This will createa new instance of a TernModule, which the rest of the hinting code can use to talkto the tern node domain, without worrying about initialization, priming the pump, etc.
+Encapsulate all the logic to talk to the tern module.  This will create
+a new instance of a TernModule, which the rest of the hinting code can use to talk
+to the tern node domain, without worrying about initialization, priming the pump, etc.
 
 **Kind**: global function  
 
 * [TernModule()](#TernModule)
     * [.getResolvedPath(file)](#TernModule..getResolvedPath) ⇒ <code>string</code>
-    * [.usingModules()](#TernModule..usingModules) ⇒ <code>boolean</code>
     * [.postMessage()](#TernModule..postMessage)
-    * [._postMessageByPass()](#TernModule.._postMessageByPass)
-    * [.updateTernFile(document)](#TernModule..updateTernFile) ⇒ <code>jQuery.Promise</code>
-    * [.handleTernGetFile(request)](#TernModule..handleTernGetFile)
-        * [.getDocText(filePath)](#TernModule..handleTernGetFile..getDocText) ⇒ <code>jQuery.Promise</code>
-        * [.findNameInProject()](#TernModule..handleTernGetFile..findNameInProject)
-    * [.primePump(path)](#TernModule..primePump) ⇒ <code>jQuery.Promise</code>
-    * [.handlePrimePumpCompletion(response)](#TernModule..handlePrimePumpCompletion)
-    * [.addFilesToTern(files)](#TernModule..addFilesToTern) ⇒ <code>boolean</code>
-    * [.addAllFilesAndSubdirectories(dir, doneCallback)](#TernModule..addAllFilesAndSubdirectories)
-    * [.initTernModule()](#TernModule..initTernModule)
-    * [.initTernServer()](#TernModule..initTernServer)
-    * [.canSkipTernInitialization(newFile)](#TernModule..canSkipTernInitialization) ⇒ <code>boolean</code>
-    * [.doEditorChange(session, document, previousDocument)](#TernModule..doEditorChange)
     * [.handleEditorChange(session, document, previousDocument)](#TernModule..handleEditorChange)
-    * [.resetModule()](#TernModule..resetModule)
 
 <a name="TernModule..getResolvedPath"></a>
 
@@ -367,155 +137,13 @@ Encapsulate all the logic to talk to the tern module.  This will createa new in
 | --- | --- | --- |
 | file | <code>string</code> | a relative path |
 
-<a name="TernModule..usingModules"></a>
-
-### TernModule.usingModules() ⇒ <code>boolean</code>
-Determine whether the current set of files are using modules to pull in additional files.
-
-**Kind**: inner method of [<code>TernModule</code>](#TernModule)  
-**Returns**: <code>boolean</code> - - true if more files than the current directory havebeen read in.  
 <a name="TernModule..postMessage"></a>
 
 ### TernModule.postMessage()
-Send a message to the tern node domain - if the module is being initialized,the message will not be posted until initialization is complete
+Send a message to the tern node domain - if the module is being initialized,
+the message will not be posted until initialization is complete
 
 **Kind**: inner method of [<code>TernModule</code>](#TernModule)  
-<a name="TernModule.._postMessageByPass"></a>
-
-### TernModule.\_postMessageByPass()
-Send a message to the tern node domain - this is only for messages thatneed to be sent before and while the addFilesPromise is being resolved.
-
-**Kind**: inner method of [<code>TernModule</code>](#TernModule)  
-<a name="TernModule..updateTernFile"></a>
-
-### TernModule.updateTernFile(document) ⇒ <code>jQuery.Promise</code>
-Update tern with the new contents of a given file.
-
-**Kind**: inner method of [<code>TernModule</code>](#TernModule)  
-**Returns**: <code>jQuery.Promise</code> - - the promise for the request  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| document | <code>Document</code> | the document to update |
-
-<a name="TernModule..handleTernGetFile"></a>
-
-### TernModule.handleTernGetFile(request)
-Handle a request from the tern node domain for text of a file
-
-**Kind**: inner method of [<code>TernModule</code>](#TernModule)  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| request | <code>Object</code> | the request from the tern node domain.  Should be an Object containing the name      of the file tern wants the contents of |
-
-
-* [.handleTernGetFile(request)](#TernModule..handleTernGetFile)
-    * [.getDocText(filePath)](#TernModule..handleTernGetFile..getDocText) ⇒ <code>jQuery.Promise</code>
-    * [.findNameInProject()](#TernModule..handleTernGetFile..findNameInProject)
-
-<a name="TernModule..handleTernGetFile..getDocText"></a>
-
-#### handleTernGetFile.getDocText(filePath) ⇒ <code>jQuery.Promise</code>
-Helper function to get the text of a given document and send it to tern.If DocumentManager successfully gets the file's text then we'll send it to the tern node domain.The Promise for getDocumentText() is returned so that custom fail functions can be used.
-
-**Kind**: inner method of [<code>handleTernGetFile</code>](#TernModule..handleTernGetFile)  
-**Returns**: <code>jQuery.Promise</code> - - the Promise returned from DocumentMangaer.getDocumentText()  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| filePath | <code>string</code> | the path of the file to get the text of |
-
-<a name="TernModule..handleTernGetFile..findNameInProject"></a>
-
-#### handleTernGetFile.findNameInProject()
-Helper function to find any files in the project that end with thename we are looking for.  This is so we can find requirejs moduleswhen the baseUrl is unknown, or when the project root is not the sameas the script root (e.g. if you open the 'brackets' dir instead of 'brackets/src' dir).
-
-**Kind**: inner method of [<code>handleTernGetFile</code>](#TernModule..handleTernGetFile)  
-<a name="TernModule..primePump"></a>
-
-### TernModule.primePump(path) ⇒ <code>jQuery.Promise</code>
-Prime the pump for a fast first lookup.
-
-**Kind**: inner method of [<code>TernModule</code>](#TernModule)  
-**Returns**: <code>jQuery.Promise</code> - - the promise for the request  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| path | <code>string</code> | full path of file |
-
-<a name="TernModule..handlePrimePumpCompletion"></a>
-
-### TernModule.handlePrimePumpCompletion(response)
-Handle the response from the tern node domain whenit responds to the prime pump message.
-
-**Kind**: inner method of [<code>TernModule</code>](#TernModule)  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| response | <code>Object</code> | the response from node domain |
-
-<a name="TernModule..addFilesToTern"></a>
-
-### TernModule.addFilesToTern(files) ⇒ <code>boolean</code>
-Add new files to tern, keeping any previous files. The tern server must be initialized before making this call.
-
-**Kind**: inner method of [<code>TernModule</code>](#TernModule)  
-**Returns**: <code>boolean</code> - - true if more files may be added, false if maximum has been reached.  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| files | <code>Array.&lt;string&gt;</code> | array of file to add to tern. |
-
-<a name="TernModule..addAllFilesAndSubdirectories"></a>
-
-### TernModule.addAllFilesAndSubdirectories(dir, doneCallback)
-Add the files in the directory and subdirectories of a given directory to tern.
-
-**Kind**: inner method of [<code>TernModule</code>](#TernModule)  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| dir | <code>string</code> | the root directory to add. |
-| doneCallback | <code>function</code> | called when all files have been added to tern. |
-
-<a name="TernModule..initTernModule"></a>
-
-### TernModule.initTernModule()
-Init the Tern module that does all the code hinting work.
-
-**Kind**: inner method of [<code>TernModule</code>](#TernModule)  
-<a name="TernModule..initTernServer"></a>
-
-### TernModule.initTernServer()
-Create a new tern server.
-
-**Kind**: inner method of [<code>TernModule</code>](#TernModule)  
-<a name="TernModule..canSkipTernInitialization"></a>
-
-### TernModule.canSkipTernInitialization(newFile) ⇒ <code>boolean</code>
-We can skip tern initialization if we are opening a file that has already been added to tern.
-
-**Kind**: inner method of [<code>TernModule</code>](#TernModule)  
-**Returns**: <code>boolean</code> - - true if tern initialization should be skipped,false otherwise.  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| newFile | <code>string</code> | full path of new file being opened in the editor. |
-
-<a name="TernModule..doEditorChange"></a>
-
-### TernModule.doEditorChange(session, document, previousDocument)
-Do the work to initialize a code hinting session.
-
-**Kind**: inner method of [<code>TernModule</code>](#TernModule)  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| session | <code>Session</code> | the active hinting session (TODO: currently unused) |
-| document | <code>Document</code> | the document the editor has changed to |
-| previousDocument | <code>Document</code> | the document the editor has changed from |
-
 <a name="TernModule..handleEditorChange"></a>
 
 ### TernModule.handleEditorChange(session, document, previousDocument)
@@ -529,33 +157,14 @@ Called each time a new editor becomes active.
 | document | <code>Document</code> | the document of the editor that has changed |
 | previousDocument | <code>Document</code> | the document of the editor is changing from |
 
-<a name="TernModule..resetModule"></a>
-
-### TernModule.resetModule()
-Do some cleanup when a project is closed.We can clean up the node tern server we use to calculate hints now, sincewe know we will need to re-init it in any new project that is opened.
-
-**Kind**: inner method of [<code>TernModule</code>](#TernModule)  
-<a name="_maybeReset"></a>
-
-## \_maybeReset(session, document, force) ⇒ <code>Promise</code>
-reset the tern module, if necessary.During debugging, you can turn this automatic resetting behavior offby running this in the console:```jsbrackets._configureJSCodeHints({ noReset: true })```This function is also used in unit testing with the "force" flag toreset the module for each test to start with a clean environment.
-
-**Kind**: global function  
-**Returns**: <code>Promise</code> - Promise resolved when the module is ready.                  The new (or current, if there was no reset) module is passed to the callback.  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| session | <code>Session</code> |  |
-| document | <code>Document</code> |  |
-| force | <code>boolean</code> | true to force a reset regardless of how long since the last one |
-
 <a name="requestParameterHint"></a>
 
 ## requestParameterHint(session, functionOffset) ⇒ <code>jQuery.Promise</code>
 Request a parameter hint from Tern.
 
 **Kind**: global function  
-**Returns**: <code>jQuery.Promise</code> - - The promise will not complete until the     hint has completed.  
+**Returns**: <code>jQuery.Promise</code> - - The promise will not complete until the
+     hint has completed.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -565,26 +174,33 @@ Request a parameter hint from Tern.
 <a name="requestHints"></a>
 
 ## requestHints(session, document) ⇒ <code>jQuery.Promise</code>
-Request hints from Tern.Note that successive calls to getScope may return the same objects, soclients that wish to modify those objects (e.g., by annotating them basedon some temporary context) should copy them first. See, e.g.,Session.getHints().
+Request hints from Tern.
+
+Note that successive calls to getScope may return the same objects, so
+clients that wish to modify those objects (e.g., by annotating them based
+on some temporary context) should copy them first. See, e.g.,
+Session.getHints().
 
 **Kind**: global function  
-**Returns**: <code>jQuery.Promise</code> - - The promise will not complete until the tern     hints have completed.  
+**Returns**: <code>jQuery.Promise</code> - - The promise will not complete until the tern
+     hints have completed.  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | session | <code>Session</code> | the active hinting session |
 | document | <code>Document</code> | the document for which scope info is      desired |
 
-<a name="trackChange"></a>
+<a name="handleFileChange"></a>
 
-## trackChange(changeList)
-Track the update area of the current document so we can tell if we can send partial updates to tern or not.
+## handleFileChange(changeList)
+Called each time the file associated with the active editor changes.
+Marks the file as being dirty.
 
 **Kind**: global function  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| changeList | <code>Object</code> | The document changes from the current change event |
+| changeList | <code>Object</code> | {from: {line:number, ch: number}, to: {line:number, ch:number}} |
 
 <a name="handleEditorChange"></a>
 
@@ -602,13 +218,15 @@ Called each time a new editor becomes active.
 <a name="handleProjectClose"></a>
 
 ## handleProjectClose()
-Do some cleanup when a project is closed.Clean up previous analysis data from the module
+Do some cleanup when a project is closed.
+Clean up previous analysis data from the module
 
 **Kind**: global function  
 <a name="handleProjectOpen"></a>
 
 ## handleProjectOpen([projectRootPath])
-Read in project preferences when a new project is opened. Look in the project root directory for a preference file.
+Read in project preferences when a new project is opened.
+ Look in the project root directory for a preference file.
 
 **Kind**: global function  
 
@@ -616,9 +234,3 @@ Read in project preferences when a new project is opened. Look in the project r
 | --- | --- | --- |
 | [projectRootPath] | <code>string</code> | new project root path(optional).  Only needed for unit tests. |
 
-<a name="_readyPromise"></a>
-
-## \_readyPromise()
-Used to avoid timing bugs in unit tests
-
-**Kind**: global function  

--- a/docs/API-Reference/JSUtils/Session.md
+++ b/docs/API-Reference/JSUtils/Session.md
@@ -18,18 +18,13 @@ const Session = brackets.getModule("JSUtils/Session")
     * [.getToken(cursor)](#Session+getToken) ⇒ <code>Object</code>
     * [.getNextTokenOnLine(cursor)](#Session+getNextTokenOnLine) ⇒ <code>Object</code>
     * [.getNextCursorOnLine()](#Session+getNextCursorOnLine) ⇒ <code>Object</code>
-    * [._getPreviousToken(cursor)](#Session+_getPreviousToken) ⇒ <code>Object</code>
     * [.getNextToken(cursor, skipWhitespace)](#Session+getNextToken) ⇒ <code>Object</code>
     * [.getQuery()](#Session+getQuery) ⇒ <code>String</code>
     * [.getContext(cursor, [depth])](#Session+getContext) ⇒ <code>String</code>
     * [.findPreviousDot()](#Session+findPreviousDot) ⇒ <code>Object</code>
     * [.getFunctionInfo()](#Session+getFunctionInfo) ⇒ <code>Object</code>
-        * [.isOnFunctionIdentifier()](#Session+getFunctionInfo..isOnFunctionIdentifier) ⇒ <code>Object</code>
-        * [.isInFunctionalCall(lex)](#Session+getFunctionInfo..isInFunctionalCall) ⇒ <code>Object</code> \| <code>Boolean</code>
     * [.getType()](#Session+getType) ⇒ <code>Object</code>
     * [.getHints(query, matcher)](#Session+getHints) ⇒ <code>Object</code>
-        * [.isBuiltin(origin)](#Session+getHints..isBuiltin)
-        * [.filterWithQueryAndMatcher(hints, matcher)](#Session+getHints..filterWithQueryAndMatcher) ⇒ <code>Array</code>
     * [.setFnType(newFnType)](#Session+setFnType)
     * [.setFunctionCallPos(functionCallPos)](#Session+setFunctionCallPos)
     * [.getParameterHint()](#Session+getParameterHint) ⇒ <code>Object</code>
@@ -39,7 +34,8 @@ const Session = brackets.getModule("JSUtils/Session")
 <a name="new_Session_new"></a>
 
 ### new Session(editor)
-Session objects encapsulate state associated with a hinting sessionand provide methods for updating and querying the session.
+Session objects encapsulate state associated with a hinting session
+and provide methods for updating and querying the session.
 
 
 | Param | Type | Description |
@@ -52,7 +48,8 @@ Session objects encapsulate state associated with a hinting sessionand provide 
 Get the name of the file associated with the current session
 
 **Kind**: instance method of [<code>Session</code>](#Session)  
-**Returns**: <code>String</code> - - the full pathname of the file associated with the     current session  
+**Returns**: <code>String</code> - - the full pathname of the file associated with the
+     current session  
 <a name="Session+getCursor"></a>
 
 ### session.getCursor() ⇒ <code>Object</code>
@@ -78,7 +75,8 @@ Get the text of a line.
 Get the offset of the current cursor position
 
 **Kind**: instance method of [<code>Session</code>](#Session)  
-**Returns**: <code>number</code> - - the offset into the current document of the current     cursor  
+**Returns**: <code>number</code> - - the offset into the current document of the current
+     cursor  
 <a name="Session+getOffsetFromCursor"></a>
 
 ### session.getOffsetFromCursor(the) ⇒ <code>number</code>
@@ -94,7 +92,8 @@ Get the offset of a cursor position
 <a name="Session+getToken"></a>
 
 ### session.getToken(cursor) ⇒ <code>Object</code>
-Get the token at the given cursor position, or at the current cursorif none is given.
+Get the token at the given cursor position, or at the current cursor
+if none is given.
 
 **Kind**: instance method of [<code>Session</code>](#Session)  
 **Returns**: <code>Object</code> - - the CodeMirror token at the given cursor position  
@@ -109,7 +108,8 @@ Get the token at the given cursor position, or at the current cursorif none is 
 Get the token after the one at the given cursor position
 
 **Kind**: instance method of [<code>Session</code>](#Session)  
-**Returns**: <code>Object</code> - - the CodeMirror token after the one at the given     cursor position  
+**Returns**: <code>Object</code> - - the CodeMirror token after the one at the given
+     cursor position  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -121,26 +121,17 @@ Get the token after the one at the given cursor position
 Get the next cursor position on the line, or null if there isn't one.
 
 **Kind**: instance method of [<code>Session</code>](#Session)  
-**Returns**: <code>Object</code> - - the cursor position     immediately following the current cursor position, or null if     none exists.  
-<a name="Session+_getPreviousToken"></a>
-
-### session.\_getPreviousToken(cursor) ⇒ <code>Object</code>
-Get the token before the one at the given cursor position
-
-**Kind**: instance method of [<code>Session</code>](#Session)  
-**Returns**: <code>Object</code> - - the CodeMirror token before the one at the given     cursor position  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| cursor | <code>Object</code> | cursor position after      which a token should be retrieved |
-
+**Returns**: <code>Object</code> - - the cursor position
+     immediately following the current cursor position, or null if
+     none exists.  
 <a name="Session+getNextToken"></a>
 
 ### session.getNextToken(cursor, skipWhitespace) ⇒ <code>Object</code>
 Get the token after the one at the given cursor position
 
 **Kind**: instance method of [<code>Session</code>](#Session)  
-**Returns**: <code>Object</code> - - the CodeMirror token after the one at the given     cursor position  
+**Returns**: <code>Object</code> - - the CodeMirror token after the one at the given
+     cursor position  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -150,14 +141,17 @@ Get the token after the one at the given cursor position
 <a name="Session+getQuery"></a>
 
 ### session.getQuery() ⇒ <code>String</code>
-Calculate a query String relative to the current cursor positionand token. E.g., from a state "identi--cursor--er", the query String is"identi".
+Calculate a query String relative to the current cursor position
+and token. E.g., from a state "identi--cursor--er", the query String is
+"identi".
 
 **Kind**: instance method of [<code>Session</code>](#Session)  
 **Returns**: <code>String</code> - - the query String for the current cursor position  
 <a name="Session+getContext"></a>
 
 ### session.getContext(cursor, [depth]) ⇒ <code>String</code>
-Find the context of a property lookup. For example, for a lookupfoo(bar, baz(quux)).prop, foo is the context.
+Find the context of a property lookup. For example, for a lookup
+foo(bar, baz(quux)).prop, foo is the context.
 
 **Kind**: instance method of [<code>Session</code>](#Session)  
 **Returns**: <code>String</code> - - the context for the property that was looked up  
@@ -171,85 +165,46 @@ Find the context of a property lookup. For example, for a lookupfoo(bar, baz(qu
 
 ### session.findPreviousDot() ⇒ <code>Object</code>
 **Kind**: instance method of [<code>Session</code>](#Session)  
-**Returns**: <code>Object</code> - - the line, col info for where the previous "."     in a property lookup occurred, or undefined if no previous "." was found.  
+**Returns**: <code>Object</code> - - the line, col info for where the previous "."
+     in a property lookup occurred, or undefined if no previous "." was found.  
 <a name="Session+getFunctionInfo"></a>
 
 ### session.getFunctionInfo() ⇒ <code>Object</code>
 Determine if the caret is either within a function call or on the function call itself.
 
 **Kind**: instance method of [<code>Session</code>](#Session)  
-**Returns**: <code>Object</code> - inFunctionCall - true if the caret if either within a function call or on thefunction call itself.functionCallPos - the offset of the '(' character of the function call if inFunctionCallis true, otherwise undefined.  
-
-* [.getFunctionInfo()](#Session+getFunctionInfo) ⇒ <code>Object</code>
-    * [.isOnFunctionIdentifier()](#Session+getFunctionInfo..isOnFunctionIdentifier) ⇒ <code>Object</code>
-    * [.isInFunctionalCall(lex)](#Session+getFunctionInfo..isInFunctionalCall) ⇒ <code>Object</code> \| <code>Boolean</code>
-
-<a name="Session+getFunctionInfo..isOnFunctionIdentifier"></a>
-
-#### getFunctionInfo.isOnFunctionIdentifier() ⇒ <code>Object</code>
-Test if the cursor is on a function identifier
-
-**Kind**: inner method of [<code>getFunctionInfo</code>](#Session+getFunctionInfo)  
-**Returns**: <code>Object</code> - - lexical state if on a function identifier, null otherwise.  
-<a name="Session+getFunctionInfo..isInFunctionalCall"></a>
-
-#### getFunctionInfo.isInFunctionalCall(lex) ⇒ <code>Object</code> \| <code>Boolean</code>
-Test is a lexical state is in a function call.
-
-**Kind**: inner method of [<code>getFunctionInfo</code>](#Session+getFunctionInfo)  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| lex | <code>Object</code> | lexical state. |
-
+**Returns**: <code>Object</code> - inFunctionCall - true if the caret if either within a function call or on the
+function call itself.
+functionCallPos - the offset of the '(' character of the function call if inFunctionCall
+is true, otherwise undefined.  
 <a name="Session+getType"></a>
 
 ### session.getType() ⇒ <code>Object</code>
-Get the type of the current session, i.e., whether it is a propertylookup and, if so, what the context of the lookup is.
+Get the type of the current session, i.e., whether it is a property
+lookup and, if so, what the context of the lookup is.
 
 **Kind**: instance method of [<code>Session</code>](#Session)  
-**Returns**: <code>Object</code> - - an Object consisting     of a {Boolean} "property" that indicates whether or not the type of     the session is a property lookup, and a {String} "context" that     indicates the object context (as described in getContext above) of     the property lookup, or null if there is none. The context is     always null for non-property lookups.  
+**Returns**: <code>Object</code> - - an Object consisting
+     of a {Boolean} "property" that indicates whether or not the type of
+     the session is a property lookup, and a {String} "context" that
+     indicates the object context (as described in getContext above) of
+     the property lookup, or null if there is none. The context is
+     always null for non-property lookups.  
 <a name="Session+getHints"></a>
 
 ### session.getHints(query, matcher) ⇒ <code>Object</code>
-Retrieves a list of hints for the current session based on the current scopeinformation.
+Retrieves a list of hints for the current session based on the current scope
+information.
 
 **Kind**: instance method of [<code>Session</code>](#Session)  
-**Returns**: <code>Object</code> - An object containing:  - `hints`: An array of matching hints.  - `needGuesses`: A Boolean indicating whether the caller needs to request guesses and call getHints again.  
+**Returns**: <code>Object</code> - An object containing:
+  - `hints`: An array of matching hints.
+  - `needGuesses`: A Boolean indicating whether the caller needs to request guesses and call getHints again.  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | query | <code>String</code> | The query prefix used to filter hints. |
 | matcher | <code>StringMatcher</code> | The class used to find query matches and sort the results. |
-
-
-* [.getHints(query, matcher)](#Session+getHints) ⇒ <code>Object</code>
-    * [.isBuiltin(origin)](#Session+getHints..isBuiltin)
-    * [.filterWithQueryAndMatcher(hints, matcher)](#Session+getHints..filterWithQueryAndMatcher) ⇒ <code>Array</code>
-
-<a name="Session+getHints..isBuiltin"></a>
-
-#### getHints.isBuiltin(origin)
-Is the origin one of the builtin files.
-
-**Kind**: inner method of [<code>getHints</code>](#Session+getHints)  
-
-| Param | Type |
-| --- | --- |
-| origin | <code>String</code> | 
-
-<a name="Session+getHints..filterWithQueryAndMatcher"></a>
-
-#### getHints.filterWithQueryAndMatcher(hints, matcher) ⇒ <code>Array</code>
-Filter an array hints using a given query and matcher. The hints are returned in the format of the matcher. The matcher returns the value in the "label" property, the match score in "matchGoodness" property.
-
-**Kind**: inner method of [<code>getHints</code>](#Session+getHints)  
-**Returns**: <code>Array</code> - - array of matching hints.  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| hints | <code>Array</code> | array of hints |
-| matcher | <code>StringMatcher</code> |  |
 
 <a name="Session+setFnType"></a>
 
@@ -276,31 +231,33 @@ The position of the function call for the current fnType.
 <a name="Session+getParameterHint"></a>
 
 ### session.getParameterHint() ⇒ <code>Object</code>
-Get the function type hint.  This will format the hint, showing theparameter at the cursor in bold.
+Get the function type hint.  This will format the hint, showing the
+parameter at the cursor in bold.
 
 **Kind**: instance method of [<code>Session</code>](#Session)  
-**Returns**: <code>Object</code> - An Object where the"parameters" property is an array of parameter objects;the "currentIndex" property index of the hint the cursor is on, may be-1 if the cursor is on the function identifier.  
+**Returns**: <code>Object</code> - An Object where the
+"parameters" property is an array of parameter objects;
+the "currentIndex" property index of the hint the cursor is on, may be
+-1 if the cursor is on the function identifier.  
 <a name="Session+getJavascriptText"></a>
 
 ### session.getJavascriptText() ⇒ <code>String</code>
-Get the javascript text of the file open in the editor for this Session.For a javascript file, this is just the text of the file.  For an HTML file,this will be only the text in the script tags.  This is so that we can passjust the javascript text to tern, and avoid confusing it with HTML tags, since itonly knows how to parse javascript.
+Get the javascript text of the file open in the editor for this Session.
+For a javascript file, this is just the text of the file.  For an HTML file,
+this will be only the text in the script tags.  This is so that we can pass
+just the javascript text to tern, and avoid confusing it with HTML tags, since it
+only knows how to parse javascript.
 
 **Kind**: instance method of [<code>Session</code>](#Session)  
 **Returns**: <code>String</code> - - the "javascript" text that can be sent to Tern.  
 <a name="Session+isFunctionName"></a>
 
 ### session.isFunctionName() ⇒ <code>Boolean</code>
-Determine if the cursor is located in the name of a function declaration.This is so we can suppress hints when in a function name, as we do for variable andparameter declarations, but we can tell those from the token itself rather than havingto look at previous tokens.
+Determine if the cursor is located in the name of a function declaration.
+This is so we can suppress hints when in a function name, as we do for variable and
+parameter declarations, but we can tell those from the token itself rather than having
+to look at previous tokens.
 
 **Kind**: instance method of [<code>Session</code>](#Session)  
-**Returns**: <code>Boolean</code> - - true if the current cursor position is in the name of a functiondeclaration.  
-<a name="getLexicalState"></a>
-
-## getLexicalState(token) ⇒ <code>\*</code>
-**Kind**: global function  
-**Returns**: <code>\*</code> - - the lexical state of the token  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| token | <code>Object</code> | a CodeMirror token |
-
+**Returns**: <code>Boolean</code> - - true if the current cursor position is in the name of a function
+declaration.  

--- a/src/JSUtils/Preferences.js
+++ b/src/JSUtils/Preferences.js
@@ -70,7 +70,7 @@ define(function (require, exports, module) {
     /**
      *  Convert an array of strings with optional wildcards, to an equivalent
      *  regular expression.
-     *
+     * @private
      * @param {Array.<string|RegExp>} settings from the file (note: this may be mutated by this function)
      * @param {?RegExp} baseRegExp - base regular expression that is always used
      * @param {?RegExp} defaultRegExp - additional regular expression that is only used if the user has not configured settings

--- a/src/JSUtils/ScopeManager.js
+++ b/src/JSUtils/ScopeManager.js
@@ -86,6 +86,7 @@ define(function (require, exports, module) {
 
     /**
      * Read in the json files that have type information for the builtins, dom,etc
+     * @private
      */
     function initTernEnv() {
         const builtinDefinitionFiles = JSON.parse(require("text!thirdparty/tern/defs/defs.json"));
@@ -110,7 +111,7 @@ define(function (require, exports, module) {
     /**
      *  Init preferences from a file in the project root or builtin
      *  defaults if no file is found;
-     *
+     * @private
      *  @param {string=} projectRootPath - new project root path. Only needed
      *  for unit tests.
      */
@@ -166,7 +167,7 @@ define(function (require, exports, module) {
 
     /**
      * Will initialize preferences only if they do not exist.
-     *
+     * @private
      */
     function ensurePreferences() {
         if (!deferredPreferences) {
@@ -186,7 +187,7 @@ define(function (require, exports, module) {
 
     /**
      * Test if the directory should be excluded from analysis.
-     *
+     * @private
      * @param {!string} path - full directory path.
      * @return {boolean} true if excluded, false otherwise.
      */
@@ -205,7 +206,7 @@ define(function (require, exports, module) {
 
     /**
      * Test if the file path is in current editor
-     *
+     * @private
      * @param {string} filePath file path to test for exclusion.
      * @return {boolean} true if in editor, false otherwise.
      */
@@ -218,7 +219,7 @@ define(function (require, exports, module) {
 
     /**
      * Test if the file path is an internal exclusion.
-     *
+     * @private
      * @param {string} path file path to test for exclusion.
      * @return {boolean} true if excluded, false otherwise.
      */
@@ -235,7 +236,7 @@ define(function (require, exports, module) {
 
     /**
      * Test if the file should be excluded from analysis.
-     *
+     * @private
      * @param {!File} file - file to test for exclusion.
      * @return {boolean} true if excluded, false otherwise.
      */
@@ -328,6 +329,7 @@ define(function (require, exports, module) {
 
     /**
      * Get a Promise for the definition from TernJS, for the file & offset passed in.
+     * @private
      * @param {{type: string, name: string, offsetLines: number, text: string}} fileInfo
      * - type of update, name of file, and the text of the update.
      * For "full" updates, the whole text of the file is present. For "part" updates,
@@ -363,6 +365,7 @@ define(function (require, exports, module) {
     /**
      * Get the text of a document, applying any size restrictions
      * if necessary
+     * @private
      * @param {Document} document - the document to get the text from
      * @return {string} the text, or the empty text if the original was too long
      */
@@ -375,7 +378,7 @@ define(function (require, exports, module) {
     /**
      * Handle the response from the tern node domain when
      * it responds with the references
-     *
+     * @private
      * @param response - the response from the node domain
      */
     function handleRename(response) {
@@ -423,7 +426,7 @@ define(function (require, exports, module) {
     /**
      * Handle the response from the tern node domain when
      * it responds with the definition
-     *
+     * @private
      * @param response - the response from the node domain
      */
     function handleJumptoDef(response) {
@@ -442,7 +445,7 @@ define(function (require, exports, module) {
     /**
      * Handle the response from the tern node domain when
      * it responds with the scope data
-     *
+     * @private
      * @param response - the response from the node domain
      */
     function handleScopeData(response) {
@@ -488,6 +491,7 @@ define(function (require, exports, module) {
 
     /**
      * Get a Promise for the function type from TernJS.
+     * @private
      * @param {{type: string, name: string, offsetLines: number, text: string}} fileInfo
      * - type of update, name of file, and the text of the update.
      * For "full" updates, the whole text of the file is present. For "part" updates,
@@ -510,7 +514,7 @@ define(function (require, exports, module) {
     /**
      *  Given a starting and ending position, get a code fragment that is self contained
      *  enough to be compiled.
-     *
+     * @private
      * @param {!Session} session - the current session
      * @param {{line: number, ch: number}} start - the starting position of the changes
      * @return {{type: string, name: string, offsetLines: number, text: string}}
@@ -580,7 +584,7 @@ define(function (require, exports, module) {
      * Get an object that describes what tern needs to know about the updated
      * file to produce a hint. As a side-effect of this calls the document
      * changes are reset.
-     *
+     * @private
      * @param {!Session} session - the current session
      * @param {boolean=} preventPartialUpdates - if true, disallow partial updates.
      * Optional, defaults to false.
@@ -619,7 +623,7 @@ define(function (require, exports, module) {
 
     /**
      *  Get the current offset. The offset is adjusted for "part" updates.
-     *
+     * @private
      * @param {!Session} session - the current session
      * @param {{type: string, name: string, offsetLines: number, text: string}} fileInfo
      * - type of update, name of file, and the text of the update.
@@ -680,7 +684,7 @@ define(function (require, exports, module) {
     /**
      * Handle the response from the tern node domain when
      * it responds with the list of completions
-     *
+     * @private
      * @param {{file: string, offset: {line: number, ch: number}, completions:Array.<string>,
      *          properties:Array.<string>}} response - the response from node domain
      */
@@ -711,7 +715,7 @@ define(function (require, exports, module) {
     /**
      * Handle the response from the tern node domain when
      * it responds to the get guesses message.
-     *
+     * @private
      * @param {{file: string, type: string, offset: {line: number, ch: number},
      *      properties: Array.<string>}} response -
      *      the response from node domain contains the guesses for a
@@ -731,7 +735,7 @@ define(function (require, exports, module) {
     /**
      * Handle the response from the tern node domain when
      * it responds to the update file message.
-     *
+     * @private
      * @param {{path: string, type: string}} response - the response from node domain
      */
     function handleUpdateFile(response) {
@@ -747,7 +751,7 @@ define(function (require, exports, module) {
 
     /**
      * Handle timed out inference
-     *
+     * @private
      * @param {{path: string, type: string}} response - the response from node domain
      */
     function handleTimedOut(response) {
@@ -809,7 +813,6 @@ define(function (require, exports, module) {
      * Encapsulate all the logic to talk to the tern module.  This will create
      * a new instance of a TernModule, which the rest of the hinting code can use to talk
      * to the tern node domain, without worrying about initialization, priming the pump, etc.
-     *
      */
     function TernModule() {
         var ternPromise         = null,
@@ -833,7 +836,7 @@ define(function (require, exports, module) {
         /**
          *  Determine whether the current set of files are using modules to pull in
          *  additional files.
-         *
+         * @private
          * @return {boolean} - true if more files than the current directory have
          * been read in.
          */
@@ -857,6 +860,7 @@ define(function (require, exports, module) {
         /**
          * Send a message to the tern node domain - this is only for messages that
          * need to be sent before and while the addFilesPromise is being resolved.
+         * @private
          */
         function _postMessageByPass(msg) {
             ternPromise.done(function () {
@@ -869,7 +873,7 @@ define(function (require, exports, module) {
 
         /**
          *  Update tern with the new contents of a given file.
-         *
+         * @private
          * @param {Document} document - the document to update
          * @return {jQuery.Promise} - the promise for the request
          */
@@ -887,7 +891,7 @@ define(function (require, exports, module) {
 
         /**
          * Handle a request from the tern node domain for text of a file
-         *
+         * @private
          * @param {{file:string}} request - the request from the tern node domain.  Should be an Object containing the name
          *      of the file tern wants the contents of
          */
@@ -907,7 +911,7 @@ define(function (require, exports, module) {
              * Helper function to get the text of a given document and send it to tern.
              * If DocumentManager successfully gets the file's text then we'll send it to the tern node domain.
              * The Promise for getDocumentText() is returned so that custom fail functions can be used.
-             *
+             * @private
              * @param {string} filePath - the path of the file to get the text of
              * @return {jQuery.Promise} - the Promise returned from DocumentMangaer.getDocumentText()
              */
@@ -937,6 +941,7 @@ define(function (require, exports, module) {
              * name we are looking for.  This is so we can find requirejs modules
              * when the baseUrl is unknown, or when the project root is not the same
              * as the script root (e.g. if you open the 'brackets' dir instead of 'brackets/src' dir).
+             * @private
              */
             function findNameInProject() {
                 // check for any files in project that end with the right path.
@@ -981,7 +986,7 @@ define(function (require, exports, module) {
 
         /**
          *  Prime the pump for a fast first lookup.
-         *
+         * @private
          * @param {string} path - full path of file
          * @return {jQuery.Promise} - the promise for the request
          */
@@ -998,7 +1003,7 @@ define(function (require, exports, module) {
         /**
          * Handle the response from the tern node domain when
          * it responds to the prime pump message.
-         *
+         * @private
          * @param {{path: string, type: string}} response - the response from node domain
          */
         function handlePrimePumpCompletion(response) {
@@ -1016,7 +1021,7 @@ define(function (require, exports, module) {
          *  Add new files to tern, keeping any previous files.
          *  The tern server must be initialized before making
          *  this call.
-         *
+         * @private
          * @param {Array.<string>} files - array of file to add to tern.
          * @return {boolean} - true if more files may be added, false if maximum has been reached.
          */
@@ -1053,7 +1058,7 @@ define(function (require, exports, module) {
         /**
          *  Add the files in the directory and subdirectories of a given directory
          *  to tern.
-         *
+         * @private
          * @param {string} dir - the root directory to add.
          * @param {function ()} doneCallback - called when all files have been
          * added to tern.
@@ -1087,6 +1092,7 @@ define(function (require, exports, module) {
 
         /**
          * Init the Tern module that does all the code hinting work.
+         * @private
          */
         function initTernModule() {
             let moduleDeferred = $.Deferred();
@@ -1147,6 +1153,7 @@ define(function (require, exports, module) {
 
         /**
          * Create a new tern server.
+         * @private
          */
         function initTernServer(dir, files) {
             initTernModule();
@@ -1171,7 +1178,7 @@ define(function (require, exports, module) {
         /**
          *  We can skip tern initialization if we are opening a file that has
          *  already been added to tern.
-         *
+         * @private
          * @param {string} newFile - full path of new file being opened in the editor.
          * @return {boolean} - true if tern initialization should be skipped,
          * false otherwise.
@@ -1183,7 +1190,7 @@ define(function (require, exports, module) {
 
         /**
          *  Do the work to initialize a code hinting session.
-         *
+         * @private
          * @param {Session} session - the active hinting session (TODO: currently unused)
          * @param {!Document} document - the document the editor has changed to
          * @param {?Document} previousDocument - the document the editor has changed from
@@ -1314,6 +1321,7 @@ define(function (require, exports, module) {
          *
          * We can clean up the node tern server we use to calculate hints now, since
          * we know we will need to re-init it in any new project that is opened.
+         * @private
          */
         function resetModule() {
             function resetTernServer() {
@@ -1354,7 +1362,7 @@ define(function (require, exports, module) {
      * ```
      * This function is also used in unit testing with the "force" flag to
      * reset the module for each test to start with a clean environment.
-     *
+     * @private
      * @param {Session} session
      * @param {Document} document
      * @param {boolean} force true to force a reset regardless of how long since the last one
@@ -1472,6 +1480,7 @@ define(function (require, exports, module) {
      *  Track the update area of the current document so we can tell if we can send
      *  partial updates to tern or not.
      * @param {{from: {line: number, ch: number}, to: {line: number, ch: number}, text: string[]}} changeList - The document changes from the current change event
+     * @private
      */
     function trackChange(changeList) {
         var changed = documentChanges, i;
@@ -1499,11 +1508,11 @@ define(function (require, exports, module) {
         }
     }
 
-    /*
+    /**
      * Called each time the file associated with the active editor changes.
      * Marks the file as being dirty.
      *
-     * @param {from: {line:number, ch: number}, to: {line:number, ch: number}}
+     * @param {{line:number, ch: number}} changeList {from: {line:number, ch: number}, to: {line:number, ch:number}}
      */
     function handleFileChange(changeList) {
         isDocumentDirty = true;
@@ -1547,7 +1556,10 @@ define(function (require, exports, module) {
         initPreferences(projectRootPath);
     }
 
-    /** Used to avoid timing bugs in unit tests */
+    /**
+     * Used to avoid timing bugs in unit tests
+     * @private
+     */
     function _readyPromise() {
         return deferredPreferences;
     }

--- a/src/JSUtils/Session.js
+++ b/src/JSUtils/Session.js
@@ -177,7 +177,7 @@ define(function (require, exports, module) {
 
     /**
      * Get the token before the one at the given cursor position
-     *
+     * @private
      * @param {{line: number, ch: number}} cursor - cursor position after
      *      which a token should be retrieved
      * @return {Object} - the CodeMirror token before the one at the given
@@ -323,7 +323,7 @@ define(function (require, exports, module) {
     };
 
     /**
-     *
+     * @private
      * @param {Object} token - a CodeMirror token
      * @return {*} - the lexical state of the token
      */
@@ -359,7 +359,7 @@ define(function (require, exports, module) {
 
         /**
          * Test if the cursor is on a function identifier
-         *
+         * @private
          * @return {Object} - lexical state if on a function identifier, null otherwise.
          */
         function isOnFunctionIdentifier() {
@@ -383,7 +383,7 @@ define(function (require, exports, module) {
 
         /**
          * Test is a lexical state is in a function call.
-         *
+         * @private
          * @param {Object} lex - lexical state.
          * @return {Object | Boolean}
          *
@@ -529,7 +529,7 @@ define(function (require, exports, module) {
 
         /**
          *  Is the origin one of the builtin files.
-         *
+         * @private
          * @param {String} origin
          */
         function isBuiltin(origin) {
@@ -541,7 +541,7 @@ define(function (require, exports, module) {
          *  The hints are returned in the format of the matcher.
          *  The matcher returns the value in the "label" property,
          *  the match score in "matchGoodness" property.
-         *
+         * @private
          * @param {Array} hints - array of hints
          * @param {StringMatcher} matcher
          * @return {Array} - array of matching hints.


### PR DESCRIPTION
In file `ScopeManager.js`, the parameter definition has been updated like this:

<---- Removed ---->
     * @param {from: {line:number, ch: number}, to: {line:number, ch: number}}
    
<---- Added ---->
     * @param {{line:number, ch: number}} changeList {from: {line:number, ch: number}, to: {line:number, ch:number}}

This change was made because Docusaurus is unable to parse nested objects as parameter types.