### PR TITLE
docs: refine API docs for files in Project dir

### DIFF
--- a/docs/API-Reference/project/FileSyncManager.md
+++ b/docs/API-Reference/project/FileSyncManager.md
@@ -3,107 +3,13 @@
 const FileSyncManager = brackets.getModule("project/FileSyncManager")
 ```
 
-<a name="_alreadyChecking"></a>
-
-## \_alreadyChecking : <code>boolean</code>
-Guard to spot re-entrancy while syncOpenDocuments() is still in progress
-
-**Kind**: global variable  
-<a name="_restartPending"></a>
-
-## \_restartPending : <code>boolean</code>
-If true, we should bail from the syncOpenDocuments() process and then re-run it. Seecomments in syncOpenDocuments() for how this works.
-
-**Kind**: global variable  
-<a name="toReload"></a>
-
-## toReload : <code>Array.&lt;Document&gt;</code>
-**Kind**: global variable  
-<a name="toClose"></a>
-
-## toClose : <code>Array.&lt;Document&gt;</code>
-**Kind**: global variable  
-<a name="editConflicts"></a>
-
-## editConflicts : <code>Object</code>
-Array
-
-**Kind**: global variable  
-<a name="deleteConflicts"></a>
-
-## deleteConflicts : <code>Object</code>
-Array
-
-**Kind**: global variable  
-<a name="findExternalChanges"></a>
-
-## findExternalChanges(docs) ⇒ <code>$.Promise</code>
-Scans all the given Documents for changes on disk, and sorts them into four buckets,populating the corresponding arrays: toReload        - changed on disk; unchanged within Brackets toClose         - deleted on disk; unchanged within Brackets editConflicts   - changed on disk; also dirty in Brackets deleteConflicts - deleted on disk; also dirty in Brackets
-
-**Kind**: global function  
-**Returns**: <code>$.Promise</code> - Resolved when all scanning done, or rejected immediately if there's any     error while reading file timestamps. Errors are logged but no UI is shown.  
-
-| Param | Type |
-| --- | --- |
-| docs | <code>Array.&lt;Document&gt;</code> | 
-
-<a name="syncUnopenWorkingSet"></a>
-
-## syncUnopenWorkingSet()
-Scans all the files in the working set that do not have Documents (and thus were not scannedby findExternalChanges()). If any were deleted on disk, removes them from the working set.
-
-**Kind**: global function  
-<a name="reloadDoc"></a>
-
-## reloadDoc(doc) ⇒ <code>$.Promise</code>
-Reloads the Document's contents from disk, discarding any unsaved changes in the editor.
-
-**Kind**: global function  
-**Returns**: <code>$.Promise</code> - Resolved after editor has been refreshed; rejected if unable to load the     file's new content. Errors are logged but no UI is shown.  
-
-| Param | Type |
-| --- | --- |
-| doc | <code>Document</code> | 
-
-<a name="reloadChangedDocs"></a>
-
-## reloadChangedDocs() ⇒ <code>$.Promise</code>
-Reloads all the documents in "toReload" silently (no prompts). The operations are all runin parallel.
-
-**Kind**: global function  
-**Returns**: <code>$.Promise</code> - Resolved/rejected after all reloads done; will be rejected if any one     file's reload failed. Errors are logged (by reloadDoc()) but no UI is shown.  
-<a name="showReloadError"></a>
-
-## showReloadError(error, doc) ⇒ <code>Dialog</code>
-**Kind**: global function  
-
-| Param | Type |
-| --- | --- |
-| error | <code>FileError</code> | 
-| doc | <code>Document</code> | 
-
-<a name="closeDeletedDocs"></a>
-
-## closeDeletedDocs()
-Closes all the documents in "toClose" silently (no prompts). Completes synchronously.
-
-**Kind**: global function  
-<a name="presentConflicts"></a>
-
-## presentConflicts(title) ⇒ <code>$.Promise</code>
-Walks through all the documents in "editConflicts" & "deleteConflicts" and prompts the userabout each one. Processing is sequential: if the user chooses to reload a document, the nextprompt is not shown until after the reload has completed.
-
-**Kind**: global function  
-**Returns**: <code>$.Promise</code> - Resolved/rejected after all documents have been prompted and (if     applicable) reloaded (and any resulting error UI has been dismissed). Rejected if any     one reload failed.  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| title | <code>string</code> | Title of the dialog. |
-
 <a name="syncOpenDocuments"></a>
 
 ## syncOpenDocuments(title)
-Check to see whether any open files have been modified by an external app since the last timeBrackets synced up with the copy on disk (either by loading or saving the file). For cleanfiles, we silently upate the editor automatically. For files with unsaved changes, we promptthe user.
+Check to see whether any open files have been modified by an external app since the last time
+Brackets synced up with the copy on disk (either by loading or saving the file). For clean
+files, we silently upate the editor automatically. For files with unsaved changes, we prompt
+the user.
 
 **Kind**: global function  
 

--- a/docs/API-Reference/project/FileTreeView.md
+++ b/docs/API-Reference/project/FileTreeView.md
@@ -6,110 +6,16 @@ const FileTreeView = brackets.getModule("project/FileTreeView")
 <a name="Preact"></a>
 
 ## Preact
-This is the view layer (template) for the file tree in the sidebar. It takes a FileTreeViewModeland renders it to the given element using Preact. User actions are signaled via an ActionCreator(in the Flux sense).
-
-**Kind**: global variable  
-<a name="pathComputer"></a>
-
-## pathComputer
-Mixin that allows a component to compute the full path to its directory entry.
-
-**Kind**: global variable  
-<a name="pathComputer.myPath"></a>
-
-### pathComputer.myPath()
-Computes the full path of the file represented by this input.
-
-**Kind**: static method of [<code>pathComputer</code>](#pathComputer)  
-<a name="renameBehavior"></a>
-
-## renameBehavior
-This is a mixin that provides rename input behavior. It is responsible for taking keyboard inputand invoking the correct action based on that input.
-
-**Kind**: global variable  
-
-* [renameBehavior](#renameBehavior)
-    * [.handleClick()](#renameBehavior.handleClick)
-    * [.handleKeyDown()](#renameBehavior.handleKeyDown)
-    * [.handleInput()](#renameBehavior.handleInput)
-    * [.handleBlur()](#renameBehavior.handleBlur)
-
-<a name="renameBehavior.handleClick"></a>
-
-### renameBehavior.handleClick()
-Stop clicks from propagating so that clicking on the rename input doesn'tcause directories to collapse.
-
-**Kind**: static method of [<code>renameBehavior</code>](#renameBehavior)  
-<a name="renameBehavior.handleKeyDown"></a>
-
-### renameBehavior.handleKeyDown()
-If the user presses enter or escape, we either successfully complete or cancel, respectively,the rename or create operation that is underway.
-
-**Kind**: static method of [<code>renameBehavior</code>](#renameBehavior)  
-<a name="renameBehavior.handleInput"></a>
-
-### renameBehavior.handleInput()
-The rename or create operation can be completed or canceled by actions outside ofthis component, so we keep the model up to date by sending every update via an action.
-
-**Kind**: static method of [<code>renameBehavior</code>](#renameBehavior)  
-<a name="renameBehavior.handleBlur"></a>
-
-### renameBehavior.handleBlur()
-If we leave the field for any reason, complete the rename.
-
-**Kind**: static method of [<code>renameBehavior</code>](#renameBehavior)  
-<a name="dragAndDrop"></a>
-
-## dragAndDrop
-This is a mixin that provides drag and drop move function.
-
-**Kind**: global variable  
-<a name="extendable"></a>
-
-## extendable
-Mixin for components that support the "icons" and "addClass" extension points.`fileNode` and `directoryNode` support this.
-
-**Kind**: global variable  
-
-* [extendable](#extendable)
-    * [.getIcons()](#extendable.getIcons) ⇒ <code>Array.&lt;PreactComponent&gt;</code>
-    * [.getClasses(classes)](#extendable.getClasses) ⇒ <code>string</code>
-
-<a name="extendable.getIcons"></a>
-
-### extendable.getIcons() ⇒ <code>Array.&lt;PreactComponent&gt;</code>
-Calls the icon providers to get the collection of icons (most likely just one) forthe current file or directory.
-
-**Kind**: static method of [<code>extendable</code>](#extendable)  
-**Returns**: <code>Array.&lt;PreactComponent&gt;</code> - icon components to render  
-<a name="extendable.getClasses"></a>
-
-### extendable.getClasses(classes) ⇒ <code>string</code>
-Calls the addClass providers to get the classes (in string form) to add for the currentfile or directory.
-
-**Kind**: static method of [<code>extendable</code>](#extendable)  
-**Returns**: <code>string</code> - classes for the current node  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| classes | <code>string</code> | Initial classes for this node |
-
-<a name="fileSelectionBox"></a>
-
-## fileSelectionBox
-Displays the absolutely positioned box for the selection or context in thefile tree. Its position is determined by passed-in info about the scroller in whichthe tree resides and the top of the selected node (as reported by the node itself).Props:* selectionViewInfo: Immutable.Map with width, scrollTop, scrollLeft and offsetTop for the tree container* visible: should this be visible now* selectedClassName: class name applied to the element that is selected
-
-**Kind**: global variable  
-<a name="selectionExtension"></a>
-
-## selectionExtension
-On Windows and Linux, the selection bar in the tree does not extend over the scroll bar.The selectionExtension sits on top of the scroll bar to make the selection bar appear to span thewhole width of the sidebar.Props:* selectionViewInfo: Immutable.Map with width, scrollTop, scrollLeft and offsetTop for the tree container* visible: should this be visible now* selectedClassName: class name applied to the element that is selected* className: class to be applied to the extension element
+This is the view layer (template) for the file tree in the sidebar. It takes a FileTreeViewModel
+and renders it to the given element using Preact. User actions are signaled via an ActionCreator
+(in the Flux sense).
 
 **Kind**: global variable  
 <a name="componentDidMount"></a>
 
 ## componentDidMount()
-When this component is displayed, we scroll it into view and select the portionof the filename that excludes the extension.
+When this component is displayed, we scroll it into view and select the portion
+of the filename that excludes the extension.
 
 **Kind**: global function  
 <a name="getInitialState"></a>
@@ -118,43 +24,6 @@ When this component is displayed, we scroll it into view and select the portion
 Ensures that we always have a state object.
 
 **Kind**: global function  
-<a name="shouldComponentUpdate"></a>
-
-## shouldComponentUpdate()
-Thanks to immutable objects, we can just do a start object identity check to knowwhether or not we need to re-render.
-
-**Kind**: global function  
-<a name="componentDidUpdate"></a>
-
-## componentDidUpdate()
-If this node is newly selected, scroll it into view. Also, move the selection orcontext boxes as appropriate.
-
-**Kind**: global function  
-<a name="handleClick"></a>
-
-## handleClick()
-When the user clicks on the node, we'll either select it or, if they've clicked twicewith a bit of delay in between, we'll invoke the `startRename` action.
-
-**Kind**: global function  
-<a name="selectNode"></a>
-
-## selectNode()
-select the current node in the file tree on mouse down event on files.This is to increase click responsiveness of file tree.
-
-**Kind**: global function  
-<a name="handleDoubleClick"></a>
-
-## handleDoubleClick()
-When the user double clicks, we will select this file and add it to the workingset (via the `selectInWorkingSet` action.)
-
-**Kind**: global function  
-<a name="getDataForExtension"></a>
-
-## getDataForExtension() ⇒ <code>Object</code>
-Create the data object to pass to extensions.
-
-**Kind**: global function  
-**Returns**: <code>Object</code> - Data for extensions  
 <a name="componentDidMount"></a>
 
 ## componentDidMount()
@@ -164,44 +33,21 @@ When this component is displayed, we scroll it into view and select the folder n
 <a name="shouldComponentUpdate"></a>
 
 ## shouldComponentUpdate()
-We need to update this component if the sort order changes or our entry objectchanges. Thanks to immutability, if any of the directory contents change, ourentry object will change.
-
-**Kind**: global function  
-<a name="handleClick"></a>
-
-## handleClick()
-If you click on a directory, it will toggle between open and closed.
-
-**Kind**: global function  
-<a name="selectNode"></a>
-
-## selectNode()
-select the current node in the file tree
-
-**Kind**: global function  
-<a name="getDataForExtension"></a>
-
-## getDataForExtension() ⇒ <code>Object</code>
-Create the data object to pass to extensions.
-
-**Kind**: global function  
-**Returns**: <code>Object</code> - Data for extensions  
-<a name="shouldComponentUpdate"></a>
-
-## shouldComponentUpdate()
 Need to re-render if the sort order or the contents change.
 
 **Kind**: global function  
 <a name="componentDidUpdate"></a>
 
 ## componentDidUpdate()
-When the component has updated in the DOM, reposition it to where the currentlyselected node is located now.
+When the component has updated in the DOM, reposition it to where the currently
+selected node is located now.
 
 **Kind**: global function  
 <a name="componentDidUpdate"></a>
 
 ## componentDidUpdate()
-When the component has updated in the DOM, reposition it to where the currentlyselected node is located now.
+When the component has updated in the DOM, reposition it to where the currently
+selected node is located now.
 
 **Kind**: global function  
 <a name="shouldComponentUpdate"></a>
@@ -235,7 +81,8 @@ Renders the file tree to the given element.
 <a name="addIconProvider"></a>
 
 ## addIconProvider(callback, [priority])
-Adds an icon provider. The callback is invoked before each working set item is created, and canreturn content to prepend to the item if it supports the icon.
+Adds an icon provider. The callback is invoked before each working set item is created, and can
+return content to prepend to the item if it supports the icon.
 
 **Kind**: global function  
 
@@ -247,7 +94,8 @@ Adds an icon provider. The callback is invoked before each working set item is c
 <a name="addClassesProvider"></a>
 
 ## addClassesProvider(callback, [priority])
-Adds a CSS class provider, invoked before each working set item is created or updated. When calledto update an existing item, all previously applied classes have been cleared.
+Adds a CSS class provider, invoked before each working set item is created or updated. When called
+to update an existing item, all previously applied classes have been cleared.
 
 **Kind**: global function  
 

--- a/docs/API-Reference/project/FileTreeViewModel.md
+++ b/docs/API-Reference/project/FileTreeViewModel.md
@@ -3,16 +3,32 @@
 const FileTreeViewModel = brackets.getModule("project/FileTreeViewModel")
 ```
 
-<a name="Contains the treeData used to generate the file tree and methods used to update thattreeData.Instances dispatch the following events_- change (FileTreeViewModel.EVENT_CHANGE constant)_ Fired any time theres a change that should be reflected in the view."></a>
+<a name="Contains the treeData used to generate the file tree and methods used to update that
+treeData.
 
-## Contains the treeData used to generate the file tree and methods used to update thattreeData.Instances dispatch the following events:- change (FileTreeViewModel.EVENT\_CHANGE constant): Fired any time theres a change that should be reflected in the view.
+Instances dispatch the following events_
+- change (FileTreeViewModel.EVENT_CHANGE constant)_ Fired any time theres a change that should be reflected in the view."></a>
+
+## Contains the treeData used to generate the file tree and methods used to update that
+treeData.
+
+Instances dispatch the following events:
+- change (FileTreeViewModel.EVENT\_CHANGE constant): Fired any time theres a change that should be reflected in the view.
 **Kind**: global class  
 <a name="Immutable"></a>
 
 ## Immutable
-The view model (or a Store in the Flux terminology) used by the file tree.Many of the view model's methods are implemented by pure functions, which can behelpful for composability. Many of the methods commit the new treeData and send achange event when they're done whereas the functions do not do this.
+The view model (or a Store in the Flux terminology) used by the file tree.
+
+Many of the view model's methods are implemented by pure functions, which can be
+helpful for composability. Many of the methods commit the new treeData and send a
+change event when they're done whereas the functions do not do this.
 
 **Kind**: global variable  
+<a name="EVENT_CHANGE"></a>
+
+## EVENT\_CHANGE : <code>string</code>
+**Kind**: global constant  
 <a name="isFile"></a>
 
 ## isFile(entry) ⇒ <code>boolean</code>
@@ -24,16 +40,4 @@ Determine if an entry from the treeData map is a file.
 | Param | Type | Description |
 | --- | --- | --- |
 | entry | <code>Immutable.Map</code> | entry to test |
-
-<a name="_closeSubtree"></a>
-
-## \_closeSubtree(directory) ⇒ <code>Immutable.Map</code>
-Closes a subtree path, given by an object path.
-
-**Kind**: global function  
-**Returns**: <code>Immutable.Map</code> - new directory  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| directory | <code>Immutable.Map</code> | Current directory |
 

--- a/docs/API-Reference/project/FileViewController.md
+++ b/docs/API-Reference/project/FileViewController.md
@@ -3,10 +3,23 @@
 const FileViewController = brackets.getModule("project/FileViewController")
 ```
 
+<a name="WORKING_SET_VIEW"></a>
+
+## WORKING\_SET\_VIEW : <code>string</code>
+view managing working set.
+
+**Kind**: global variable  
+<a name="PROJECT_MANAGER"></a>
+
+## PROJECT\_MANAGER : <code>string</code>
+manager handling project-related operations.
+
+**Kind**: global variable  
 <a name="setFileViewFocus"></a>
 
 ## setFileViewFocus(fileSelectionFocus)
-Modifies the selection focus in the project side bar. A file can either be selectedin the working set (the open files) or in the file tree, but not both.
+Modifies the selection focus in the project side bar. A file can either be selected
+in the working set (the open files) or in the file tree, but not both.
 
 **Kind**: global function  
 
@@ -17,7 +30,8 @@ Modifies the selection focus in the project side bar. A file can either be selec
 <a name="openAndSelectDocument"></a>
 
 ## openAndSelectDocument(fullPath, fileSelectionFocus, paneId) ⇒ <code>$.Promise</code>
-Opens a document if it's not open and selects the file in the UI corresponding tofileSelectionFocus
+Opens a document if it's not open and selects the file in the UI corresponding to
+fileSelectionFocus
 
 **Kind**: global function  
 
@@ -30,7 +44,8 @@ Opens a document if it's not open and selects the file in the UI corresponding t
 <a name="openFileAndAddToWorkingSet"></a>
 
 ## openFileAndAddToWorkingSet(fullPath, [paneId]) ⇒ <code>$.Promise</code>
-Opens the specified document if it's not already open, adds it to the working set,and selects it in the WorkingSetView
+Opens the specified document if it's not already open, adds it to the working set,
+and selects it in the WorkingSetView
 
 **Kind**: global function  
 
@@ -45,19 +60,6 @@ Opens the specified document if it's not already open, adds it to the working se
 Opens the specified document with its associated external editor,
 
 **Kind**: global function  
-<a name="addToWorkingSetAndSelect"></a>
-
-## ..addToWorkingSetAndSelect(fullPath) ⇒ <code>$.Promise</code>..
-***Deprecated***
-
-Opens the specified document if it's not already open, adds it to the working set,and selects it in the WorkingSetView
-
-**Kind**: global function  
-
-| Param | Type |
-| --- | --- |
-| fullPath | <code>fullPath</code> | 
-
 <a name="getFileSelectionFocus"></a>
 
 ## getFileSelectionFocus() ⇒ <code>String</code>

--- a/docs/API-Reference/project/ProjectManager.md
+++ b/docs/API-Reference/project/ProjectManager.md
@@ -3,12 +3,73 @@
 const ProjectManager = brackets.getModule("project/ProjectManager")
 ```
 
-<a name="SORT_DIRECTORIES_FIRST"></a>
+<a name="EVENT_PROJECT_BEFORE_CLOSE"></a>
 
-## SORT\_DIRECTORIES\_FIRST : <code>string</code>
-Name of the preferences for sorting directories first
+## EVENT\_PROJECT\_BEFORE\_CLOSE : <code>string</code>
+Triggered before the project closes.
 
-**Kind**: global variable  
+**Kind**: global constant  
+<a name="EVENT_PROJECT_CLOSE"></a>
+
+## EVENT\_PROJECT\_CLOSE : <code>string</code>
+Triggered when the project has closed.
+
+**Kind**: global constant  
+<a name="EVENT_PROJECT_OPEN_FAILED"></a>
+
+## EVENT\_PROJECT\_OPEN\_FAILED : <code>string</code>
+Triggered when opening a project file fails.
+
+**Kind**: global constant  
+<a name="EVENT_PROJECT_OPEN"></a>
+
+## EVENT\_PROJECT\_OPEN : <code>string</code>
+Triggered when a project is opened.
+
+**Kind**: global constant  
+<a name="EVENT_AFTER_PROJECT_OPEN"></a>
+
+## EVENT\_AFTER\_PROJECT\_OPEN : <code>string</code>
+Triggered after a project is successfully opened.
+
+**Kind**: global constant  
+<a name="EVENT_AFTER_STARTUP_FILES_LOADED"></a>
+
+## EVENT\_AFTER\_STARTUP\_FILES\_LOADED : <code>string</code>
+Triggered after startup files (from OS or CLI) are loaded.
+Note: This may occur before extensions are loaded, so check `isStartupFilesLoaded()`.
+
+**Kind**: global constant  
+<a name="EVENT_PROJECT_REFRESH"></a>
+
+## EVENT\_PROJECT\_REFRESH : <code>string</code>
+Triggered when the project is refreshed.
+
+**Kind**: global constant  
+<a name="EVENT_CONTENT_CHANGED"></a>
+
+## EVENT\_CONTENT\_CHANGED : <code>string</code>
+Triggered when content in the project changes.
+
+**Kind**: global constant  
+<a name="EVENT_PROJECT_FILE_CHANGED"></a>
+
+## EVENT\_PROJECT\_FILE\_CHANGED : <code>string</code>
+Triggered when any file or folder in the project changes, excluding renames.
+
+**Kind**: global constant  
+<a name="EVENT_PROJECT_FILE_RENAMED"></a>
+
+## EVENT\_PROJECT\_FILE\_RENAMED : <code>string</code>
+Triggered specifically when a project file is renamed.
+
+**Kind**: global constant  
+<a name="EVENT_PROJECT_CHANGED_OR_RENAMED_PATH"></a>
+
+## EVENT\_PROJECT\_CHANGED\_OR\_RENAMED\_PATH : <code>string</code>
+Triggered when paths in the project are changed or renamed.
+
+**Kind**: global constant  
 <a name="getFileTreeContext"></a>
 
 ## getFileTreeContext() ⇒ <code>File</code> \| <code>Directory</code>
@@ -18,13 +79,17 @@ Returns the File or Directory corresponding to the item that was right-clicked o
 <a name="getSelectedItem"></a>
 
 ## getSelectedItem() ⇒ <code>File</code> \| <code>Directory</code>
-Returns the File or Directory corresponding to the item selected in the sidebar panel, whether inthe file tree OR in the working set; or null if no item is selected anywhere in the sidebar.May NOT be identical to the current Document - a folder may be selected in the sidebar, or the sidebar may nothave the current document visible in the tree & working set.
+Returns the File or Directory corresponding to the item selected in the sidebar panel, whether in
+the file tree OR in the working set; or null if no item is selected anywhere in the sidebar.
+May NOT be identical to the current Document - a folder may be selected in the sidebar, or the sidebar may not
+have the current document visible in the tree & working set.
 
 **Kind**: global function  
 <a name="getBaseUrl"></a>
 
 ## getBaseUrl() ⇒ <code>String</code>
-Returns the encoded Base URL of the currently loaded project, or empty string if no projectis open (during startup, or running outside of app shell).
+Returns the encoded Base URL of the currently loaded project, or empty string if no project
+is open (during startup, or running outside of app shell).
 
 **Kind**: global function  
 <a name="setBaseUrl"></a>
@@ -41,7 +106,8 @@ Sets the encoded Base URL of the currently loaded project.
 <a name="isWithinProject"></a>
 
 ## isWithinProject(absPathOrEntry) ⇒ <code>boolean</code>
-Returns true if absPath lies within the project, false otherwise.Does not support paths containing ".."
+Returns true if absPath lies within the project, false otherwise.
+Does not support paths containing ".."
 
 **Kind**: global function  
 
@@ -64,7 +130,9 @@ Returns an array of files that is within the project from the supplied list of p
 <a name="makeProjectRelativeIfPossible"></a>
 
 ## makeProjectRelativeIfPossible(absPath) ⇒ <code>string</code>
-If absPath lies within the project, returns a project-relative path. Else returns absPathunmodified.Does not support paths containing ".."
+If absPath lies within the project, returns a project-relative path. Else returns absPath
+unmodified.
+Does not support paths containing ".."
 
 **Kind**: global function  
 
@@ -75,7 +143,11 @@ If absPath lies within the project, returns a project-relative path. Else return
 <a name="getProjectRelativeOrDisplayPath"></a>
 
 ## getProjectRelativeOrDisplayPath(fullPath) ⇒ <code>string</code>
-Gets a generally displayable path that can be shown to the user in most cases.Gets the project relative path if possible. If paths is not in project, then if its a platform path(Eg. in tauri)it will return the full platform path. If not, then it will return a mount relative path for fs access mountfolders opened in the bowser. at last, falling back to vfs path. This should only be used for display purposesas this path will be changed by phcode depending on the situation in the future.
+Gets a generally displayable path that can be shown to the user in most cases.
+Gets the project relative path if possible. If paths is not in project, then if its a platform path(Eg. in tauri)
+it will return the full platform path. If not, then it will return a mount relative path for fs access mount
+folders opened in the bowser. at last, falling back to vfs path. This should only be used for display purposes
+as this path will be changed by phcode depending on the situation in the future.
 
 **Kind**: global function  
 
@@ -86,30 +158,34 @@ Gets a generally displayable path that can be shown to the user in most cases.G
 <a name="getProjectRoot"></a>
 
 ## getProjectRoot() ⇒ <code>Directory</code>
-Returns the root folder of the currently loaded project, or null if no project is open (duringstartup, or running outside of app shell).
+Returns the root folder of the currently loaded project, or null if no project is open (during
+startup, or running outside of app shell).
 
 **Kind**: global function  
-<a name="getLocalProjectsPath"></a>
+<a name="getWelcomeProjectPath"></a>
 
-## getLocalProjectsPath() ⇒ <code>string</code>
-The flder where all the system managed projects live
-
-**Kind**: global function  
-<a name="addWelcomeProjectPath"></a>
-
-## addWelcomeProjectPath(path)
-Adds the path to the list of welcome projects we've ever seen, if not on the list already.
+## getWelcomeProjectPath(sampleUrl, initialPath) ⇒ <code>string</code>
+Returns the full path to the welcome project, which we open on first launch.
 
 **Kind**: global function  
+**Returns**: <code>string</code> - fullPath reference  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| path | <code>string</code> | Path to possibly add |
+| sampleUrl | <code>string</code> | URL for getting started project |
+| initialPath | <code>string</code> | Path to Brackets directory (see FileUtils.getNativeBracketsDirectoryPath()) |
 
+<a name="getLocalProjectsPath"></a>
+
+## getLocalProjectsPath() ⇒ <code>string</code>
+The folder where all the system managed projects live
+
+**Kind**: global function  
 <a name="isWelcomeProjectPath"></a>
 
 ## isWelcomeProjectPath(path) ⇒ <code>boolean</code>
-Returns true if the given path is the same as one of the welcome projects we've previously opened,or the one for the current build.
+Returns true if the given path is the same as one of the welcome projects we've previously opened,
+or the one for the current build.
 
 **Kind**: global function  
 **Returns**: <code>boolean</code> - true if this is a welcome project path  
@@ -124,40 +200,27 @@ Returns true if the given path is the same as one of the welcome projects we've 
 If the provided path is to an old welcome project, returns the current one instead.
 
 **Kind**: global function  
-<a name="getInitialProjectPath"></a>
-
-## ..getInitialProjectPath()..
-***Deprecated***
-
-**Kind**: global function  
 <a name="getStartupProjectPath"></a>
 
 ## getStartupProjectPath()
-Initial project path is stored in prefs, which defaults to the welcome project onfirst launch.
+Initial project path is stored in prefs, which defaults to the welcome project on
+first launch.
 
 **Kind**: global function  
-<a name="_loadProject"></a>
-
-## \_loadProject(rootPath) ⇒ <code>$.Promise</code>
-Loads the given folder as a project. Does NOT prompt about any unsaved changes - use openProject()instead to check for unsaved changes and (optionally) let the user choose the folder to open.
-
-**Kind**: global function  
-**Returns**: <code>$.Promise</code> - A promise object that will be resolved when the project is loaded and tree is rendered, or rejected if the project path fails to load.  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| rootPath | <code>string</code> | Absolute path to the root folder of the project.  A trailing "/" on the path is optional (unlike many Brackets APIs that assume a trailing "/"). |
-
 <a name="refreshFileTree"></a>
 
 ## refreshFileTree()
-Refresh the project's file tree, maintaining the current selection.Note that the original implementation of this returned a promise to be resolved when the refresh is complete.That use is deprecated and `refreshFileTree` is now a "fire and forget" kind of function.
+Refresh the project's file tree, maintaining the current selection.
+
+Note that the original implementation of this returned a promise to be resolved when the refresh is complete.
+That use is deprecated and `refreshFileTree` is now a "fire and forget" kind of function.
 
 **Kind**: global function  
 <a name="showInTree"></a>
 
 ## showInTree(entry) ⇒ <code>$.Promise</code>
-Expands tree nodes to show the given file or folder and selects it. Silently no-ops if thepath lies outside the project, or if it doesn't exist.
+Expands tree nodes to show the given file or folder and selects it. Silently no-ops if the
+path lies outside the project, or if it doesn't exist.
 
 **Kind**: global function  
 **Returns**: <code>$.Promise</code> - Resolved when done; or rejected if not found  
@@ -169,28 +232,27 @@ Expands tree nodes to show the given file or folder and selects it. Silently no-
 <a name="openProject"></a>
 
 ## openProject([path]) ⇒ <code>$.Promise</code>
-Open a new project. Currently, Brackets must always have a project open, sothis method handles both closing the current project and opening a new project.
+Open a new project. Currently, Brackets must always have a project open, so
+this method handles both closing the current project and opening a new project.
 
 **Kind**: global function  
-**Returns**: <code>$.Promise</code> - A promise object that will be resolved when the project is loaded and tree is rendered, or rejected if the project path fails to load.  
+**Returns**: <code>$.Promise</code> - A promise object that will be resolved when the
+ project is loaded and tree is rendered, or rejected if the project path
+ fails to load.  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | [path] | <code>string</code> | Optional absolute path to the root folder of the project.  If path is undefined or null, displays a dialog where the user can choose a  folder to load. If the user cancels the dialog, nothing more happens. |
 
-<a name="_projectSettings"></a>
-
-## \_projectSettings() ⇒ <code>$.Promise</code>
-Invoke project settings dialog.
-
-**Kind**: global function  
 <a name="createNewItem"></a>
 
 ## createNewItem(baseDir, initialName, skipRename, isFolder) ⇒ <code>$.Promise</code>
 Create a new item in the current project.
 
 **Kind**: global function  
-**Returns**: <code>$.Promise</code> - A promise object that will be resolved with the File of the created object, or rejected if the user cancelled or entered an illegal filename.  
+**Returns**: <code>$.Promise</code> - A promise object that will be resolved with the File
+ of the created object, or rejected if the user cancelled or entered an illegal
+ filename.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -230,7 +292,14 @@ Causes the rename operation that's in progress to complete.
 <a name="setProjectBusy"></a>
 
 ## setProjectBusy(isBusy, message)
-Sets or unsets project busy spinner with the specified message as reason.For Eg., if you want to mark project as busy with reason compiling project:`setProjectBusy(true, "compiling project...")` . The project spinner will be shown with the specified reason.Once the compilation is complete, call, we need to unset the busy status by calling:`setProjectBusy(false, "compiling project...")` . Make sure to pass in the exact message whencalling set and unset.
+Sets or unsets project busy spinner with the specified message as reason.
+
+For Eg., if you want to mark project as busy with reason compiling project:
+`setProjectBusy(true, "compiling project...")` . The project spinner will be shown with the specified reason.
+
+Once the compilation is complete, call, we need to unset the busy status by calling:
+`setProjectBusy(false, "compiling project...")` . Make sure to pass in the exact message when
+calling set and unset.
 
 **Kind**: global function  
 
@@ -259,7 +328,9 @@ Gets the filesystem object for the current context in the file tree.
 <a name="renameItemInline"></a>
 
 ## renameItemInline(entry, [isMoved]) ⇒ <code>$.Promise</code>
-Starts a rename operation, completing the current operation if there is one.The Promise returned is resolved with an object with a `newPath` property with the renamed path. If the user cancels the operation, the promise is resolved with the value RENAME_CANCELLED.
+Starts a rename operation, completing the current operation if there is one.
+
+The Promise returned is resolved with an object with a `newPath` property with the renamed path. If the user cancels the operation, the promise is resolved with the value RENAME_CANCELLED.
 
 **Kind**: global function  
 **Returns**: <code>$.Promise</code> - a promise resolved when the rename is done.  
@@ -272,7 +343,10 @@ Starts a rename operation, completing the current operation if there is one.Th
 <a name="getAllFiles"></a>
 
 ## getAllFiles(filter, [includeWorkingSet], [sort], options) ⇒ <code>$.Promise</code>
-Returns an Array of all files for this project, optionally includingfiles in the working set that are *not* under the project root. Files arefiltered first by ProjectModel.shouldShow(), then by the custom filterargument (if one was provided).
+Returns an Array of all files for this project, optionally including
+files in the working set that are *not* under the project root. Files are
+filtered first by ProjectModel.shouldShow(), then by the custom filter
+argument (if one was provided).
 
 **Kind**: global function  
 **Returns**: <code>$.Promise</code> - Promise that is resolved with an Array of File objects.  
@@ -288,7 +362,8 @@ Returns an Array of all files for this project, optionally includingfiles in th
 <a name="addIconProvider"></a>
 
 ## addIconProvider(callback, [priority])
-Adds an icon provider. The callback is invoked before each working set item is created, and canreturn content to prepend to the item if it supports the icon.
+Adds an icon provider. The callback is invoked before each working set item is created, and can
+return content to prepend to the item if it supports the icon.
 
 **Kind**: global function  
 
@@ -300,7 +375,8 @@ Adds an icon provider. The callback is invoked before each working set item is c
 <a name="addClassesProvider"></a>
 
 ## addClassesProvider(callback, [priority])
-Adds a CSS class provider, invoked before each working set item is created or updated. When calledto update an existing item, all previously applied classes have been cleared.
+Adds a CSS class provider, invoked before each working set item is created or updated. When called
+to update an existing item, all previously applied classes have been cleared.
 
 **Kind**: global function  
 
@@ -312,6 +388,9 @@ Adds a CSS class provider, invoked before each working set item is created or up
 <a name="rerenderTree"></a>
 
 ## rerenderTree()
-Forces the file tree to rerender. Typically, the tree only rerenders the portions of thetree that have changed data. If an extension that augments the tree has changes that itneeds to display, calling rerenderTree will cause the components for the whole tree tobe rerendered.
+Forces the file tree to rerender. Typically, the tree only rerenders the portions of the
+tree that have changed data. If an extension that augments the tree has changes that it
+needs to display, calling rerenderTree will cause the components for the whole tree to
+be rerendered.
 
 **Kind**: global function  

--- a/docs/API-Reference/project/ProjectModel.md
+++ b/docs/API-Reference/project/ProjectModel.md
@@ -3,9 +3,23 @@
 const ProjectModel = brackets.getModule("project/ProjectModel")
 ```
 
-<a name="The ProjectModel provides methods for accessing information about the current open project.It also manages the view model to display a FileTreeView of the project.Events_- EVENT_CHANGE (`change`) - Fired when theres a change that should refresh the UI- EVENT_SHOULD_SELECT (`select`) - Fired when a selection has been made in the file tree and the file tree should be selected- EVENT_SHOULD_FOCUS (`focus`)- ERROR_CREATION (`creationError`) - Triggered when theres a problem creating a file"></a>
+<a name="The ProjectModel provides methods for accessing information about the current open project.
+It also manages the view model to display a FileTreeView of the project.
 
-## The ProjectModel provides methods for accessing information about the current open project.It also manages the view model to display a FileTreeView of the project.Events:- EVENT\_CHANGE (`change`) - Fired when theres a change that should refresh the UI- EVENT\_SHOULD\_SELECT (`select`) - Fired when a selection has been made in the file tree and the file tree should be selected- EVENT\_SHOULD\_FOCUS (`focus`)- ERROR\_CREATION (`creationError`) - Triggered when theres a problem creating a file
+Events_
+- EVENT_CHANGE (`change`) - Fired when theres a change that should refresh the UI
+- EVENT_SHOULD_SELECT (`select`) - Fired when a selection has been made in the file tree and the file tree should be selected
+- EVENT_SHOULD_FOCUS (`focus`)
+- ERROR_CREATION (`creationError`) - Triggered when theres a problem creating a file"></a>
+
+## The ProjectModel provides methods for accessing information about the current open project.
+It also manages the view model to display a FileTreeView of the project.
+
+Events:
+- EVENT\_CHANGE (`change`) - Fired when theres a change that should refresh the UI
+- EVENT\_SHOULD\_SELECT (`select`) - Fired when a selection has been made in the file tree and the file tree should be selected
+- EVENT\_SHOULD\_FOCUS (`focus`)
+- ERROR\_CREATION (`creationError`) - Triggered when theres a problem creating a file
 **Kind**: global class  
 <a name="InMemoryFile"></a>
 
@@ -13,16 +27,86 @@ const ProjectModel = brackets.getModule("project/ProjectModel")
 Provides the data source for a project and manages the view model for the FileTreeView.
 
 **Kind**: global variable  
+<a name="EVENT_CHANGE"></a>
+
+## EVENT\_CHANGE : <code>string</code>
+Triggered when change occurs.
+
+**Kind**: global constant  
+<a name="EVENT_SHOULD_SELECT"></a>
+
+## EVENT\_SHOULD\_SELECT : <code>string</code>
+Triggered when item should be selected.
+
+**Kind**: global constant  
+<a name="EVENT_SHOULD_FOCUS"></a>
+
+## EVENT\_SHOULD\_FOCUS : <code>string</code>
+Triggered when item should receive focus.
+
+**Kind**: global constant  
+<a name="EVENT_FS_RENAME_STARTED"></a>
+
+## EVENT\_FS\_RENAME\_STARTED : <code>string</code>
+Triggered when file system rename operation starts.
+
+**Kind**: global constant  
+<a name="EVENT_FS_RENAME_END"></a>
+
+## EVENT\_FS\_RENAME\_END : <code>string</code>
+Triggered when file system rename operation ends.
+
+**Kind**: global constant  
+<a name="ERROR_CREATION"></a>
+
+## ERROR\_CREATION : <code>string</code>
+Error during creation.
+
+**Kind**: global constant  
+<a name="ERROR_INVALID_FILENAME"></a>
+
+## ERROR\_INVALID\_FILENAME : <code>string</code>
+Error because of Invalid filename
+
+**Kind**: global constant  
+<a name="ERROR_NOT_IN_PROJECT"></a>
+
+## ERROR\_NOT\_IN\_PROJECT : <code>string</code>
+Error when an item is not in a project
+
+**Kind**: global constant  
 <a name="defaultIgnoreGlobs"></a>
 
 ## defaultIgnoreGlobs
-Glob definition of files and folders that should be excluded directlyinside node domain watching with chokidar
+Glob definition of files and folders that should be excluded directly
+inside node domain watching with chokidar
+
+**Kind**: global constant  
+<a name="FILE_RENAMING"></a>
+
+## FILE\_RENAMING : <code>number</code>
+File renaming
+
+**Kind**: global constant  
+<a name="FILE_CREATING"></a>
+
+## FILE\_CREATING : <code>number</code>
+File creating
+
+**Kind**: global constant  
+<a name="RENAME_CANCELLED"></a>
+
+## RENAME\_CANCELLED : <code>number</code>
+Rename cancelled
 
 **Kind**: global constant  
 <a name="isValidFilename"></a>
 
 ## isValidFilename(filename) ⇒ <code>boolean</code>
-Returns true if this matches valid filename specifications.See http://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspxTODO: This likely belongs in FileUtils.
+Returns true if this matches valid filename specifications.
+See http://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx
+
+TODO: This likely belongs in FileUtils.
 
 **Kind**: global function  
 **Returns**: <code>boolean</code> - true if the filename is valid  
@@ -58,7 +142,8 @@ Returns false for files and directories that are not commonly useful to display.
 <a name="shouldIndex"></a>
 
 ## shouldIndex(entry) ⇒ <code>boolean</code>
-Returns false for files and directories that should not be indexed for search or code hints.If the entry is a directory, its children should be indexed too.
+Returns false for files and directories that should not be indexed for search or code hints.
+If the entry is a directory, its children should be indexed too.
 
 **Kind**: global function  
 **Returns**: <code>boolean</code> - true if the file should be displayed  
@@ -70,7 +155,8 @@ Returns false for files and directories that should not be indexed for search or
 <a name="doCreate"></a>
 
 ## doCreate(path, isFolder) ⇒ <code>$.Promise</code>
-Creates a new file or folder at the given path. The returned promise is rejected if the filenameis invalid, the new path already exists or some other filesystem error comes up.
+Creates a new file or folder at the given path. The returned promise is rejected if the filename
+is invalid, the new path already exists or some other filesystem error comes up.
 
 **Kind**: global function  
 **Returns**: <code>$.Promise</code> - resolved when the file or directory has been created.  
@@ -79,29 +165,4 @@ Creates a new file or folder at the given path. The returned promise is rejected
 | --- | --- | --- |
 | path | <code>string</code> | path to create |
 | isFolder | <code>boolean</code> | true if the new entry is a folder |
-
-<a name="_ensureTrailingSlash"></a>
-
-## \_ensureTrailingSlash(fullPath) ⇒ <code>string</code>
-Although Brackets is generally standardized on folder paths with a trailing "/", some APIs herereceive project paths without "/" due to legacy preference storage formats, etc.
-
-**Kind**: global function  
-**Returns**: <code>string</code> - Path that ends in "/"  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| fullPath | <code>string</code> | Path that may or may not end in "/" |
-
-<a name="_isWelcomeProjectPath"></a>
-
-## \_isWelcomeProjectPath(path, welcomeProjectPath, [welcomeProjects])
-Returns true if the given path is the same as one of the welcome projects we've previously opened,or the one for the current build.
-
-**Kind**: global function  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| path | <code>string</code> | Path to check to see if it's a welcome project |
-| welcomeProjectPath | <code>string</code> | Current welcome project path |
-| [welcomeProjects] | <code>Array.&lt;string&gt;</code> | All known welcome projects |
 

--- a/docs/API-Reference/project/SidebarView.md
+++ b/docs/API-Reference/project/SidebarView.md
@@ -6,13 +6,16 @@ const SidebarView = brackets.getModule("project/SidebarView")
 <a name="AppInit"></a>
 
 ## AppInit
-The view that controls the showing and hiding of the sidebar.Although the sidebar view doesn't dispatch any events directly, it is aresizable element (../utils/Resizer.js), which means it can dispatch Resizerevents.  For example, if you want to listen for the sidebar showingor hiding itself, set up listeners for the corresponding Resizer events,panelCollapsed and panelExpanded:     $("#sidebar").on("panelCollapsed", ...);     $("#sidebar").on("panelExpanded", ...);
+The view that controls the showing and hiding of the sidebar.
 
-**Kind**: global variable  
-<a name="_cmdSplitNone"></a>
+Although the sidebar view doesn't dispatch any events directly, it is a
+resizable element (../utils/Resizer.js), which means it can dispatch Resizer
+events.  For example, if you want to listen for the sidebar showing
+or hiding itself, set up listeners for the corresponding Resizer events,
+panelCollapsed and panelExpanded:
 
-## \_cmdSplitNone
-Register Command Handlers
+     $("#sidebar").on("panelCollapsed", ...);
+     $("#sidebar").on("panelExpanded", ...);
 
 **Kind**: global variable  
 <a name="toggle"></a>

--- a/docs/API-Reference/project/WorkingSetSort.md
+++ b/docs/API-Reference/project/WorkingSetSort.md
@@ -3,71 +3,6 @@
 const WorkingSetSort = brackets.getModule("project/WorkingSetSort")
 ```
 
-<a name="Sort"></a>
-
-## Sort
-**Kind**: global class  
-
-* [Sort](#Sort)
-    * [new Sort(commandID, compareFn, events)](#new_Sort_new)
-    * [.getCommandID()](#Sort+getCommandID) ⇒ <code>string</code>
-    * [.getCompareFn()](#Sort+getCompareFn) ⇒ <code>function</code>
-    * [.getEvents()](#Sort+getEvents) ⇒ <code>string</code>
-    * [.setChecked(value)](#Sort+setChecked)
-    * [.execute()](#Sort+execute)
-    * [.sort()](#Sort+sort)
-
-<a name="new_Sort_new"></a>
-
-### new Sort(commandID, compareFn, events)
-
-| Param | Type | Description |
-| --- | --- | --- |
-| commandID | <code>string</code> | A valid command identifier. |
-| compareFn | <code>function</code> | A valid sort      function (see register for a longer explanation). |
-| events | <code>string</code> | Space-separated WorkingSetSort possible events      ending with ".sort". |
-
-<a name="Sort+getCommandID"></a>
-
-### sort.getCommandID() ⇒ <code>string</code>
-The Command ID
-
-**Kind**: instance method of [<code>Sort</code>](#Sort)  
-<a name="Sort+getCompareFn"></a>
-
-### sort.getCompareFn() ⇒ <code>function</code>
-The compare function
-
-**Kind**: instance method of [<code>Sort</code>](#Sort)  
-<a name="Sort+getEvents"></a>
-
-### sort.getEvents() ⇒ <code>string</code>
-Gets the event that this sort object is listening to
-
-**Kind**: instance method of [<code>Sort</code>](#Sort)  
-<a name="Sort+setChecked"></a>
-
-### sort.setChecked(value)
-Checks/Unchecks the command which will show a check in the menu
-
-**Kind**: instance method of [<code>Sort</code>](#Sort)  
-
-| Param | Type |
-| --- | --- |
-| value | <code>boolean</code> | 
-
-<a name="Sort+execute"></a>
-
-### sort.execute()
-Performs the sort and makes it the current sort method.
-
-**Kind**: instance method of [<code>Sort</code>](#Sort)  
-<a name="Sort+sort"></a>
-
-### sort.sort()
-Only performs the working set sort if this is the current sort.
-
-**Kind**: instance method of [<code>Sort</code>](#Sort)  
 <a name="Commands"></a>
 
 ## Commands
@@ -76,7 +11,7 @@ Manages the workingSetList sort methods.
 **Kind**: global variable  
 <a name="get"></a>
 
-## get(command) ⇒ [<code>Sort</code>](#Sort)
+## get(command) ⇒ [<code>Sort</code>](#new_Sort_new)
 Retrieves a Sort object by id
 
 **Kind**: global function  
@@ -103,7 +38,7 @@ Enables/Disables Automatic Sort depending on the value.
 
 <a name="register"></a>
 
-## register(command, compareFn, events) ⇒ [<code>Sort</code>](#Sort)
+## register(command, compareFn, events) ⇒ [<code>Sort</code>](#new_Sort_new)
 Registers a working set sort method.
 
 **Kind**: global function  

--- a/docs/API-Reference/project/WorkingSetSort.md
+++ b/docs/API-Reference/project/WorkingSetSort.md
@@ -3,6 +3,71 @@
 const WorkingSetSort = brackets.getModule("project/WorkingSetSort")
 ```
 
+<a name="Sort"></a>
+
+## Sort
+**Kind**: global class  
+
+* [Sort](#Sort)
+    * [new Sort(commandID, compareFn, events)](#new_Sort_new)
+    * [.getCommandID()](#Sort+getCommandID) ⇒ <code>string</code>
+    * [.getCompareFn()](#Sort+getCompareFn) ⇒ <code>function</code>
+    * [.getEvents()](#Sort+getEvents) ⇒ <code>string</code>
+    * [.setChecked(value)](#Sort+setChecked)
+    * [.execute()](#Sort+execute)
+    * [.sort()](#Sort+sort)
+
+<a name="new_Sort_new"></a>
+
+### new Sort(commandID, compareFn, events)
+
+| Param | Type | Description |
+| --- | --- | --- |
+| commandID | <code>string</code> | A valid command identifier. |
+| compareFn | <code>function</code> | A valid sort      function (see register for a longer explanation). |
+| events | <code>string</code> | Space-separated WorkingSetSort possible events      ending with ".sort". |
+
+<a name="Sort+getCommandID"></a>
+
+### sort.getCommandID() ⇒ <code>string</code>
+The Command ID
+
+**Kind**: instance method of [<code>Sort</code>](#Sort)  
+<a name="Sort+getCompareFn"></a>
+
+### sort.getCompareFn() ⇒ <code>function</code>
+The compare function
+
+**Kind**: instance method of [<code>Sort</code>](#Sort)  
+<a name="Sort+getEvents"></a>
+
+### sort.getEvents() ⇒ <code>string</code>
+Gets the event that this sort object is listening to
+
+**Kind**: instance method of [<code>Sort</code>](#Sort)  
+<a name="Sort+setChecked"></a>
+
+### sort.setChecked(value)
+Checks/Unchecks the command which will show a check in the menu
+
+**Kind**: instance method of [<code>Sort</code>](#Sort)  
+
+| Param | Type |
+| --- | --- |
+| value | <code>boolean</code> | 
+
+<a name="Sort+execute"></a>
+
+### sort.execute()
+Performs the sort and makes it the current sort method.
+
+**Kind**: instance method of [<code>Sort</code>](#Sort)  
+<a name="Sort+sort"></a>
+
+### sort.sort()
+Only performs the working set sort if this is the current sort.
+
+**Kind**: instance method of [<code>Sort</code>](#Sort)  
 <a name="Commands"></a>
 
 ## Commands
@@ -11,7 +76,7 @@ Manages the workingSetList sort methods.
 **Kind**: global variable  
 <a name="get"></a>
 
-## get(command) ⇒ [<code>Sort</code>](#new_Sort_new)
+## get(command) ⇒ [<code>Sort</code>](#Sort)
 Retrieves a Sort object by id
 
 **Kind**: global function  
@@ -38,7 +103,7 @@ Enables/Disables Automatic Sort depending on the value.
 
 <a name="register"></a>
 
-## register(command, compareFn, events) ⇒ [<code>Sort</code>](#new_Sort_new)
+## register(command, compareFn, events) ⇒ [<code>Sort</code>](#Sort)
 Registers a working set sort method.
 
 **Kind**: global function  

--- a/docs/API-Reference/project/WorkingSetView.md
+++ b/docs/API-Reference/project/WorkingSetView.md
@@ -3,30 +3,6 @@
 const WorkingSetView = brackets.getModule("project/WorkingSetView")
 ```
 
-<a name="$workingFilesContainer"></a>
-
-## $workingFilesContainer : <code>jQuery</code>
-#working-set-list-container
-
-**Kind**: global variable  
-<a name="LEFT_BUTTON"></a>
-
-## LEFT\_BUTTON : <code>enum</code>
-Constants for event.which values
-
-**Kind**: global enum  
-<a name="NOMANSLAND"></a>
-
-## NOMANSLAND : <code>enum</code>
-Constants for hitTest.where
-
-**Kind**: global enum  
-<a name="_DRAG_MOVE_DETECTION_START"></a>
-
-## \_DRAG\_MOVE\_DETECTION\_START
-Drag an item has to move 3px before dragging starts
-
-**Kind**: global constant  
 <a name="refresh"></a>
 
 ## refresh()
@@ -54,7 +30,8 @@ Creates a new WorkingSetView object for the specified pane
 <a name="addIconProvider"></a>
 
 ## addIconProvider(callback, [priority])
-Adds an icon provider. The callback is invoked before each working set item is created, and canreturn content to prepend to the item if it supports the icon.
+Adds an icon provider. The callback is invoked before each working set item is created, and can
+return content to prepend to the item if it supports the icon.
 
 **Kind**: global function  
 
@@ -66,7 +43,8 @@ Adds an icon provider. The callback is invoked before each working set item is c
 <a name="addClassProvider"></a>
 
 ## addClassProvider(callback, [priority])
-Adds a CSS class provider, invoked before each working set item is created or updated. When calledto update an existing item, all previously applied classes have been cleared.
+Adds a CSS class provider, invoked before each working set item is created or updated. When called
+to update an existing item, all previously applied classes have been cleared.
 
 **Kind**: global function  
 

--- a/src/project/FileSyncManager.js
+++ b/src/project/FileSyncManager.js
@@ -55,6 +55,7 @@ define(function (require, exports, module) {
 
     /**
      * Guard to spot re-entrancy while syncOpenDocuments() is still in progress
+     * @private
      * @type {boolean}
      */
     var _alreadyChecking = false;
@@ -62,27 +63,32 @@ define(function (require, exports, module) {
     /**
      * If true, we should bail from the syncOpenDocuments() process and then re-run it. See
      * comments in syncOpenDocuments() for how this works.
+     * @private
      * @type {boolean}
      */
     var _restartPending = false;
 
     /**
      * @type {Array.<Document>}
+     * @private
      */
     var toReload;
 
     /**
      * @type {Array.<Document>}
+     * @private
      */
     var toClose;
 
     /**
      * @type {{doc: Document, fileTime: number}} Array
+     * @private
      */
     var editConflicts;
 
     /**
      * @type {{doc: Document, fileTime: number}} Array
+     * @private
      */
     var deleteConflicts;
 
@@ -94,6 +100,7 @@ define(function (require, exports, module) {
      *  toClose         - deleted on disk; unchanged within Brackets
      *  editConflicts   - changed on disk; also dirty in Brackets
      *  deleteConflicts - deleted on disk; also dirty in Brackets
+     *  @private
      *
      * @param {!Array.<Document>} docs
      * @return {$.Promise}  Resolved when all scanning done, or rejected immediately if there's any
@@ -176,6 +183,7 @@ define(function (require, exports, module) {
     /**
      * Scans all the files in the working set that do not have Documents (and thus were not scanned
      * by findExternalChanges()). If any were deleted on disk, removes them from the working set.
+     * @private
      */
     function syncUnopenWorkingSet() {
         // We only care about working set entries that have never been open (have no Document).
@@ -212,7 +220,7 @@ define(function (require, exports, module) {
 
     /**
      * Reloads the Document's contents from disk, discarding any unsaved changes in the editor.
-     *
+     * @private
      * @param {!Document} doc
      * @return {$.Promise} Resolved after editor has been refreshed; rejected if unable to load the
      *      file's new content. Errors are logged but no UI is shown.
@@ -233,6 +241,7 @@ define(function (require, exports, module) {
     /**
      * Reloads all the documents in "toReload" silently (no prompts). The operations are all run
      * in parallel.
+     * @private
      * @return {$.Promise} Resolved/rejected after all reloads done; will be rejected if any one
      *      file's reload failed. Errors are logged (by reloadDoc()) but no UI is shown.
      */
@@ -242,6 +251,7 @@ define(function (require, exports, module) {
     }
 
     /**
+     * @private
      * @param {FileError} error
      * @param {!Document} doc
      * @return {Dialog}
@@ -261,6 +271,7 @@ define(function (require, exports, module) {
 
     /**
      * Closes all the documents in "toClose" silently (no prompts). Completes synchronously.
+     * @private
      */
     function closeDeletedDocs() {
         toClose.forEach(function (doc) {
@@ -273,7 +284,7 @@ define(function (require, exports, module) {
      * Walks through all the documents in "editConflicts" & "deleteConflicts" and prompts the user
      * about each one. Processing is sequential: if the user chooses to reload a document, the next
      * prompt is not shown until after the reload has completed.
-     *
+     * @private
      * @param {string} title Title of the dialog.
      * @return {$.Promise} Resolved/rejected after all documents have been prompted and (if
      *      applicable) reloaded (and any resulting error UI has been dismissed). Rejected if any

--- a/src/project/FileTreeView.js
+++ b/src/project/FileTreeView.js
@@ -85,10 +85,12 @@ define(function (require, exports, module) {
 
     /**
      * Mixin that allows a component to compute the full path to its directory entry.
+     * @private
      */
     var pathComputer = {
         /**
          * Computes the full path of the file represented by this input.
+         * @private
          */
         myPath: function () {
             var result = this.props.parentPath + this.props.name;
@@ -155,11 +157,13 @@ define(function (require, exports, module) {
     /**
      * This is a mixin that provides rename input behavior. It is responsible for taking keyboard input
      * and invoking the correct action based on that input.
+     * @private
      */
     var renameBehavior = {
         /**
          * Stop clicks from propagating so that clicking on the rename input doesn't
          * cause directories to collapse.
+         * @private
          */
         handleClick: function (e) {
             e.stopPropagation();
@@ -171,6 +175,7 @@ define(function (require, exports, module) {
         /**
          * If the user presses enter or escape, we either successfully complete or cancel, respectively,
          * the rename or create operation that is underway.
+         * @private
          */
         handleKeyDown: function (e) {
             this.props.actions.setRenameValue(this.props.parentPath + this.refs.name.value.trim());
@@ -184,6 +189,7 @@ define(function (require, exports, module) {
         /**
          * The rename or create operation can be completed or canceled by actions outside of
          * this component, so we keep the model up to date by sending every update via an action.
+         * @private
          */
         handleInput: function (e) {
             this.props.actions.setRenameValue(this.props.parentPath + this.refs.name.value.trim());
@@ -199,6 +205,7 @@ define(function (require, exports, module) {
 
         /**
          * If we leave the field for any reason, complete the rename.
+         * @private
          */
         handleBlur: function () {
             this.props.actions.performRename();
@@ -207,6 +214,7 @@ define(function (require, exports, module) {
 
     /**
      * This is a mixin that provides drag and drop move function.
+     * @private
      */
     var dragAndDrop = {
         handleDrag: function(e) {
@@ -397,13 +405,14 @@ define(function (require, exports, module) {
     /**
      * Mixin for components that support the "icons" and "addClass" extension points.
      * `fileNode` and `directoryNode` support this.
+     * @private
      */
     var extendable = {
 
         /**
          * Calls the icon providers to get the collection of icons (most likely just one) for
          * the current file or directory.
-         *
+         * @private
          * @return {Array.<PreactComponent>} icon components to render
          */
         getIcons: function () {
@@ -445,7 +454,7 @@ define(function (require, exports, module) {
         /**
          * Calls the addClass providers to get the classes (in string form) to add for the current
          * file or directory.
-         *
+         * @private
          * @param {string} classes Initial classes for this node
          * @return {string} classes for the current node
          */
@@ -504,6 +513,7 @@ define(function (require, exports, module) {
         /**
          * Thanks to immutable objects, we can just do a start object identity check to know
          * whether or not we need to re-render.
+         * @private
          */
         shouldComponentUpdate: function (nextProps, nextState) {
             return nextProps.forceRender ||
@@ -514,6 +524,7 @@ define(function (require, exports, module) {
         /**
          * If this node is newly selected, scroll it into view. Also, move the selection or
          * context boxes as appropriate.
+         * @private
          */
         componentDidUpdate: function (prevProps, prevState) {
             var wasSelected = prevProps.entry.get("selected"),
@@ -538,6 +549,7 @@ define(function (require, exports, module) {
         /**
          * When the user clicks on the node, we'll either select it or, if they've clicked twice
          * with a bit of delay in between, we'll invoke the `startRename` action.
+         * @private
          */
         handleClick: function (e) {
             // If we're renaming, allow the click to go through to the rename input.
@@ -569,6 +581,7 @@ define(function (require, exports, module) {
         /**
          * select the current node in the file tree on mouse down event on files.
          * This is to increase click responsiveness of file tree.
+         * @private
          */
         selectNode: function (e) {
             if (e.button !== LEFT_MOUSE_BUTTON) {
@@ -591,6 +604,7 @@ define(function (require, exports, module) {
         /**
          * When the user double clicks, we will select this file and add it to the working
          * set (via the `selectInWorkingSet` action.)
+         * @private
          */
         handleDoubleClick: function () {
             if (!this.props.entry.get("rename")) {
@@ -606,7 +620,7 @@ define(function (require, exports, module) {
 
         /**
          * Create the data object to pass to extensions.
-         *
+         * @private
          * @return {!{name:string, isFile:boolean, fullPath:string}} Data for extensions
          */
         getDataForExtension: function () {
@@ -801,6 +815,7 @@ define(function (require, exports, module) {
          * We need to update this component if the sort order changes or our entry object
          * changes. Thanks to immutability, if any of the directory contents change, our
          * entry object will change.
+         * @private
          */
         shouldComponentUpdate: function (nextProps, nextState) {
             return nextProps.forceRender ||
@@ -812,6 +827,7 @@ define(function (require, exports, module) {
 
         /**
          * If you click on a directory, it will toggle between open and closed.
+         * @private
          */
         handleClick: function (event) {
             if (this.props.entry.get("rename")) {
@@ -853,6 +869,7 @@ define(function (require, exports, module) {
 
         /**
          * select the current node in the file tree
+         * @private
          */
         selectNode: function (e) {
             // Do nothing for folders on keydown event. Only expand the file tree on click event
@@ -863,6 +880,7 @@ define(function (require, exports, module) {
          * Create the data object to pass to extensions.
          *
          * @return {{name: {string}, isFile: {boolean}, fullPath: {string}}} Data for extensions
+         * @private
          */
         getDataForExtension: function () {
             return {
@@ -1032,6 +1050,7 @@ define(function (require, exports, module) {
      * * selectionViewInfo: Immutable.Map with width, scrollTop, scrollLeft and offsetTop for the tree container
      * * visible: should this be visible now
      * * selectedClassName: class name applied to the element that is selected
+     * @private
      */
     var fileSelectionBox = Preact.createFactory(Preact.createClass({
         /**
@@ -1081,6 +1100,7 @@ define(function (require, exports, module) {
      * * visible: should this be visible now
      * * selectedClassName: class name applied to the element that is selected
      * * className: class to be applied to the extension element
+     * @private
      */
     var selectionExtension = Preact.createFactory(Preact.createClass({
         /**

--- a/src/project/FileTreeViewModel.js
+++ b/src/project/FileTreeViewModel.js
@@ -39,7 +39,10 @@ define(function (require, exports, module) {
         EventDispatcher     = require("utils/EventDispatcher"),
         FileUtils           = require("file/FileUtils");
 
-    // Constants
+    /**
+     * @const
+     * @type {string}
+     */
     var EVENT_CHANGE = "change";
 
     /**
@@ -577,7 +580,7 @@ define(function (require, exports, module) {
 
     /**
      * Returns the object at the given file path.
-     *
+     * @private
      * @param {string} path Path to the object
      * @return {Immutable.Map=} directory or file object from the tree. Null if it's not found.
      */
@@ -591,7 +594,7 @@ define(function (require, exports, module) {
 
     /**
      * Closes a subtree path, given by an object path.
-     *
+     * @private
      * @param {Immutable.Map} directory Current directory
      * @return {Immutable.Map} new directory
      */

--- a/src/project/FileViewController.js
+++ b/src/project/FileViewController.js
@@ -61,7 +61,17 @@ define(function (require, exports, module) {
      * @private
      */
     var _curDocChangedDueToMe = false;
+
+    /**
+     * view managing working set.
+     * @type {string}
+     */
     var WORKING_SET_VIEW = "WorkingSetView";
+
+    /**
+     * manager handling project-related operations.
+     * @type {string}
+     */
     var PROJECT_MANAGER = "ProjectManager";
 
     /**
@@ -73,6 +83,7 @@ define(function (require, exports, module) {
     // Due to circular dependencies, not safe to call on() directly
     /**
      * Change the doc selection to the working set when ever a new file is added to the working set
+     * @private
      */
     EventDispatcher.on_duringInit(MainViewManager, "workingSetAdd", function (event, addedFile) {
         _fileSelectionFocus = WORKING_SET_VIEW;
@@ -81,6 +92,7 @@ define(function (require, exports, module) {
 
     /**
      * Update the file selection focus whenever the contents of the editor area change
+     * @private
      */
     EventDispatcher.on_duringInit(MainViewManager, "currentFileChange", function (event, file, paneId) {
         var perfTimerName;
@@ -236,6 +248,7 @@ define(function (require, exports, module) {
     /**
      * Opens the specified document if it's not already open, adds it to the working set,
      * and selects it in the WorkingSetView
+     * @private
      * @deprecated use FileViewController.openFileAndAddToWorkingSet() instead
      * @param {!fullPath}
      * @return {!$.Promise}

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -82,24 +82,83 @@ define(function (require, exports, module) {
     // See #10115
     require("command/DefaultMenus");
 
-    const EVENT_PROJECT_BEFORE_CLOSE = "beforeProjectClose",
-        EVENT_PROJECT_CLOSE = "projectClose",
-        EVENT_PROJECT_OPEN_FAILED = "projectFileOpenFailed",
-        EVENT_PROJECT_OPEN = "projectOpen",
-        EVENT_AFTER_PROJECT_OPEN = "afterProjectOpen",
-        // on boot, we load files that have been passed in from os either with `open with` from os file explorer or
-        // as cli from terminal. EVENT_AFTER_STARTUP_FILES_LOADED is trigerred after those files have been loaded.
-        // Note that this may be trigerred before any extensions get loaded, so always a good idea to check for
-        // isStartupFilesLoaded()
-        EVENT_AFTER_STARTUP_FILES_LOADED = "startupFilesLoaded",
-        EVENT_PROJECT_REFRESH = "projectRefresh",
-        EVENT_CONTENT_CHANGED = "contentChanged",
-        // This will capture all file/folder changes in projects except renames. If you want to track renames,
-        // use EVENT_PROJECT_PATH_CHANGED_OR_RENAMED to track all changes or EVENT_PROJECT_FILE_RENAMED too.
-        EVENT_PROJECT_FILE_CHANGED = "projectFileChanged",
-        EVENT_PROJECT_FILE_RENAMED = "projectFileRenamed",
-        // the path changed event differs in the sense that all events returned by this will be a path.
-        EVENT_PROJECT_CHANGED_OR_RENAMED_PATH = "projectChangedPath";
+    /**
+     * Triggered before the project closes.
+     * @type {string}
+     */
+    const EVENT_PROJECT_BEFORE_CLOSE = "beforeProjectClose";
+
+    /**
+     * Triggered when the project has closed.
+     * @type {string}
+     */
+    const EVENT_PROJECT_CLOSE = "projectClose";
+
+    /**
+     * Triggered when opening a project file fails.
+     * @type {string}
+     */
+    const EVENT_PROJECT_OPEN_FAILED = "projectFileOpenFailed";
+
+    /**
+     * Triggered when a project is opened.
+     * @type {string}
+     */
+    const EVENT_PROJECT_OPEN = "projectOpen";
+
+    /**
+     * Triggered after a project is successfully opened.
+     * @type {string}
+     */
+    const EVENT_AFTER_PROJECT_OPEN = "afterProjectOpen";
+
+    /**
+     * Triggered after startup files (from OS or CLI) are loaded.
+     * Note: This may occur before extensions are loaded, so check `isStartupFilesLoaded()`.
+     * @type {string}
+     */
+    const EVENT_AFTER_STARTUP_FILES_LOADED = "startupFilesLoaded";
+
+
+    // on boot, we load files that have been passed in from os either with `open with` from os file explorer or
+    // as cli from terminal. EVENT_AFTER_STARTUP_FILES_LOADED is trigerred after those files have been loaded.
+    // Note that this may be trigerred before any extensions get loaded, so always a good idea to check for
+    // isStartupFilesLoaded()
+    /**
+     * Triggered when the project is refreshed.
+     * @type {string}
+     */
+    const EVENT_PROJECT_REFRESH = "projectRefresh";
+
+    /**
+     * Triggered when content in the project changes.
+     * @type {string}
+     */
+    const EVENT_CONTENT_CHANGED = "contentChanged";
+
+
+    // This will capture all file/folder changes in projects except renames. If you want to track renames,
+    // use EVENT_PROJECT_PATH_CHANGED_OR_RENAMED to track all changes or EVENT_PROJECT_FILE_RENAMED too.
+    /**
+     * Triggered when any file or folder in the project changes, excluding renames.
+     * @type {string}
+     */
+    const EVENT_PROJECT_FILE_CHANGED = "projectFileChanged";
+
+    /**
+     * Triggered specifically when a project file is renamed.
+     * @type {string}
+     */
+    const EVENT_PROJECT_FILE_RENAMED = "projectFileRenamed";
+
+
+    // the path changed event differs in the sense that all events returned by this will be a path.
+    /**
+     * Triggered when paths in the project are changed or renamed.
+     * @type {string}
+     */
+    const EVENT_PROJECT_CHANGED_OR_RENAMED_PATH = "projectChangedPath";
+
 
     EventDispatcher.setLeakThresholdForEvent(EVENT_PROJECT_OPEN, 25);
 
@@ -115,7 +174,7 @@ define(function (require, exports, module) {
 
     /**
      * Name of the preferences for sorting directories first
-     *
+     * @private
      * @type {string}
      */
     var SORT_DIRECTORIES_FIRST = "sortDirectoriesFirst";
@@ -294,6 +353,7 @@ define(function (require, exports, module) {
      * Sets the directory at the given path to open in the tree and saves the open nodes to view state.
      *
      * See `ProjectModel.setDirectoryOpen`
+     * @private
      */
     ActionCreator.prototype.setDirectoryOpen = function (path, open) {
         this.model.setDirectoryOpen(path, open).then(_saveTreeState);
@@ -301,6 +361,7 @@ define(function (require, exports, module) {
 
     /**
      * See `ProjectModel.setSelected`
+     * @private
      */
     ActionCreator.prototype.setSelected = function (path, doNotOpen) {
         this.model.setSelected(path, doNotOpen);
@@ -308,6 +369,7 @@ define(function (require, exports, module) {
 
     /**
      * See `ProjectModel.selectInWorkingSet`
+     * @private
      */
     ActionCreator.prototype.selectInWorkingSet = function (path) {
         this.model.selectInWorkingSet(path);
@@ -315,6 +377,7 @@ define(function (require, exports, module) {
 
     /**
      * See `FileViewController.openWithExternalApplication`
+     * @private
      */
     ActionCreator.prototype.openWithExternalApplication = function (path) {
         FileViewController.openWithExternalApplication(path);
@@ -323,6 +386,7 @@ define(function (require, exports, module) {
 
     /**
      * See `ProjectModel.setContext`
+     * @private
      */
     ActionCreator.prototype.setContext = function (path) {
         this.model.setContext(path);
@@ -330,6 +394,7 @@ define(function (require, exports, module) {
 
     /**
      * See `ProjectModel.restoreContext`
+     * @private
      */
     ActionCreator.prototype.restoreContext = function () {
         this.model.restoreContext();
@@ -337,6 +402,7 @@ define(function (require, exports, module) {
 
     /**
      * See `ProjectModel.startRename`
+     * @private
      */
     ActionCreator.prototype.startRename = function (path, isMoved) {
         // This is very not Flux-like, which is a sign that Flux may not be the
@@ -348,6 +414,7 @@ define(function (require, exports, module) {
 
     /**
      * See `ProjectModel.setRenameValue`
+     * @private
      */
     ActionCreator.prototype.setRenameValue = function (path) {
         this.model.setRenameValue(path);
@@ -355,6 +422,7 @@ define(function (require, exports, module) {
 
     /**
      * See `ProjectModel.cancelRename`
+     * @private
      */
     ActionCreator.prototype.cancelRename = function () {
         this.model.cancelRename();
@@ -362,6 +430,7 @@ define(function (require, exports, module) {
 
     /**
      * See `ProjectModel.performRename`
+     * @private
      */
     ActionCreator.prototype.performRename = function () {
         return this.model.performRename();
@@ -369,6 +438,7 @@ define(function (require, exports, module) {
 
     /**
      * See `ProjectModel.startCreating`
+     * @private
      */
     ActionCreator.prototype.startCreating = function (basedir, newName, isFolder) {
         return this.model.startCreating(basedir, newName, isFolder);
@@ -376,6 +446,7 @@ define(function (require, exports, module) {
 
     /**
      * See `ProjectModel.setSortDirectoriesFirst`
+     * @private
      */
     ActionCreator.prototype.setSortDirectoriesFirst = function (sortDirectoriesFirst) {
         this.model.setSortDirectoriesFirst(sortDirectoriesFirst);
@@ -383,6 +454,7 @@ define(function (require, exports, module) {
 
     /**
      * See `ProjectModel.setFocused`
+     * @private
      */
     ActionCreator.prototype.setFocused = function (focused) {
         this.model.setFocused(focused);
@@ -390,6 +462,7 @@ define(function (require, exports, module) {
 
     /**
      * See `ProjectModel.setCurrentFile`
+     * @private
      */
     ActionCreator.prototype.setCurrentFile = function (curFile) {
         this.model.setCurrentFile(curFile);
@@ -397,6 +470,7 @@ define(function (require, exports, module) {
 
     /**
      * See `ProjectModel.toggleSubdirectories`
+     * @private
      */
     ActionCreator.prototype.toggleSubdirectories = function (path, openOrClose) {
         this.model.toggleSubdirectories(path, openOrClose).then(_saveTreeState);
@@ -404,6 +478,7 @@ define(function (require, exports, module) {
 
     /**
      * See `ProjectModel.closeSubtree`
+     * @private
      */
     ActionCreator.prototype.closeSubtree = function (path) {
         this.model.closeSubtree(path);
@@ -425,6 +500,7 @@ define(function (require, exports, module) {
 
     /**
      * Moves the item in the oldPath to the newDirectory directory
+     * @private
      */
     ActionCreator.prototype.moveItem = function (oldPath, newDirectory) {
         var fileName = FileUtils.getBaseName(oldPath),
@@ -450,6 +526,7 @@ define(function (require, exports, module) {
 
     /**
      * See `ProjectModel.refresh`
+     * @private
      */
     ActionCreator.prototype.refresh = function () {
         this.model.refresh();
@@ -754,7 +831,6 @@ define(function (require, exports, module) {
     _renderTree = _.debounce(_renderTreeSync, _RENDER_DEBOUNCE_TIME);
 
     /**
-     * @private
      *
      * Returns the full path to the welcome project, which we open on first launch.
      *
@@ -775,7 +851,7 @@ define(function (require, exports, module) {
     }
 
     /**
-     * The flder where all the system managed projects live
+     * The folder where all the system managed projects live
      * @returns {string}
      */
     function getLocalProjectsPath() {
@@ -784,7 +860,7 @@ define(function (require, exports, module) {
 
     /**
      * Adds the path to the list of welcome projects we've ever seen, if not on the list already.
-     *
+     * @private
      * @param {string} path Path to possibly add
      */
     function addWelcomeProjectPath(path) {
@@ -820,6 +896,7 @@ define(function (require, exports, module) {
      * @deprecated use getStartupProjectPath instead. Can be removed anytime after 2-Apr-2023.
      * Initial project path is stored in prefs, which defaults to the welcome project on
      * first launch.
+     * @private
      */
     function getInitialProjectPath() {
         return updateWelcomeProjectPath(PreferencesManager.getViewState("projectPath"));
@@ -1250,7 +1327,7 @@ define(function (require, exports, module) {
     /**
      * Loads the given folder as a project. Does NOT prompt about any unsaved changes - use openProject()
      * instead to check for unsaved changes and (optionally) let the user choose the folder to open.
-     *
+     * @private
      * @param {!string} rootPath  Absolute path to the root folder of the project.
      *  A trailing "/" on the path is optional (unlike many Brackets APIs that assume a trailing "/").
      * @return {$.Promise} A promise object that will be resolved when the
@@ -1387,6 +1464,7 @@ define(function (require, exports, module) {
 
     /**
      * Invoke project settings dialog.
+     * @private
      * @return {$.Promise}
      */
     function _projectSettings() {

--- a/src/project/ProjectModel.js
+++ b/src/project/ProjectModel.js
@@ -42,15 +42,54 @@ define(function (require, exports, module) {
         Async               = require("utils/Async"),
         PerfUtils           = require("utils/PerfUtils");
 
-    // Constants
-    var EVENT_CHANGE            = "change",
-        EVENT_SHOULD_SELECT     = "select",
-        EVENT_SHOULD_FOCUS      = "focus",
-        EVENT_FS_RENAME_STARTED = "mvStart",
-        EVENT_FS_RENAME_END     = "mvEnd",
-        ERROR_CREATION          = "creationError",
-        ERROR_INVALID_FILENAME  = "invalidFilename",
-        ERROR_NOT_IN_PROJECT    = "notInProject";
+
+    /**
+     * Triggered when change occurs.
+     * @type {string}
+     */
+    const EVENT_CHANGE = "change";
+
+    /**
+     * Triggered when item should be selected.
+     * @type {string}
+     */
+    const EVENT_SHOULD_SELECT = "select";
+
+    /**
+     * Triggered when item should receive focus.
+     * @type {string}
+     */
+    const EVENT_SHOULD_FOCUS = "focus";
+
+    /**
+     * Triggered when file system rename operation starts.
+     * @type {string}
+     */
+    const EVENT_FS_RENAME_STARTED = "mvStart";
+
+    /**
+     * Triggered when file system rename operation ends.
+     * @type {string}
+     */
+    const EVENT_FS_RENAME_END = "mvEnd";
+
+    /**
+     * Error during creation.
+     * @type {string}
+     */
+    const ERROR_CREATION = "creationError";
+
+    /**
+     * Error because of Invalid filename
+     * @type {string}
+     */
+    const ERROR_INVALID_FILENAME = "invalidFilename";
+
+    /**
+     * Error when an item is not in a project
+     * @type {string}
+     */
+    const ERROR_NOT_IN_PROJECT = "notInProject";
 
     /**
      * @private
@@ -165,11 +204,26 @@ define(function (require, exports, module) {
         return shouldShow(entry) && !_cacheExcludeFileNameRegEx.test(entry.name);
     }
 
-    // Constants used by the ProjectModel
+    /**
+     * File renaming
+     * @const
+     * @type {number}
+     */
+    const FILE_RENAMING = 0;
 
-    var FILE_RENAMING     = 0,
-        FILE_CREATING     = 1,
-        RENAME_CANCELLED  = 2;
+    /**
+     * File creating
+     * @const
+     * @type {number}
+     */
+    const FILE_CREATING = 1;
+
+    /**
+     * Rename cancelled
+     * @const
+     * @type {number}
+     */
+    const RENAME_CANCELLED = 2;
 
 
     /**
@@ -1244,6 +1298,7 @@ define(function (require, exports, module) {
     /**
      * Cancels the creation process that is underway. The original promise returned will be resolved with the
      * RENAME_CANCELLED value. The temporary entry added to the file tree will be deleted.
+     * @private
      */
     ProjectModel.prototype._cancelCreating = function () {
         var renameInfo = this._selections.rename;
@@ -1454,6 +1509,7 @@ define(function (require, exports, module) {
     /**
      * Although Brackets is generally standardized on folder paths with a trailing "/", some APIs here
      * receive project paths without "/" due to legacy preference storage formats, etc.
+     * @private
      * @param {!string} fullPath  Path that may or may not end in "/"
      * @return {!string} Path that ends in "/"
      */
@@ -1493,7 +1549,7 @@ define(function (require, exports, module) {
     /**
      * Returns true if the given path is the same as one of the welcome projects we've previously opened,
      * or the one for the current build.
-     *
+     * @private
      * @param {string} path Path to check to see if it's a welcome project
      * @param {string} welcomeProjectPath Current welcome project path
      * @param {Array.<string>=} welcomeProjects All known welcome projects

--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -250,6 +250,7 @@ define(function (require, exports, module) {
 
     /**
      * Register Command Handlers
+     * @private
      */
     _cmdSplitNone       = CommandManager.register(Strings.CMD_SPLITVIEW_NONE,       Commands.CMD_SPLITVIEW_NONE,       _handleSplitViewNone);
     _cmdSplitVertical   = CommandManager.register(Strings.CMD_SPLITVIEW_VERTICAL,   Commands.CMD_SPLITVIEW_VERTICAL,   _handleSplitViewVertical);

--- a/src/project/WorkingSetSort.js
+++ b/src/project/WorkingSetSort.js
@@ -204,6 +204,7 @@ define(function (require, exports, module) {
 
 
     /**
+     * @private
      * @constructor
      * @param {string} commandID A valid command identifier.
      * @param {function(File, File): number} compareFn A valid sort
@@ -219,6 +220,7 @@ define(function (require, exports, module) {
 
     /**
      * The Command ID
+     * @private
      * @return {string}
      */
     Sort.prototype.getCommandID = function () {
@@ -227,6 +229,7 @@ define(function (require, exports, module) {
 
     /**
      * The compare function
+     * @private
      * @return {function(File, File): number}
      */
     Sort.prototype.getCompareFn = function () {
@@ -235,6 +238,7 @@ define(function (require, exports, module) {
 
     /**
      * Gets the event that this sort object is listening to
+     * @private
      * @return {string}
      */
     Sort.prototype.getEvents = function () {
@@ -243,6 +247,7 @@ define(function (require, exports, module) {
 
     /**
      * Checks/Unchecks the command which will show a check in the menu
+     * @private
      * @param {boolean} value
      */
     Sort.prototype.setChecked = function (value) {
@@ -254,6 +259,7 @@ define(function (require, exports, module) {
 
     /**
      * Performs the sort and makes it the current sort method.
+     * @private
      */
     Sort.prototype.execute = function () {
         _setCurrentSort(this);
@@ -262,6 +268,7 @@ define(function (require, exports, module) {
 
     /**
      * Only performs the working set sort if this is the current sort.
+     * @private
      */
     Sort.prototype.sort = function () {
         if (_currentSort === this) {
@@ -378,12 +385,14 @@ define(function (require, exports, module) {
 
     /**
      * Initialize default values for sorting preferences
+     * @private
      */
     PreferencesManager.stateManager.definePreference("automaticSort", "boolean", false);
 
     /**
      * Define a default sort method that's empty so that we
      *   just convert and use the legacy sort method
+     *  @private
      */
     PreferencesManager.stateManager.definePreference(_WORKING_SET_SORT_PREF, "string", "");
 
@@ -405,6 +414,7 @@ define(function (require, exports, module) {
 
     /**
      * Initialize items dependent on extensions/workingSetList
+     * @private
      */
     AppInit.appReady(function () {
         var sortMethod = initSortMethod(),

--- a/src/project/WorkingSetSort.js
+++ b/src/project/WorkingSetSort.js
@@ -38,6 +38,7 @@ define(function (require, exports, module) {
 
     /**
      * List of sorting method objects
+     *
      * @private
      * @type {Array.<Sort>}
      */
@@ -45,6 +46,7 @@ define(function (require, exports, module) {
 
     /**
      * Denotes the current sort method object
+     *
      * @private
      * @type {Sort}
      */
@@ -52,6 +54,7 @@ define(function (require, exports, module) {
 
     /**
      * Denotes if automatic sorting is enabled or not
+     *
      * @private
      * @type {boolean}
      */
@@ -73,6 +76,7 @@ define(function (require, exports, module) {
 
     /**
      * Events which the sort command will listen for to trigger a sort
+     *
      * @constant {string}
      * @private
      */
@@ -80,6 +84,7 @@ define(function (require, exports, module) {
 
     /**
      * Preference name
+     *
      * @constant {string}
      * @private
      */
@@ -87,6 +92,7 @@ define(function (require, exports, module) {
 
     /**
      * Legacy preference name
+     *
      * @constant {string}
      * @private
      */
@@ -94,6 +100,7 @@ define(function (require, exports, module) {
 
     /**
      * Retrieves a Sort object by id
+     *
      * @param {(string|Command)} command A command ID or a command object.
      * @return {?Sort}
      */
@@ -114,6 +121,7 @@ define(function (require, exports, module) {
 
     /**
      * Converts the old brackets working set sort preference into the modern paneview sort preference
+     *
      * @private
      * @param {!string} sortMethod - sort preference to convert
      * @return {?string} new sort preference string or undefined if an sortMethod is not found
@@ -142,6 +150,7 @@ define(function (require, exports, module) {
 
     /**
      * Removes the sort listeners.
+     *
      * @private
      */
     function _removeListeners() {
@@ -150,6 +159,7 @@ define(function (require, exports, module) {
 
     /**
      * Enables/Disables Automatic Sort depending on the value.
+     *
      * @param {boolean} enable True to enable, false to disable.
      */
     function setAutomatic(enable) {
@@ -167,6 +177,7 @@ define(function (require, exports, module) {
 
     /**
      * Adds the current sort MainViewManager listeners.
+     *
      * @private
      */
     function _addListeners() {
@@ -184,6 +195,7 @@ define(function (require, exports, module) {
 
     /**
      * Sets the current sort method and checks it on the context menu.
+     *
      * @private
      * @param {Sort} newSort
      */
@@ -204,7 +216,6 @@ define(function (require, exports, module) {
 
 
     /**
-     * @private
      * @constructor
      * @param {string} commandID A valid command identifier.
      * @param {function(File, File): number} compareFn A valid sort
@@ -220,7 +231,7 @@ define(function (require, exports, module) {
 
     /**
      * The Command ID
-     * @private
+     *
      * @return {string}
      */
     Sort.prototype.getCommandID = function () {
@@ -229,7 +240,7 @@ define(function (require, exports, module) {
 
     /**
      * The compare function
-     * @private
+     *
      * @return {function(File, File): number}
      */
     Sort.prototype.getCompareFn = function () {
@@ -238,7 +249,7 @@ define(function (require, exports, module) {
 
     /**
      * Gets the event that this sort object is listening to
-     * @private
+     *
      * @return {string}
      */
     Sort.prototype.getEvents = function () {
@@ -247,7 +258,7 @@ define(function (require, exports, module) {
 
     /**
      * Checks/Unchecks the command which will show a check in the menu
-     * @private
+     *
      * @param {boolean} value
      */
     Sort.prototype.setChecked = function (value) {
@@ -259,7 +270,6 @@ define(function (require, exports, module) {
 
     /**
      * Performs the sort and makes it the current sort method.
-     * @private
      */
     Sort.prototype.execute = function () {
         _setCurrentSort(this);
@@ -268,7 +278,6 @@ define(function (require, exports, module) {
 
     /**
      * Only performs the working set sort if this is the current sort.
-     * @private
      */
     Sort.prototype.sort = function () {
         if (_currentSort === this) {
@@ -281,6 +290,7 @@ define(function (require, exports, module) {
 
     /**
      * Registers a working set sort method.
+     *
      * @param {(string|Command)} command A command ID or a command object
      * @param {function(File, File): number} compareFn The function that
      *      will be used inside JavaScript's sort function. The return a value
@@ -330,6 +340,7 @@ define(function (require, exports, module) {
 
     /**
      * Command Handler for CMD_WORKING_SORT_TOGGLE_AUTO
+     *
      * @private
      */
     function _handleToggleAutoSort() {
@@ -338,6 +349,7 @@ define(function (require, exports, module) {
 
     /**
      * Command Handler for CMD_WORKINGSET_SORT_BY_*
+     *
      * @private
      * @param {!string} commandId identifies the sort method to use
      */
@@ -385,6 +397,7 @@ define(function (require, exports, module) {
 
     /**
      * Initialize default values for sorting preferences
+     *
      * @private
      */
     PreferencesManager.stateManager.definePreference("automaticSort", "boolean", false);
@@ -392,6 +405,7 @@ define(function (require, exports, module) {
     /**
      * Define a default sort method that's empty so that we
      *   just convert and use the legacy sort method
+     *
      *  @private
      */
     PreferencesManager.stateManager.definePreference(_WORKING_SET_SORT_PREF, "string", "");
@@ -414,6 +428,7 @@ define(function (require, exports, module) {
 
     /**
      * Initialize items dependent on extensions/workingSetList
+     *
      * @private
      */
     AppInit.appReady(function () {

--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -80,11 +80,13 @@ define(function (require, exports, module) {
     /**
      * #working-set-list-container
      * @type {jQuery}
+     * @private
      */
     var $workingFilesContainer;
 
     /**
      * Constants for event.which values
+     * @private
      * @enum {number}
      */
     var LEFT_BUTTON = 1,
@@ -101,6 +103,7 @@ define(function (require, exports, module) {
     /**
      * Constants for hitTest.where
      * @enum {string}
+     * @private
      */
     var NOMANSLAND = "nomansland",
         NOMOVEITEM = "nomoveitem",
@@ -114,6 +117,7 @@ define(function (require, exports, module) {
     /**
      * Drag an item has to move 3px before dragging starts
      * @constant
+     * @private
      */
     var _DRAG_MOVE_DETECTION_START = 3;
 
@@ -855,8 +859,9 @@ define(function (require, exports, module) {
         });
     }
 
-    /*
+    /**
      * WorkingSetView constructor
+     * @private
      * @constructor
      * @param {!jQuery} $container - owning container
      * @param {!string} paneId - paneId of this view pertains to
@@ -874,8 +879,9 @@ define(function (require, exports, module) {
         this.init();
     }
 
-    /*
+    /**
      * Hides or shows the WorkingSetView
+     * @private
      */
     WorkingSetView.prototype._updateVisibility = function () {
         var fileList = MainViewManager.getWorkingSet(this.paneId);
@@ -889,7 +895,7 @@ define(function (require, exports, module) {
         }
     };
 
-    /*
+    /**
      * paneLayoutChange event listener
      * @private
      */
@@ -929,7 +935,7 @@ define(function (require, exports, module) {
         return result;
     };
 
-    /*
+    /**
      * creates a name that is namespaced to this pane
      * @param {!string} name - name of the event to create.
      * use an empty string to get just the event name to turn off all events in the namespace
@@ -1403,6 +1409,7 @@ define(function (require, exports, module) {
 
     /**
      * Initializes the WorkingSetView object
+     * @private
      */
     WorkingSetView.prototype.init = function () {
         this.$openFilesContainer = this.$el.find(".open-files-container");
@@ -1441,6 +1448,7 @@ define(function (require, exports, module) {
 
     /**
      * Destroys the WorkingSetView DOM element and removes all event handlers
+     * @private
      */
     WorkingSetView.prototype.destroy = function () {
         ViewUtils.removeScrollerShadow(this.$openFilesContainer[0], null);
@@ -1521,10 +1529,11 @@ define(function (require, exports, module) {
         });
     });
 
-    /*
+    /**
      * To be used by other modules/default-extensions which needs to borrow working set entry icons
      * @param {!object} data - contains file info {fullPath, name, isFile}
      * @param {!jQuery} $element - jquery fn wrap for the list item
+     * @private
      */
     function useIconProviders(data, $element) {
         for(let provider of _iconProviders){
@@ -1540,10 +1549,11 @@ define(function (require, exports, module) {
         }
     }
 
-    /*
+    /**
      * To be used by other modules/default-extensions which needs to borrow working set entry custom classes
      * @param {!object} data - contains file info {fullPath, name, isFile}
      * @param {!jQuery} $element - jquery fn wrap for the list item
+     * @private
      */
     function useClassProviders(data, $element) {
         let succeededPriority = null;


### PR DESCRIPTION
In ProjectManager.js and ProjectModel.js, JSDoc comments were missing for some constants that needed to be included in the API documentation. These have now been added.

In workingSetView.js, certain comments were written using /*...*/. These have been reformatted to /**...*/ to maintain consistency across the codebase.