### PR TITLE
fix: extension manager not showing updated extensions due to local storage quota exceeded

### DIFF
--- a/src/extensibility/ExtensionManager.js
+++ b/src/extensibility/ExtensionManager.js
@@ -61,8 +61,10 @@ define(function (require, exports, module) {
     // next update. This migration code can be removed after July 2025(6 Months).
     localStorage.removeItem(EXTENSION_REGISTRY_LOCAL_STORAGE_KEY);
 
+    const REGISTRY_CACHE_FILE = Phoenix.isTestWindow ?
+        "test_registry_cache.json" : "registry_cache.json";
     const REGISTRY_CACHE_PATH = path.normalize(
-        Phoenix.app.getExtensionsDirectory() + "/" + "registry_cache.json");
+        Phoenix.app.getExtensionsDirectory() + "/" + REGISTRY_CACHE_FILE);
     function _getCachedRegistry() {
         // never rejects
         return new Promise((resolve) => {
@@ -87,6 +89,11 @@ define(function (require, exports, module) {
                     resolve();
                 });
         });
+    }
+
+    function _removeCachedRegistry() {
+        const registryFile = FileSystem.getFileForPath(REGISTRY_CACHE_PATH);
+        return registryFile.unlinkAsync();
     }
 
     // semver.browser is an AMD-compatible module
@@ -964,6 +971,8 @@ define(function (require, exports, module) {
     exports._reset                  = _reset;
     exports._setExtensions          = _setExtensions;
     if(Phoenix.isTestWindow){
-        exports.EXTENSION_REGISTRY_LOCAL_STORAGE_KEY = EXTENSION_REGISTRY_LOCAL_STORAGE_KEY;
+        exports._getCachedRegistry = _getCachedRegistry;
+        exports._putCachedRegistry = _putCachedRegistry;
+        exports._removeCachedRegistry = _removeCachedRegistry;
     }
 });

--- a/src/loggerSetup.js
+++ b/src/loggerSetup.js
@@ -72,8 +72,8 @@
         },
         /**
          * By default all uncaught exceptions and promise rejections are sent to logger utility. But in some cases
-         * you may want to sent handled errors too if it is critical. use this function to report those
-         * @param {Error} error
+         * you may want to log error without having an error object with you.
+         *
          * @param {string} [message] optional message
          */
         reportErrorMessage: function (message) {

--- a/test/spec/ExtensionManager-test.js
+++ b/test/spec/ExtensionManager-test.js
@@ -176,9 +176,9 @@ define(function (require, exports, module) {
             });
 
             it("should registry update cache registry locally", async function () {
-                localStorage.removeItem(ExtensionManager.EXTENSION_REGISTRY_LOCAL_STORAGE_KEY);
+                await ExtensionManager._removeCachedRegistry();
                 await awaitsForDone(ExtensionManager.downloadRegistry(true), "fetching registry");
-                expect(localStorage.getItem(ExtensionManager.EXTENSION_REGISTRY_LOCAL_STORAGE_KEY)).not.toBeNull();
+                expect(await ExtensionManager._getCachedRegistry()).not.toBeNull();
             });
 
             it("should fail if it can't access the registry", async function () {
@@ -419,7 +419,7 @@ define(function (require, exports, module) {
                 var model;
 
                 beforeEach(async function () {
-                    localStorage.removeItem(ExtensionManager.EXTENSION_REGISTRY_LOCAL_STORAGE_KEY);
+                    await ExtensionManager._removeCachedRegistry();
                     mockRegistry = JSON.parse(mockRegistryForSearch);
                     model = new ExtensionManagerViewModel.RegistryViewModel();
                     await awaitsForDone(model.initialize(), "model initialization");
@@ -515,7 +515,7 @@ define(function (require, exports, module) {
                 var model;
 
                 beforeEach(async function () {
-                    localStorage.removeItem(ExtensionManager.EXTENSION_REGISTRY_LOCAL_STORAGE_KEY);
+                    await ExtensionManager._removeCachedRegistry();
                     mockRegistry = JSON.parse(mockRegistryThemesText);
                     model = new ExtensionManagerViewModel.ThemesViewModel();
                     await awaitsForDone(model.initialize(), "model initialization");


### PR DESCRIPTION
 earlier, we used to cache the full uncompressed registry in ls which has a usual size limit of 5mb, and the
 registry takes a few MB. So we moved this storage to file system. 

For migration, we will clear local storage on any existing installs on next update. The migration code `localStorage.removeItem(EXTENSION_REGISTRY_LOCAL_STORAGE_KEY);`  can be removed after July 2025(6 Months).