### PR TITLE
chore: extension registry embed in distributable for better first use UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ test/thirdparty/jasmine-reporters
 !/src/extensions/dev/README.*
 
 /src/extensions/disabled
+/src/extensions/registry
 
 # ignore .disabled file for default extensions
 /src/extensions/default/*/.disabled

--- a/src/extensibility/ExtensionManager.js
+++ b/src/extensibility/ExtensionManager.js
@@ -339,6 +339,17 @@ define(function (require, exports, module) {
         return filteredRegistry;
     }
 
+    function _getTaskManager() {
+        if(Phoenix.isTestWindow){
+            return {
+                close: ()=>{}
+            };
+        }
+        return TaskManager.addNewTask(Strings.EXTENSIONS_REGISTRY_TASK_TITLE,
+            Strings.EXTENSIONS_REGISTRY_TASK_MESSAGE,
+            `<i class="fa-solid fa-list"></i>`);
+    }
+
     /**
      * Downloads the registry of Brackets extensions and stores the information in our
      * extension info.
@@ -356,9 +367,7 @@ define(function (require, exports, module) {
 
         function _updateRegistry(newVersion) {
             console.log("downloading extension registry: ", newVersion, brackets.config.extension_registry);
-            const downloadTask = TaskManager.addNewTask(Strings.EXTENSIONS_REGISTRY_TASK_TITLE,
-                Strings.EXTENSIONS_REGISTRY_TASK_MESSAGE,
-                `<i class="fa-solid fa-list"></i>`);
+            const downloadTask = _getTaskManager();
             $.ajax({
                 url: brackets.config.extension_registry,
                 dataType: "json",

--- a/src/extensibility/ExtensionManager.js
+++ b/src/extensibility/ExtensionManager.js
@@ -49,6 +49,7 @@ define(function (require, exports, module) {
         Strings             = require("strings"),
         StringUtils         = require("utils/StringUtils"),
         ThemeManager        = require("view/ThemeManager"),
+        TaskManager    = require("features/TaskManager"),
         Metrics = require("utils/Metrics");
 
     const EXTENSION_REGISTRY_LOCAL_STORAGE_KEY = Phoenix.isTestWindow ?
@@ -355,6 +356,9 @@ define(function (require, exports, module) {
 
         function _updateRegistry(newVersion) {
             console.log("downloading extension registry: ", newVersion, brackets.config.extension_registry);
+            const downloadTask = TaskManager.addNewTask(Strings.EXTENSIONS_REGISTRY_TASK_TITLE,
+                Strings.EXTENSIONS_REGISTRY_TASK_MESSAGE,
+                `<i class="fa-solid fa-list"></i>`);
             $.ajax({
                 url: brackets.config.extension_registry,
                 dataType: "json",
@@ -371,9 +375,11 @@ define(function (require, exports, module) {
                         }
                     }).finally(()=>{
                         pendingDownloadRegistry = null;
+                        downloadTask.close();
                     });
                 })
                 .fail(function (err) {
+                    downloadTask.close();
                     console.error("error Fetching Extension Registry", err);
                     if(!pendingDownloadRegistry.alreadyResolvedFromCache){
                         pendingDownloadRegistry.reject();

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -811,6 +811,8 @@ define({
     "EXTENSIONS_UPDATES_TITLE": "Updates",
     "EXTENSIONS_LAST_UPDATED": "Last Updated",
     "EXTENSIONS_DOWNLOADS": "Downloads",
+    "EXTENSIONS_REGISTRY_TASK_TITLE": "Updating Extension List",
+    "EXTENSIONS_REGISTRY_TASK_MESSAGE": "Downloading\u2026",
 
     "INLINE_EDITOR_NO_MATCHES": "No matches available.",
     "INLINE_EDITOR_HIDDEN_MATCHES": "All matches are collapsed. Expand the files listed at right to view matches.",


### PR DESCRIPTION
#### Problem
The extension registry (`extensions/registry/registry.json`), which is approximately 1.5MB in size, takes noticeable time to download, causing delays in the user experience. Users have reported frustration with this delay, particularly when opening the extension manager for the first time.
![image](https://github.com/user-attachments/assets/cce7ad3f-6861-48dd-906c-8457556b0222)


#### To address this
we have packaged a **local copy** of the registry in the `src/extensions/registry/` folder, to load extension manager instantly on the first launch, even if the online registry is still downloading. 

- **Behavior on First Launch**:
  - The local copy of the registry is loaded to display extensions instantly. While this local registry may be outdated if the installer is old, it provides immediate functionality.
  
- **Updating the Registry**:
  - When the user opens the extension manager, the application downloads the latest registry in the background. 
  - A visual indicator in the status bar informs the user about the ongoing update. Once downloaded, the updated registry replaces the outdated one, ensuring users see the most recent extensions.

![image](https://github.com/user-attachments/assets/b59ae156-cfd5-4943-8a29-ee50131a2c1b)
