### PR TITLE
fix: indent guides gaps when setting custom lineheight like 1.5

### DIFF
--- a/src/extensions/default/DarkTheme/main.less
+++ b/src/extensions/default/DarkTheme/main.less
@@ -96,6 +96,7 @@
 .CodeMirror-matchingtag {
     /* Ensure visibility against gray inline editor background */
     background-color: @matching-tags;
+    display: inline-block;
 }
 
 .CodeMirror-overwrite .CodeMirror-cursor {

--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -293,4 +293,5 @@ span.cm-emstrong {
     position: relative;
     background-repeat: repeat-y;
     background-image: url('images/indent-guide-line.svg');
+    display: inline-block;
 }


### PR DESCRIPTION
## Before
![image](https://github.com/user-attachments/assets/799cbc43-0d2f-4edd-b592-f52c13d6a493)

## After
![image](https://github.com/user-attachments/assets/b1bdad23-708c-4056-b614-8f380f55a44a)
