### PR TITLE
fix: split matching tags in light theme

### DIFF
--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -271,7 +271,10 @@ div.CodeMirror-cursors {
         }
     }
 
-    .CodeMirror-matchingtag { background: @matching-bracket; }
+    .CodeMirror-matchingtag {
+        background: @matching-bracket;
+        display: inline-block;
+    }
 }
 
 /*


### PR DESCRIPTION
## without fix
![image](https://github.com/user-attachments/assets/488785c5-7428-47b3-9933-f18c19ecc076)

## after this fix
![image](https://github.com/user-attachments/assets/d5a29b05-64a2-469f-9157-fb76edccefd9)
