### PR TITLE
Moving the color gutter to right

### DIFF
--- a/src/extensions/default/CodeFolding/main.less
+++ b/src/extensions/default/CodeFolding/main.less
@@ -1,4 +1,4 @@
-@font-size: 1.1em;
+@font-size: 1em;
 @color-triangle: #ccc;
 @color-triangle-mouseover: #aaa;
 @color-triangle-collapsed: #999;

--- a/src/extensionsIntegrated/CSSColorPreview/main.js
+++ b/src/extensionsIntegrated/CSSColorPreview/main.js
@@ -238,6 +238,7 @@ define(function (require, exports, module) {
         // Add listener for all editor changes
         EditorManager.on("activeEditorChange", function (event, newEditor, oldEditor) {
             if (newEditor) {
+                // todo: only attach if the color gutter is present as we disable it in certain languages
                 newEditor.off("cursorActivity.colorPreview");
                 newEditor.on("cursorActivity.colorPreview", _cursorActivity);
                 // Unbind the previous editor's change event if it exists

--- a/src/styles/Extn-CSSColorPreview.less
+++ b/src/styles/Extn-CSSColorPreview.less
@@ -22,9 +22,9 @@
 
 /* Multiple colors preview container (this is a div) */
 .ico-multiple-cssColorPreview {
-    border: solid 1px rgba(255, 255, 255, 0.2);
+    border: solid .05em rgba(255, 255, 255, 0.2);
     .dark & {
-        border: solid 1px rgba(0, 0, 0, 0.2);
+        border: solid .05em rgba(0, 0, 0, 0.2);
     }
     position: relative;
     display: inline-block;

--- a/src/styles/Extn-CSSColorPreview.less
+++ b/src/styles/Extn-CSSColorPreview.less
@@ -1,6 +1,13 @@
 // These styles are for CssColorPreview feature
 // Check `extensionsIntegrated/CSSColorPreview for more reference
 /* Single color preview */
+
+.CodeMirror .CodeMirror-colorGutter {
+    width: 1em;
+    background-color: transparent;
+    text-align: center;
+}
+
 .ico-cssColorPreview {
     border: solid 1px rgba(255, 255, 255, 0.2);
     .dark & {
@@ -10,7 +17,6 @@
     top: .1em;
     height:.7em;
     width: .7em;
-    margin-left: .15em;
     position: relative;
 }
 
@@ -22,16 +28,15 @@
     }
     position: relative;
     display: inline-block;
-    top: .1em;
-    width: .7em;
-    height:.7em;
-    margin-left: .15em;
+    top: .2em;
+    width: .9em;
+    height:.9em;
 }
 
 /* For individual color boxes, they will be added inside the main .ico-multiple-cssColorPreview div */
 .ico-multiple-cssColorPreview .color-box {
     position: absolute;
-    width: .3em;
-    height: .3em;
+    width: .4em;
+    height: .4em;
     box-sizing: border-box;
 }

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -2962,6 +2962,7 @@ textarea.exclusions-editor {
 .CodeMirror .code-inspection-gutter {
     width: 1em;
     background-color: transparent;
+    text-align: center;
 }
 
 .brackets-inspection-gutter-marker {
@@ -2970,7 +2971,7 @@ textarea.exclusions-editor {
     line-height: 1em;
     height: 1em;
     width: 1em;
-    font-size: .8em;
+    font-size: .7em;
     pointer-events: auto;
 }
 

--- a/test/spec/Editor-test.js
+++ b/test/spec/Editor-test.js
@@ -2084,7 +2084,8 @@ define(function (require, exports, module) {
             var leftGutter = "left",
                 rightGutter = "right",
                 lineNumberGutter = "CodeMirror-linenumbers",
-                codeInspectionGutter = "code-inspection-gutter";
+                codeInspectionGutter = "code-inspection-gutter",
+                colorGutter = "CodeMirror-colorGutter";
 
             beforeEach(function () {
                 createTestEditor("hello\nworld\nyo", "javascript");
@@ -2110,7 +2111,7 @@ define(function (require, exports, module) {
                     return gutter.name;
                 });
                 expect(gutters).toEqual(expectedGutters);
-                expect(registeredGutters).toEqual([...expectedGutters, codeInspectionGutter]);
+                expect(registeredGutters).toEqual([...expectedGutters, colorGutter, codeInspectionGutter]);
             });
 
             it("should isGutterRegistered work on multiple gutters", function () {
@@ -2124,19 +2125,25 @@ define(function (require, exports, module) {
                 var secondRightGutter = "second-right";
                 Editor.registerGutter(secondRightGutter, 101);
                 var expectedGutters = [leftGutter, lineNumberGutter, rightGutter, secondRightGutter];
-                var gutters  = myEditor._codeMirror.getOption("gutters");
+                var guttersInEditor  = myEditor._codeMirror.getOption("gutters");
                 var registeredGutters = Editor.getRegisteredGutters().map(function (gutter) {
                     return gutter.name;
                 });
-                expect(gutters).toEqual(expectedGutters);
-                expect(registeredGutters).toEqual(expectedGutters);
+                // registered color gutter is disabled in javascript files
+                expect(guttersInEditor.includes(colorGutter)).toBeFalse();
+                expect(registeredGutters.includes(colorGutter)).toBeTrue();
+                const allNonColorRegisteredGutters = registeredGutters.filter(function (gutter) {
+                    return gutter !== colorGutter;
+                });
+                expect(guttersInEditor).toEqual(expectedGutters);
+                expect(allNonColorRegisteredGutters).toEqual(expectedGutters);
             });
 
             it("should have only gutters registered with the intended languageIds ", function () {
                 var lessOnlyGutter = "less-only-gutter";
                 Editor.registerGutter(lessOnlyGutter, 101, ["less"]);
                 var expectedGutters = [leftGutter, lineNumberGutter, rightGutter];
-                var expectedRegisteredGutters = [leftGutter, lineNumberGutter, rightGutter, lessOnlyGutter];
+                var expectedRegisteredGutters = [leftGutter, lineNumberGutter, rightGutter, lessOnlyGutter, colorGutter];
                 var gutters  = myEditor._codeMirror.getOption("gutters");
                 var registeredGutters = Editor.getRegisteredGutters().map(function (gutter) {
                     return gutter.name;
@@ -2150,12 +2157,12 @@ define(function (require, exports, module) {
                 Editor.unregisterGutter(rightGutter);
                 Editor.registerGutter(leftGutter, 1);
                 var expectedGutters = [leftGutter, lineNumberGutter];
-                var gutters  = myEditor._codeMirror.getOption("gutters");
+                var guttersInEditor  = myEditor._codeMirror.getOption("gutters");
                 var registeredGutters = Editor.getRegisteredGutters().map(function (gutter) {
                     return gutter.name;
                 });
-                expect(gutters).toEqual(expectedGutters);
-                expect(registeredGutters).toEqual(expectedGutters);
+                expect(guttersInEditor).toEqual(expectedGutters); // js files dont have color gutter
+                expect(registeredGutters).toEqual([...expectedGutters, colorGutter]);
             });
 
             it("should set gutter marker correctly", function () {


### PR DESCRIPTION
1. Refactor to not use cm gutter apis directly and use editor gutter apis
2. code folding gutter set its width to 1.1em above gutter width of 1em. this caused the gutter to render over the left most indent line or even cursor at the beginning of the line at certain sidebar widths! Note that this appears only at certain sidebar width and doesnt come in the default sidebar width. This is an issue in all existing builds. See image:
 ### before fix
![image](https://github.com/user-attachments/assets/54e3c2bc-47cc-472d-a0ae-1ac4b7f19e26)
### with fix
![image](https://github.com/user-attachments/assets/a686e822-c8e9-432e-936d-cddef1a2a187)

4. Address layout issues in the color gutter.