### PR TITLE
feat: inline color preview

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1491,18 +1491,40 @@ define(function (require, exports, module) {
     };
 
     /**
-     * Clears all mark of the given type. If nothing is given, clears all marks(Don't use this API without types!).
+     * Clears all marks of the given type. If a lineNumbers array is given, only clears marks on those lines.
+     * If no markType or lineNumbers are given, clears all marks (use cautiously).
      * @param {string} [markType] - Optional, if given will only delete marks of that type. Else delete everything.
+     * @param {number[]} [lineNumbers] - Optional, array of line numbers where marks should be cleared.
      */
-    Editor.prototype.clearAllMarks = function (markType) {
+    Editor.prototype.clearAllMarks = function (markType, lineNumbers) {
         const self = this;
+
         self._codeMirror.operation(function () {
             let marks = self.getAllMarks(markType);
+
+            if (lineNumbers && Array.isArray(lineNumbers)) {
+                // Filter marks to only those within the specified line numbers
+                marks = marks.filter(function (mark) {
+                    const range = mark.find(); // Get the range of the mark
+                    if (!range) {
+                        return false;
+                    }
+
+                    const startLine = range.from.line;
+                    const endLine = range.to.line;
+
+                    // Check if the mark overlaps with any of the specified lines
+                    return lineNumbers.some(line => line >= startLine && line <= endLine);
+                });
+            }
+
+            // Clear the filtered marks
             for (let mark of marks) {
                 mark.clear();
             }
         });
     };
+
 
     /**
      * Checks if two positions in the editor are the same.

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -1251,5 +1251,6 @@ define({
     // indent guides extension
     "DESCRIPTION_INDENT_GUIDES_ENABLED": "true to show indent guide lines, else false.",
     "DESCRIPTION_HIDE_FIRST": "true to show the first Indent Guide line else false.",
-    "DESCRIPTION_CSS_COLOR_PREVIEW": "true to display color previews in the gutter, else false."
+    "DESCRIPTION_CSS_COLOR_PREVIEW": "true to display color previews in the gutter, else false.",
+    "DESCRIPTION_CSS_COLOR_PREVIEW_INLINE": "When true, color codes in the editor will display a colored background behind them, making it easy to visualize colors while editing CSS, else false."
 });


### PR DESCRIPTION
Current status: Not merging till the ux issues are addressed.
Having Christmas light colors as the cursor moves is distracting, so its not the best ux. The advantage here is that we get a visual indication of colors fast. But since this cannot be a default feature, we are not merging this at this time till the UX issues are addressed. Keeping it open for future refinement and comments. Pending integration tests as well.

When enabled, color codes in the editor will display a colored background behind them, making it easy to visualize colors while editing CSS. See video below.

1. Feature is currently disabled by default

[inline color preview.webm](https://github.com/user-attachments/assets/52bcfca6-8d46-40ca-8342-0f24d928edff)
