### PR TITLE
fix: ux issues in project open workflows when path doesnt exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Welcome to Phoenix!
 
-**Website: https://phcode.dev**
+**Website: https://phcode.io**
 
-Phoenix is a modern open-source and [free software](https://www.gnu.org/philosophy/free-sw.en.html) code editor for the web, built for the browser.
+Phoenix is a modern open-source and [free software](https://www.gnu.org/philosophy/free-sw.en.html) text editor
+designed to make coding as simple and fun as playing a video game.
 
 #### Code Guardian
 [![Phoenix build verification](https://github.com/phcode-dev/phoenix/actions/workflows/build_verify.yml/badge.svg)](https://github.com/phcode-dev/phoenix/actions/workflows/build_verify.yml)
@@ -27,7 +28,7 @@ Phoenix is a modern open-source and [free software](https://www.gnu.org/philosop
 <img src="https://assets-global.website-files.com/607f4f6df411bd01527dc7d5/63bc40cd9d502eda8ea74ce7_Bugsnag%20Full%20Color.svg" alt="bugsnag" style="width:200px;"/>
 </a>
 
-#### Development status:  Stable/Release-candidate.
+#### Development status:  Stable/Active.
 
 ![Screenshot from 2022-09-20 13-35-03](https://user-images.githubusercontent.com/5336369/191202975-6069d270-526a-443d-bd76-903353ae1222.png)
 

--- a/src/extensionsIntegrated/CSSColorPreview/main.js
+++ b/src/extensionsIntegrated/CSSColorPreview/main.js
@@ -230,7 +230,6 @@ define(function (require, exports, module) {
         // Add listener for all editor changes
         EditorManager.on("activeEditorChange", function (event, newEditor, oldEditor) {
             if (newEditor && newEditor.isGutterActive(GUTTER_NAME)) {
-                console.time("xxxxxxxxxxx");
                 newEditor.off("cursorActivity.colorPreview");
                 newEditor.on("cursorActivity.colorPreview", _cursorActivity);
                 // Unbind the previous editor's change event if it exists
@@ -241,7 +240,6 @@ define(function (require, exports, module) {
                 newEditor.on("change", onChanged);
                 showColorMarks();
                 _cursorActivity(null, newEditor);
-                console.timeEnd("xxxxxxxxxxx");
             }
         });
 

--- a/src/extensionsIntegrated/RecentProjects/main.js
+++ b/src/extensionsIntegrated/RecentProjects/main.js
@@ -363,7 +363,7 @@ define(function (require, exports, module) {
                     }
                     FileSystem.resolve(fullPath, function (err, item) {
                         if (err) {
-                            recentProjects.splice(index, 1);
+                            removeFromRecentProject(fullPath);
                         }
                         reject();
                     });

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -1468,6 +1468,12 @@ define(function (require, exports, module) {
             _openProject(null, result);
             return result.promise();
         }
+        const rootPath = ProjectModel._ensureTrailingSlash(path);
+        if(rootPath === getWelcomeProjectPath()) {
+            // welcome project path is always guaranteed to be present!
+            _openProject(rootPath, result);
+            return result.promise();
+        }
 
         const rootEntry = FileSystem.getDirectoryForPath(path);
         rootEntry.exists(function (err, exists) {

--- a/test/spec/CSSColorPreview-test-files/base.css
+++ b/test/spec/CSSColorPreview-test-files/base.css
@@ -16,5 +16,5 @@
 .class-6 {color: #ff0090 #802095 #954e3e #454e3e #150e3e;}
 
 .class-vars {
-    color: var(--slight-red); background-color: @blue-light; color: var(--red); background-color: @blue;
+    color: var(--slight-red); background-color: @blue-light; color: var(--red); background-color: @blue; color: $white;
 }


### PR DESCRIPTION
1. If we switch project and path doesn't exist, then we used to switch to the default project which is not expected. Now if path doesn't exist, we show an error dialog and not switch from the current project.
2. Project error messages shown to user was virtual `/tauri` or `/fs` or `/mnt/`, ie vfs paths. Now we resolve to a user readable path.
3. update readme
4. also add sass variables test case in color gutter tests.