### PR TITLE
fix: ctrl-click in mac app and safari didnt open context menu

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -470,6 +470,11 @@ define(function (require, exports, module) {
         // jQuery hides non-left clicks from such event handlers, yet middle-clicks still cause CEF to
         // navigate. Also, a capture handler is more reliable than bubble.
         window.document.body.addEventListener("click", function (e) {
+            // Don't interfere with context menu clicks
+            if (e.button === 2 || (brackets.platform === "mac" && e.ctrlKey)) {
+                return;
+            }
+
             // Check parents too, in case link has inline formatting tags
             let node = e.target, url;
             while (node) {

--- a/src/project/FileTreeView.js
+++ b/src/project/FileTreeView.js
@@ -835,7 +835,8 @@ define(function (require, exports, module) {
                 return;
             }
 
-            if (event.button !== LEFT_MOUSE_BUTTON) {
+            if (event.button !== LEFT_MOUSE_BUTTON
+                || (brackets.platform === "mac" && event.ctrlKey)) { // in mac ctrl-click is context menu
                 return;
             }
 

--- a/src/widgets/bootstrap-dropdown.js
+++ b/src/widgets/bootstrap-dropdown.js
@@ -156,7 +156,15 @@
    * =================================== */
 
   $(document)
-    .on('click.dropdown.data-api', clearMenus)
+      .on('click.dropdown.data-api', function(e) {
+          // Don't clear menus if this is a context menu click in mac/safari
+          // In Chrome, Ctrl+Click = context menu event and doesn't trigger the normal click handlers
+          // In Safari, Cmd+Click generates both a context menu event AND a regular click event so this check
+          if (e.button === 2 || (brackets.platform === "mac" && e.ctrlKey)) {
+              return;
+          }
+          clearMenus();
+      })
     .on('click.dropdown.data-api', '.dropdown form', function (e) { e.stopPropagation() })
     .on('click.dropdown-menu', function (e) { e.stopPropagation() })
     .on('click.dropdown.data-api'  , toggle, Dropdown.prototype.toggle)


### PR DESCRIPTION
Fixes: https://github.com/orgs/phcode-dev/discussions/1993

This issue existed from our first desktop version released in Apr 2024 which used the safari engine. In the desktop app, we cant open context menus with `ctrl-click` on mac as it will get dismissed as soon as it opens.
This is a mac desktop and safari only issue with `ctrl-click` based context menu activation. Context menu activation with right mouse button click works as expected.
The issue happens only in safari as it treats `ctrl-click` based right click in mac differently:

- In Chrome, when you Cmd+Click, it treats it as a special context menu event and doesn't trigger the normal click handlers
- In Safari, Cmd+Click generates both a context menu event AND a regular click event, which triggers the clearMenus handler. The twin calls leads to the context menu getting dismissed as the second event gets treated as a click event outside popup to dismiss it.
- We now account for this safari quirk.
