### PR TITLE
fix: dropdowns doesnt close reliably and multiple dropdowns may come

### DIFF
--- a/src/extensionsIntegrated/RecentProjects/main.js
+++ b/src/extensionsIntegrated/RecentProjects/main.js
@@ -484,7 +484,7 @@ define(function (require, exports, module) {
             })
             .appendTo($("body"));
 
-        PopUpManager.addPopUp($dropdown, cleanupDropdown, true);
+        PopUpManager.addPopUp($dropdown, cleanupDropdown, true, {closeCurrentPopups: true});
 
         // TODO: should use capture, otherwise clicking on the menus doesn't close it. More fallout
         // from the fact that we can't use the Boostrap (1.4) dropdowns.

--- a/src/utils/DropdownEventHandler.js
+++ b/src/utils/DropdownEventHandler.js
@@ -147,7 +147,7 @@ define(function (require, exports, module) {
 
         if (this.$list) {
             this._registerMouseEvents();
-            PopUpManager.addPopUp(this.$list, closeCallback, true);
+            PopUpManager.addPopUp(this.$list, closeCallback, true, {closeCurrentPopups: true});
         }
     };
 

--- a/src/widgets/PopUpManager.js
+++ b/src/widgets/PopUpManager.js
@@ -45,12 +45,17 @@ define(function (require, exports, module) {
      *      remove the popup from the _popUps array when the popup is closed. Specify false
      *      when the popup is always persistant in the _popUps array.
      * @param {object} options
-     * @param {boolean} options.popupManagesFocus - set to true if the popup manages focus restore on close
+     * @param {boolean} [options.popupManagesFocus] - set to true if the popup manages focus restore on close
+     * @param {boolean} [options.closeCurrentPopups] - set to true if you want to dismiss all exiting popups before
+     *              adding this. Useful when this should be the only popup visible.
      *
      */
     function addPopUp($popUp, removeHandler, autoRemove, options) {
         autoRemove = autoRemove || false;
         options = options || {};
+        if(options.closeCurrentPopups) {
+            closeAllPopups();
+        }
         const popupManagesFocus = options.popupManagesFocus || false;
 
         _popUps.push($popUp[0]);
@@ -130,7 +135,7 @@ define(function (require, exports, module) {
     function _keydownCaptureListener(keyEvent) {
         // Escape key or Alt key (Windows-only)
         if (keyEvent.keyCode !== KeyEvent.DOM_VK_ESCAPE &&
-                !(keyEvent.keyCode === KeyEvent.DOM_VK_ALT && brackets.platform === "win")) {
+            !(keyEvent.keyCode === KeyEvent.DOM_VK_ALT && brackets.platform === "win")) {
             return;
         }
 
@@ -184,10 +189,14 @@ define(function (require, exports, module) {
         WorkspaceManager.addEscapeKeyEventHandler("PopUpManager", _dontToggleWorkspacePanel);
     });
 
+    function closeAllPopups() {
+        removeCurrentPopUp();
+    }
 
     EventDispatcher.makeEventDispatcher(exports);
 
     exports.addPopUp            = addPopUp;
     exports.removePopUp         = removePopUp;
+    exports.closeAllPopups      = closeAllPopups;
     exports.listenToContextMenu = listenToContextMenu;
 });


### PR DESCRIPTION
click on the project dropdown, then click on the langugae drop down in status bar. you can see that two dropdowns are simultaneously open. 

This happened as the add dropdown API did not clear existing dropdowns as that may not be needed all the time(and to prevent braking legacy extensions). So we now add a parameter to also dismiss exiting popups while adding a new popup.