### PR TITLE
feat: add open in terminal, open in cmd and powershell feature

### DIFF
--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -267,6 +267,12 @@ define(function (require, exports, module) {
     /** Submenu for zoom options */
     exports.VIEW_ZOOM_SUBMENU           = "zoom-view-submenu";
 
+    /** Submenu for Open in project context menu */
+    exports.OPEN_IN_SUBMENU             = "file-open-in-submenu";
+
+    /** Submenu for Open in working set context menu */
+    exports.OPEN_IN_SUBMENU_WS          = "file-open-in-submenu-ws";
+
     /** Increases editor font size */
     exports.VIEW_INCREASE_FONT_SIZE     = "view.increaseFontSize";      // ViewCommandHandlers.js       _handleIncreaseFontSize()
 

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -340,6 +340,12 @@ define(function (require, exports, module) {
     /** Shows current file in OS file explorer */
     exports.NAVIGATE_SHOW_IN_OS         = "navigate.showInOS";          // DocumentCommandHandlers.js   handleShowInOS()
 
+    /** Shows current file in OS Terminal */
+    exports.NAVIGATE_OPEN_IN_TERMINAL         = "navigate.openInTerminal";
+
+    /** Shows current file in open powershell in Windows os */
+    exports.NAVIGATE_OPEN_IN_POWERSHELL         = "navigate.openInPowerShell";
+
     /** Opens quick open dialog */
     exports.NAVIGATE_QUICK_OPEN         = "navigate.quickOpen";         // QuickOpen.js                 doFileSearch()
 

--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -297,7 +297,8 @@ define(function (require, exports, module) {
         workingset_cmenu.addMenuItem(Commands.FILE_SAVE);
         workingset_cmenu.addMenuItem(Commands.NAVIGATE_SHOW_IN_FILE_TREE);
         if(Phoenix.isNativeApp){
-            workingset_cmenu.addMenuItem(Commands.NAVIGATE_SHOW_IN_OS);
+            let subMenu = workingset_cmenu.addSubMenu(Strings.CMD_OPEN_IN, Commands.OPEN_IN_SUBMENU_WS);
+            subMenu.addMenuItem(Commands.NAVIGATE_SHOW_IN_OS);
         }
         workingset_cmenu.addMenuDivider();
         workingset_cmenu.addMenuItem(Commands.FILE_COPY);
@@ -331,7 +332,8 @@ define(function (require, exports, module) {
         project_cmenu.addMenuItem(Commands.FILE_NEW);
         project_cmenu.addMenuItem(Commands.FILE_NEW_FOLDER);
         if(Phoenix.isNativeApp){
-            project_cmenu.addMenuItem(Commands.NAVIGATE_SHOW_IN_OS);
+            let subMenu = project_cmenu.addSubMenu(Strings.CMD_OPEN_IN, Commands.OPEN_IN_SUBMENU);
+            subMenu.addMenuItem(Commands.NAVIGATE_SHOW_IN_OS);
         }
         project_cmenu.addMenuDivider();
         project_cmenu.addMenuItem(Commands.FILE_CUT);

--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -58,7 +58,7 @@ define(function (require, exports, module) {
                     return err;
                 }
                 _setContextMenuItemsVisible(isPresent, [Commands.FILE_RENAME,
-                    Commands.NAVIGATE_SHOW_IN_FILE_TREE, Commands.NAVIGATE_SHOW_IN_OS]);
+                    Commands.NAVIGATE_SHOW_IN_FILE_TREE, Commands.NAVIGATE_SHOW_IN_OS, Commands.NAVIGATE_OPEN_IN_TERMINAL]);
             });
         }
     }
@@ -299,6 +299,10 @@ define(function (require, exports, module) {
         if(Phoenix.isNativeApp){
             let subMenu = workingset_cmenu.addSubMenu(Strings.CMD_OPEN_IN, Commands.OPEN_IN_SUBMENU_WS);
             subMenu.addMenuItem(Commands.NAVIGATE_SHOW_IN_OS);
+            subMenu.addMenuItem(Commands.NAVIGATE_OPEN_IN_TERMINAL);
+            if (brackets.platform === "win") {
+                subMenu.addMenuItem(Commands.NAVIGATE_OPEN_IN_POWERSHELL);
+            }
         }
         workingset_cmenu.addMenuDivider();
         workingset_cmenu.addMenuItem(Commands.FILE_COPY);
@@ -334,6 +338,10 @@ define(function (require, exports, module) {
         if(Phoenix.isNativeApp){
             let subMenu = project_cmenu.addSubMenu(Strings.CMD_OPEN_IN, Commands.OPEN_IN_SUBMENU);
             subMenu.addMenuItem(Commands.NAVIGATE_SHOW_IN_OS);
+            subMenu.addMenuItem(Commands.NAVIGATE_OPEN_IN_TERMINAL);
+            if (brackets.platform === "win") {
+                subMenu.addMenuItem(Commands.NAVIGATE_OPEN_IN_POWERSHELL);
+            }
         }
         project_cmenu.addMenuDivider();
         project_cmenu.addMenuItem(Commands.FILE_CUT);

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -2252,7 +2252,7 @@ define(function (require, exports, module) {
 
     // Set some command strings
     var quitString  = Strings.CMD_QUIT,
-        showInOS    = Strings.CMD_SHOW_IN_OS;
+        showInOS    = Strings.CMD_SHOW_IN_FILE_MANAGER;
     if (brackets.platform === "win") {
         quitString  = Strings.CMD_EXIT;
         showInOS    = Strings.CMD_SHOW_IN_EXPLORER;

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -58,6 +58,7 @@ define(function (require, exports, module) {
         LanguageManager     = require("language/LanguageManager"),
         NewFileContentManager     = require("features/NewFileContentManager"),
         NodeConnector = require("NodeConnector"),
+        NodeUtils           = require("utils/NodeUtils"),
         _                   = require("thirdparty/lodash");
 
     /**
@@ -1959,6 +1960,20 @@ define(function (require, exports, module) {
         }
     }
 
+    function openDefaultTerminal() {
+        const entry = ProjectManager.getSelectedItem();
+        if (entry && entry.fullPath) {
+            NodeUtils.openNativeTerminal(entry.fullPath);
+        }
+    }
+
+    function openPowerShell() {
+        const entry = ProjectManager.getSelectedItem();
+        if (entry && entry.fullPath) {
+            NodeUtils.openNativeTerminal(entry.fullPath, true);
+        }
+    }
+
     function raceAgainstTime(promise, timeout = 2000) {
         const timeoutPromise = new Promise((_resolve, reject) => {
             setTimeout(() => {
@@ -2251,11 +2266,13 @@ define(function (require, exports, module) {
     exports._parseDecoratedPath = _parseDecoratedPath;
 
     // Set some command strings
-    var quitString  = Strings.CMD_QUIT,
-        showInOS    = Strings.CMD_SHOW_IN_FILE_MANAGER;
+    let quitString  = Strings.CMD_QUIT,
+        showInOS    = Strings.CMD_SHOW_IN_FILE_MANAGER,
+        defaultTerminal    = Strings.CMD_OPEN_IN_TERMINAL;
     if (brackets.platform === "win") {
         quitString  = Strings.CMD_EXIT;
         showInOS    = Strings.CMD_SHOW_IN_EXPLORER;
+        defaultTerminal    = Strings.CMD_OPEN_IN_CMD;
     } else if (brackets.platform === "mac") {
         showInOS    = Strings.CMD_SHOW_IN_FINDER;
     }
@@ -2304,6 +2321,10 @@ define(function (require, exports, module) {
 
     // Special Commands
     CommandManager.register(showInOS,                                Commands.NAVIGATE_SHOW_IN_OS,            handleShowInOS);
+    CommandManager.register(defaultTerminal,                         Commands.NAVIGATE_OPEN_IN_TERMINAL,      openDefaultTerminal);
+    if (brackets.platform === "win") {
+        CommandManager.register(Strings.CMD_OPEN_IN_POWER_SHELL,     Commands.NAVIGATE_OPEN_IN_POWERSHELL,    openPowerShell);
+    }
     CommandManager.register(Strings.CMD_NEW_BRACKETS_WINDOW,         Commands.FILE_NEW_WINDOW,                handleFileNewWindow);
     CommandManager.register(quitString,                              Commands.FILE_QUIT,                      handleFileCloseWindow);
     CommandManager.register(Strings.CMD_SHOW_IN_TREE,                Commands.NAVIGATE_SHOW_IN_FILE_TREE,     handleShowInTree);

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -598,6 +598,9 @@ define({
     "CMD_SHOW_IN_EXPLORER": "Windows File Explorer",
     "CMD_SHOW_IN_FINDER": "macOS Finder",
     "CMD_SHOW_IN_FILE_MANAGER": "File Manager",
+    "CMD_OPEN_IN_TERMINAL": "Terminal",
+    "CMD_OPEN_IN_CMD": "Command Prompt",
+    "CMD_OPEN_IN_POWER_SHELL": "Power Shell",
     "CMD_SWITCH_PANE_FOCUS": "Switch Pane Focus",
 
     // Debug menu commands

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -495,6 +495,7 @@ define({
     "CMD_FILE_REFRESH": "Refresh File Tree",
     "CMD_FILE_SHOW_FOLDERS_FIRST": "Sort Folders First",
     "CMD_QUIT": "Quit",
+    "CMD_OPEN_IN": "Open In",
     // Used in native File menu on Windows
     "CMD_EXIT": "Exit",
 
@@ -594,9 +595,9 @@ define({
     "CMD_NEXT_DOC_LIST_ORDER": "Next Document in List",
     "CMD_PREV_DOC_LIST_ORDER": "Previous Document in List",
     "CMD_SHOW_IN_TREE": "Show in File Tree",
-    "CMD_SHOW_IN_EXPLORER": "Show in Explorer",
-    "CMD_SHOW_IN_FINDER": "Show in Finder",
-    "CMD_SHOW_IN_OS": "Show in OS Files",
+    "CMD_SHOW_IN_EXPLORER": "Windows File Explorer",
+    "CMD_SHOW_IN_FINDER": "macOS Finder",
+    "CMD_SHOW_IN_FILE_MANAGER": "File Manager",
     "CMD_SWITCH_PANE_FOCUS": "Switch Pane Focus",
 
     // Debug menu commands

--- a/src/utils/NodeUtils.js
+++ b/src/utils/NodeUtils.js
@@ -159,6 +159,23 @@ define(function (require, exports, module) {
         });
     }
 
+    /**
+     * Runs ESLint on a file
+     * This is only available in the native app
+     *
+     * @param {string} cwd the working directory of terminal
+     * @param {boolean} [usePowerShell]
+     */
+    async function openNativeTerminal(cwd, usePowerShell = false) {
+        if(!Phoenix.isNativeApp) {
+            throw new Error("openNativeTerminal not available in browser");
+        }
+        return utilsConnector.execPeer("openNativeTerminal", {
+            cwd: window.fs.getTauriPlatformPath(cwd),
+            usePowerShell
+        });
+    }
+
     if(NodeConnector.isNodeAvailable()) {
         // todo we need to update the strings if a user extension adds its translations. Since we dont support
         // node extensions for now, should consider when we support node extensions.
@@ -195,6 +212,7 @@ define(function (require, exports, module) {
     exports.openUrlInBrowser = openUrlInBrowser;
     exports.ESLintFile = ESLintFile;
     exports.getEnvironmentVariable = getEnvironmentVariable;
+    exports.openNativeTerminal = openNativeTerminal;
 
     /**
      * checks if Node connector is ready


### PR DESCRIPTION
### Changed `Shown in Files` menu to `Open in` menu.
#### before
![image](https://github.com/user-attachments/assets/02367b71-8475-4449-8483-e24caaa0eb4f)

#### after
![image](https://github.com/user-attachments/assets/6bac50ae-bd56-4573-8b56-7740a74a298e)

### You can now right click on project and working set files to open them in terminal.
#### Linux
![image](https://github.com/user-attachments/assets/7a106b17-b0cd-48cd-8553-2e4d0262ab82)

#### Windows powershell
![image](https://github.com/user-attachments/assets/2c7159af-ee21-4062-aefc-3633f2a8d3b3)

#### Windows command prompt
![image](https://github.com/user-attachments/assets/cf701e1f-02d1-4ad6-91ec-ac90ec59d937)

#### Mac
![image](https://github.com/user-attachments/assets/03dbd67d-2b01-4b2c-a55f-573a85c54be1)
