### PR TITLE
fix: accdental triple ctrlx3 press event in windows for ui overlay mode

### DIFF
--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -1174,13 +1174,20 @@ define(function (require, exports, module) {
         Control: true,
         Meta: true
     };
+    let isCtrlDepressed = false; // flag set to true if the user keeps the ctrl key pressed without releasing
     function _detectTripleCtrlKeyPress(event) {
+        const isCtrlKeyPressStart = !isCtrlDepressed;
+        if (ctrlKeyCodes[event.code] && ctrlKeyCodes[event.key]) {
+            isCtrlDepressed = true;
+        }
         if(PreferencesManager && !PreferencesManager.get(PREF_TRIPLE_CTRL_KEY_PRESS_ENABLED)){
             return false;
         }
         const currentTime = new Date().getTime(); // Get the current time
-        if (ctrlKeyCodes[event.code] && ctrlKeyCodes[event.key] && !event.shiftKey && !event.altKey) {
+        if (ctrlKeyCodes[event.code] && ctrlKeyCodes[event.key] && !event.shiftKey && !event.altKey
+            && isCtrlKeyPressStart) {
             pressCount++;
+            isCtrlDepressed = true;
             if(pressCount === PRESS_ACTIVATE_COUNT && (currentTime - lastCtrlKeyPressTime) <= doublePressInterval) {
                 KeyboardOverlayMode.startOverlayMode();
                 event.stopPropagation();
@@ -1280,6 +1287,15 @@ define(function (require, exports, module) {
         window.document.body.addEventListener(
             "keydown",
             _handleKeyEvent,
+            true
+        );
+        window.document.body.addEventListener(
+            "keyup",
+            (event)=>{
+                if (ctrlKeyCodes[event.code] && ctrlKeyCodes[event.key]) {
+                    isCtrlDepressed = false;
+                }
+            },
             true
         );
         document.body.addEventListener('mousemove', ()=>{

--- a/test/spec/Keyboard-nav-integ-test.js
+++ b/test/spec/Keyboard-nav-integ-test.js
@@ -19,7 +19,7 @@
  *
  */
 
-/*global describe, it, expect, beforeAll, afterAll, awaitsFor, awaitsForDone */
+/*global describe, it, expect, beforeAll, afterAll, awaitsFor, awaitsForDone, awaits */
 
 define(function (require, exports, module) {
     // Recommended to avoid reloading the integration test window Phoenix instance for each test.
@@ -66,12 +66,20 @@ define(function (require, exports, module) {
 
         function tripleControlEvent() {
             keyboardType(Keys.KEY.CONTROL);
+            keyboardType(Keys.KEY.CONTROL, "keyup");
+            keyboardType(Keys.KEY.CONTROL);
+            keyboardType(Keys.KEY.CONTROL, "keyup");
+            keyboardType(Keys.KEY.CONTROL);
+        }
+
+        function tripleControlContinuousEvent() {
+            keyboardType(Keys.KEY.CONTROL);
             keyboardType(Keys.KEY.CONTROL);
             keyboardType(Keys.KEY.CONTROL);
         }
 
-        function keyboardType(key) {
-            const ctrlEvent = new KeyboardEvent("keydown", {
+        function keyboardType(key, type) {
+            const ctrlEvent = new KeyboardEvent(type || "keydown", {
                 key: key,
                 bubbles: true, // Event bubbles up through the DOM
                 cancelable: true, // Event can be canceled,
@@ -116,6 +124,17 @@ define(function (require, exports, module) {
             await awaitsFor(()=>{
                 return !testWindow.$('#ctrl-nav-overlay').is(":visible");
             }, "overlay to be closed");
+        });
+
+        it("Should not show overlay on triple control continuous press", async function () {
+            MainViewManager.setLayoutScheme(1, 1);
+            await openAnyFile();
+            await awaitsFor(()=>{
+                return !testWindow.$('#ctrl-nav-overlay').is(":visible");
+            }, "overlay to be not visible");
+            tripleControlContinuousEvent();
+            await awaits(20); // give some time so that we are sure that the overlay didn't come up.
+            expect(testWindow.$('#ctrl-nav-overlay').is(":visible")).toBeFalse();
         });
 
         async function _verifyMenuNav() {


### PR DESCRIPTION
in Windows and Chrome (as well as most modern browsers), holding down a key like `Ctrl` will repeatedly fire the keydown event. The keydown event is triggered continuously while the key is pressed and held down. This behavior is called `keyboard auto-repeat`.

So this launched the ui overlay workflow accidentally. bad ux fix!
