### PR TITLE
fix: update virtual path before displaying in UI

### DIFF
--- a/src/extensionsIntegrated/NavigationAndHistory/main.js
+++ b/src/extensionsIntegrated/NavigationAndHistory/main.js
@@ -221,7 +221,7 @@ define(function (require, exports, module) {
     }
 
     function _createFileEntries($mrofList) {
-        var data, fileEntry, $link, $newItem;
+        var data, fileEntry, $link, $newItem, $removeBtn;
         // Iterate over the MROF list and create the pop over UI items
 
         // If we are in split view we might want to show the panes corresponding to the entries
@@ -270,35 +270,41 @@ define(function (require, exports, module) {
                 ViewUtils.getFileEntryDisplay({name: FileUtils.getBaseName(value.file)})
             );
 
-            // Create remove button
-            var $removeBtn = $("<span class='remove-file'>&times;</span>").on("click", function(e) {
-                e.preventDefault();
-                e.stopPropagation();
+            // Create remove button only for files not in working set
+            $removeBtn = null;
+            if (indxInWS === -1) {
+                $removeBtn = $("<span class='remove-file'>&times;</span>").on("click", function(e) {
+                    e.preventDefault();
+                    e.stopPropagation();
 
-                // Find and remove the entry from _mrofList
-                var filePath = $(this).parent().data("path");
-                var paneId = $(this).parent().data("paneId");
+                    // Find and remove the entry from _mrofList
+                    var filePath = $(this).parent().data("path");
+                    var paneId = $(this).parent().data("paneId");
 
-                _mrofList = _mrofList.filter(function(entry) {
-                    return !(entry && entry.file === filePath && entry.paneId === paneId);
+                    _mrofList = _mrofList.filter(function(entry) {
+                        return !(entry && entry.file === filePath && entry.paneId === paneId);
+                    });
+
+                    // Remove the list item from UI
+                    $(this).parent().remove();
+
+                    // Update preferences
+                    PreferencesManager.setViewState(
+                        OPEN_FILES_VIEW_STATE,
+                        _mrofList,
+                        PreferencesManager.STATE_PROJECT_CONTEXT
+                    );
                 });
-
-                // Remove the list item from UI
-                $(this).parent().remove();
-
-                // Update preferences
-                PreferencesManager.setViewState(
-                    OPEN_FILES_VIEW_STATE,
-                    _mrofList,
-                    PreferencesManager.STATE_PROJECT_CONTEXT
-                );
-            });
+            }
 
             // Use the file icon providers
             WorkingSetView.useIconProviders(data, $link);
 
-            // Create list item with link and remove button
-            $newItem = $("<li></li>").append($link).append($removeBtn);
+            // Create list item with link and conditionally add remove button
+            $newItem = $("<li></li>").append($link);
+            if ($removeBtn) {
+                $newItem.append($removeBtn);
+            }
 
             if (indxInWS !== -1) { // in working set show differently
                 $newItem.addClass("working-set");

--- a/src/extensionsIntegrated/NavigationAndHistory/main.js
+++ b/src/extensionsIntegrated/NavigationAndHistory/main.js
@@ -311,10 +311,14 @@ define(function (require, exports, module) {
             }
 
             $newItem.data("path", value.file);
+
+            // convert the virtual path to display path
+            var displayPath = Phoenix.app.getDisplayPath(value.file);
+
             $newItem.data("paneId", value.paneId);
             $newItem.data("cursor", value.cursor);
             $newItem.data("file", fileEntry);
-            $newItem.attr("title", value.file);
+            $newItem.attr("title", displayPath); // this is for the tooltip
 
             if (isPaneLabelReqd && value.paneId) {
                 $newItem.addClass(value.paneId);
@@ -442,8 +446,12 @@ define(function (require, exports, module) {
             var $scope = $(event.target).parent();
             $("#mrof-container #mrof-list > li.highlight").removeClass("highlight");
             $(event.target).parent().addClass("highlight");
-            $mrofContainer.find("#recent-file-path").text($scope.data("path"));
-            $mrofContainer.find("#recent-file-path").attr('title', ($scope.data("path")));
+
+            // convert the virtual path to display path
+            var displayPath = Phoenix.app.getDisplayPath($scope.data("path"));
+            $mrofContainer.find("#recent-file-path").text(displayPath);
+            $mrofContainer.find("#recent-file-path").attr('title', displayPath);
+
             $currentContext = $scope;
         }
 

--- a/src/styles/Extn-NavigationAndHistory.less
+++ b/src/styles/Extn-NavigationAndHistory.less
@@ -84,7 +84,7 @@
   line-height: 15px;
   padding: 3px;
   cursor: default;
-  padding-left: 10px;
+  padding-left: 20px;
   width: 100%;
   box-sizing: border-box;
   text-overflow: ellipsis;
@@ -104,14 +104,14 @@
   background: transparent;
   color:#8fddff;
   box-shadow: none !important;
-  padding-left: 10px;
+  padding-left: 20px;
 }
 
 #mrof-container #mrof-list > li.highlight > a.mroitem {
   background: transparent;
   color:#8fddff;
   box-shadow: none !important;
-  padding-left: 10px;
+  padding-left: 20px;
 }
 
 #mrof-container #mrof-list > li.highlight > a.mroitem > .extension {
@@ -245,7 +245,7 @@
 .remove-file {
   color: #adb9bd;
   position: absolute;
-  right: 8px;
+  left: 6px;
   top: 50%;
   transform: translateY(-50%);
   cursor: pointer;

--- a/src/styles/Extn-NavigationAndHistory.less
+++ b/src/styles/Extn-NavigationAndHistory.less
@@ -243,20 +243,24 @@
 }
 
 .remove-file {
+  color: #adb9bd;
   position: absolute;
   right: 8px;
   top: 50%;
   transform: translateY(-50%);
   cursor: pointer;
   opacity: 0.6;
-  font-size: 18px;
+  font-size: 20px;
+  font-weight: 500;
   display: none;
 }
 
 #mrof-list li:hover .remove-file {
+  color: #fff;
   display: block;
 }
 
 .remove-file:hover {
+  color: #fff;
   opacity: 1;
 }

--- a/src/styles/Extn-NavigationAndHistory.less
+++ b/src/styles/Extn-NavigationAndHistory.less
@@ -238,11 +238,7 @@
   border-top: 1px solid #343434;
 }
 
-#mrof-list li {
-  position: relative;
-}
-
-.remove-file {
+#mrof-container #mrof-list > li .remove-file {
   color: #adb9bd;
   position: absolute;
   left: 6px;
@@ -255,12 +251,12 @@
   display: none;
 }
 
-#mrof-list li:hover .remove-file {
+#mrof-container #mrof-list > li:hover .remove-file {
   color: #fff;
   display: block;
 }
 
-.remove-file:hover {
+#mrof-container #mrof-list > li .remove-file:hover {
   color: #fff;
   opacity: 1;
 }

--- a/src/styles/Extn-NavigationAndHistory.less
+++ b/src/styles/Extn-NavigationAndHistory.less
@@ -237,3 +237,26 @@
   background-color: #2c2c2c;
   border-top: 1px solid #343434;
 }
+
+#mrof-list li {
+  position: relative;
+}
+
+.remove-file {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  cursor: pointer;
+  opacity: 0.6;
+  font-size: 18px;
+  display: none;
+}
+
+#mrof-list li:hover .remove-file {
+  display: block;
+}
+
+.remove-file:hover {
+  opacity: 1;
+}


### PR DESCRIPTION
In the 'Recent Files' dialog box, at the bottom left and in the tooltip for each file, the file path was previously displayed as a virtual path, containing segments like /mnt/ or /tauri/e. This is not the expected behaviour. 
This issue is now resolved to show paths correctly.

![Screenshot 2025-01-09 031232](https://github.com/user-attachments/assets/60dc9b2b-fee6-41ef-8e36-34a9dfa0cc55)
