### PR TITLE
fix: update virtual path before displaying in the UI

### DIFF
--- a/src/extensionsIntegrated/NavigationAndHistory/main.js
+++ b/src/extensionsIntegrated/NavigationAndHistory/main.js
@@ -311,10 +311,14 @@ define(function (require, exports, module) {
             }
 
             $newItem.data("path", value.file);
+
+            // convert the virtual path to display path
+            var displayPath = Phoenix.app.getDisplayPath(value.file);
+
             $newItem.data("paneId", value.paneId);
             $newItem.data("cursor", value.cursor);
             $newItem.data("file", fileEntry);
-            $newItem.attr("title", value.file);
+            $newItem.attr("title", displayPath); // this is for the tooltip
 
             if (isPaneLabelReqd && value.paneId) {
                 $newItem.addClass(value.paneId);
@@ -442,8 +446,12 @@ define(function (require, exports, module) {
             var $scope = $(event.target).parent();
             $("#mrof-container #mrof-list > li.highlight").removeClass("highlight");
             $(event.target).parent().addClass("highlight");
-            $mrofContainer.find("#recent-file-path").text($scope.data("path"));
-            $mrofContainer.find("#recent-file-path").attr('title', ($scope.data("path")));
+
+            // convert the virtual path to display path
+            var displayPath = Phoenix.app.getDisplayPath($scope.data("path"));
+            $mrofContainer.find("#recent-file-path").text(displayPath);
+            $mrofContainer.find("#recent-file-path").attr('title', displayPath);
+
             $currentContext = $scope;
         }
 


### PR DESCRIPTION
In the 'Recent Files' dialog box, at the bottom left and in the tooltip for each file, the file path was previously displayed as a virtual path, containing segments like /mnt/ or /tauri/e. This is not the expected behaviour.
This issue is now resolved to show paths correctly.