### PR TITLE
chore: alert divs styling for low warnings

### DIFF
--- a/src/styles/brackets_core_ui_variables.less
+++ b/src/styles/brackets_core_ui_variables.less
@@ -196,7 +196,9 @@
 
 // Warning
 @dark-bc-warning-bg:                 #c95800;
+@dark-bc-warning-bg-low:             #ffd966;
 @dark-bc-warning-text:               #fff;
+@dark-bc-warning-text-low:           #333333;
 
 // Text
 @dark-bc-text:                       #ccc;

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -2221,9 +2221,24 @@ dt,
     border: none;
 
     .dark & {
-        color: @dark-bc-warning-bg;
+        background: @dark-bc-warning-bg;
+        border-radius: 2px;
+        color: @dark-bc-warning-text;
     }
 }
+
+.alert.alert-warning {
+    text-shadow: none;
+    background-color: @bc-warning-bg;
+    border: none;
+
+    .dark & {
+        background: @dark-bc-warning-bg-low;
+        border-radius: 2px;
+        color: @dark-bc-warning-text-low;
+    }
+}
+
 .alert h4 {
     // Specified for the h4 to prevent conflicts of changing @headingsColor
     color: @bc-warning-bg;


### PR DESCRIPTION
Introduces a lower warning style to be not as alarming. available if you apply the class `alert alert-warning` to the div.

## Dark theme low alert
observe the yellow alert banner
### new alert - now should be used for low severity boxes
![image](https://github.com/user-attachments/assets/f04850ce-a40f-4a68-96f1-d255683d8e38)
### Existing alert - now should be used for high severity only
![image](https://github.com/user-attachments/assets/11cb099e-5af1-4219-b1a3-badc937d2bd5)

## light theme low alert
### new alert - now should be used for low severity boxes
same as before
### Existing alert - now should be used for high severity only
![image](https://github.com/user-attachments/assets/f62b57cd-caa9-4a13-ac97-9bf6ca8da79f)
