### PR TITLE
feat: go to line will accept :ln:col format along with :ln,col

### DIFF
--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -89,7 +89,7 @@ define(function (require, exports, module) {
      * @private
      * @const {RegExp}
      */
-    var CURSOR_POS_EXP = new RegExp(":([^,]+)?(,(.+)?)?");
+    var CURSOR_POS_EXP = new RegExp(":([^,:]+)?([,:](.+)?)?");
 
     /**
      * Current plugin

--- a/test/spec/QuickOpen-integ-test.js
+++ b/test/spec/QuickOpen-integ-test.js
@@ -182,5 +182,21 @@ define(function (require, exports, module) {
         it("can directly open a file in a given line and column, centering that line on the screen", async function () {
             await quickOpenTest("lines:150,20", null, "lotsOfLines.html", 150, 20);
         });
+
+        it("can open a file and jump to a line and column with no space after comma", async function () {
+            await quickOpenTest("lines", ":50,20", "lotsOfLines.html", 50, 20);
+        });
+
+        it("can open a file and jump to a line and column with space after comma", async function () {
+            await quickOpenTest("lines", ":50, 20", "lotsOfLines.html", 50, 20);
+        });
+
+        it("can directly open a file with line:column format", async function () {
+            await quickOpenTest("lines:150:20", null, "lotsOfLines.html", 150, 20);
+        });
+
+        it("can directly open a file with line:column format and spaces", async function () {
+            await quickOpenTest("lines:150: 20", null, "lotsOfLines.html", 150, 20);
+        });
     });
 });


### PR DESCRIPTION
### Add Support for `ln:col` Format in `Ctrl+G`

This update modifies the `Ctrl+G` "Go to Line" command to accept the `ln:col` format (e.g., `13:15`) in addition to the existing `line,col` format. 

Reason: The status bar shows the cursor position in the `ln:col` format since last release, replacing the earlier `line 13, column 15` format  to save space in the status bar. so for UX consistency we need to do this now.

https://discord.com/channels/879126209114542181/879126209554948116/1329280951188062209

![image](https://github.com/user-attachments/assets/1db1bbd6-72ea-4b58-aa4b-43c28b6f4075)

