### PR TITLE
fix: cursor not seen if line is empty and no git gutter marker in line in git projects

### DIFF
--- a/src/LiveDevelopment/LiveDevMultiBrowser.js
+++ b/src/LiveDevelopment/LiveDevMultiBrowser.js
@@ -588,7 +588,7 @@ define(function (require, exports, module) {
 
         // reload the page if the given document is a JS file related
         // to the current live document.
-        if (_liveDocument.isRelated(absolutePath)) {
+        if (_liveDocument.isRelated && _liveDocument.isRelated(absolutePath)) {
             if (doc.getLanguage().getId() === "javascript") {
                 _setStatus(STATUS_RELOADING);
                 _protocol.reload();
@@ -610,7 +610,7 @@ define(function (require, exports, module) {
 
         var absolutePath = doc.file.fullPath;
 
-        if (_liveDocument.isRelated(absolutePath)) {
+        if (_liveDocument.isRelated && _liveDocument.isRelated(absolutePath)) {
             // Set status to out of sync if dirty. Otherwise, set it to active status.
             _setStatus(_docIsOutOfSync(doc) ? STATUS_OUT_OF_SYNC : STATUS_ACTIVE);
         }

--- a/src/extensions/default/Git/src/Panel.js
+++ b/src/extensions/default/Git/src/Panel.js
@@ -1083,7 +1083,7 @@ define(function (require, exports) {
                 if ($this.attr("x-status") === Git.FILE_STATUS.DELETED) {
                     return;
                 }
-                FileViewController.addToWorkingSetAndSelect(Preferences.get("currentGitRoot") + $this.attr("x-file"));
+                FileViewController.openFileAndAddToWorkingSet(Preferences.get("currentGitRoot") + $this.attr("x-file"));
             });
 
     }
@@ -1316,6 +1316,7 @@ define(function (require, exports) {
             toggle(true);
         }
         _panelResized();
+        GutterManager.init();
     } // function init() {
 
     function enable() {

--- a/src/extensions/default/Git/src/Utils.js
+++ b/src/extensions/default/Git/src/Utils.js
@@ -273,7 +273,7 @@ define(function (require, exports, module) {
             }
 
             // create entry for temporary file
-            var fileEntry = FileSystem.getFileForPath(folder + ".bracketsGitTemp");
+            var fileEntry = FileSystem.getFileForPath(folder + ".phoenixGitTemp");
 
             function finish(bool) {
                 // delete the temp file and resolve

--- a/src/extensions/default/Git/src/git/GitCli.js
+++ b/src/extensions/default/Git/src/git/GitCli.js
@@ -606,10 +606,10 @@ define(function (require, exports) {
         } else {
             return new Promise(function (resolve, reject) {
                 // FUTURE: maybe use git commit --file=-
-                var fileEntry = FileSystem.getFileForPath(Preferences.get("currentGitRoot") + ".bracketsGitTemp");
+                var fileEntry = FileSystem.getFileForPath(Preferences.get("currentGitRoot") + ".phoenixGitTemp");
                 jsPromise(FileUtils.writeText(fileEntry, message))
                     .then(function () {
-                        args.push("-F", ".bracketsGitTemp");
+                        args.push("-F", ".phoenixGitTemp");
                         return git(args, {progressTracker});
                     })
                     .then(function (res) {

--- a/src/extensions/default/Git/styles/git-styles.less
+++ b/src/extensions/default/Git/styles/git-styles.less
@@ -3,11 +3,14 @@
 // common
 @git-moreDarkGrey:               #868888;
 @git-green:                      #91CC41;
+@dark-git-green:                 #78A336;
 @git-red:                        #F74687;
+@dark-git-red:                   #D03A6F;
 @git-red-text:                   #F74687;
 @git-blue-text:                  #1976DD;
 @git-dark-blue-text:             #51c0ff;
 @git-orange:                     #E3B551;
+@dark-git-orange:                #C29844;
 @git-orange-text:                #e28200;
 
 // Diff colors ('d' for 'dark', `l` for "light")
@@ -291,41 +294,58 @@
 
 .CodeMirror {
     .brackets-git-gutter {
+        pointer-events: auto;
         width: @gutterWidth;
-        margin-left: 1px;
     }
     .brackets-git-gutter-added,
     .brackets-git-gutter-modified,
     .brackets-git-gutter-removed {
+        pointer-events: auto;
         background-size: @gutterWidth @gutterWidth;
         background-repeat: no-repeat;
-        font-size: 1em;
-        font-weight: bold;
         color: @bc-menu-bg;
 
+        border-left: 0.4em solid transparent;
+        transition: border-left-width 0.2s ease;
         .dark & {
             color: @dark-bc-menu-bg;
+            border-left-width: 0.3em;
         }
     }
     .brackets-git-gutter-added {
-        background-color: @git-green;
+        border-left-color: @git-green;
+        .dark & {
+            border-left-color: @dark-git-green;
+        }
     }
 
     .brackets-git-gutter-modified {
-        background-color: @git-orange;
+        border-left-color: @git-orange;
+        &:hover {
+            border-left-width: 2em;
+        }
+        .dark & {
+            border-left-color: @dark-git-orange;
+        }
     }
 
     .brackets-git-gutter-removed {
-        background-color: @git-red;
+        border-left-color: @git-red;
+        &:hover {
+            border-left-width: 2em;
+        }
+        .dark & {
+            border-left-color: @dark-git-red;
+        }
     }
 
     .brackets-git-gutter-deleted-lines {
         color: @bc-text;
-        background-color: lighten(@git-red, 25%);
+        border-left-color: lighten(@git-red, 25%);
         .selectable-text();
 
         .dark & {
-            background-color: darken(@git-red, 25%);
+            border-left-color: darken(@dark-git-red, 25%);
             color: @dark-bc-text;
         }
 
@@ -337,6 +357,10 @@
             padding: 1px;
             height: 1.2em;
             line-height: 0.5em;
+        }
+
+        &:hover {
+            border-left-width: 1em;
         }
     }
 }
@@ -814,7 +838,7 @@
 
 // main
 
-@gutterWidth: 0.65em; // using ems so that it'll be scalable on cmd +/-
+@gutterWidth: 1em; // using ems so that it'll be scalable on cmd +/-
 
 #editor-holder {
     .git.spinner {

--- a/src/extensions/default/Git/styles/git-styles.less
+++ b/src/extensions/default/Git/styles/git-styles.less
@@ -613,7 +613,6 @@
         }
         .commitBody {
             padding: 0 30px;
-            user-select: text;
         }
         .commit-files {
             padding: 0 20px;

--- a/src/extensions/default/Git/styles/git-styles.less
+++ b/src/extensions/default/Git/styles/git-styles.less
@@ -613,6 +613,7 @@
         }
         .commitBody {
             padding: 0 30px;
+            user-select: text;
         }
         .commit-files {
             padding: 0 20px;

--- a/src/extensions/default/Git/templates/history-viewer.html
+++ b/src/extensions/default/Git/templates/history-viewer.html
@@ -33,7 +33,7 @@
         </div>
     </div>
     <div class="body">
-        <div class="commitBody">{{{bodyMarkdown}}}</div>
+        <div class="commitBody selectable-text">{{{bodyMarkdown}}}</div>
         <div class="table-striped tab-content">
             <div class="commit-files">
                 <ul class="nav nav-tabs nav-stacked filesContainer"></ul>


### PR DESCRIPTION
This was caused by fractional .7em rendering of git gutter. The css pixel approximation will hide
the 1px cursor line in certain window widths, so we should not use fractional em in the gutter.
if was to use a 1em gutter and set a fractional em inset border so that gutter width not fractional

also added hover style so that when user hovers over 1em gutter, it expands to 2 em to have
the user not work with needle threading precision to click git gutter. the green git-added-lines
gutter will not expand as there is currently no action associated with it.