### PR TITLE
fix: file recovery not working if file has comma in it. don't save not be treated as crash, new project dialog size change

### DIFF
--- a/src/extensionsIntegrated/NavigationAndHistory/FileRecovery.js
+++ b/src/extensionsIntegrated/NavigationAndHistory/FileRecovery.js
@@ -162,20 +162,25 @@ define(function (require, exports, module) {
         if(!input){
             return null;
         }
-        const parts = input.split(',', 2);
+        // Find the first comma
+        const firstCommaIndex = input.indexOf(',');
 
-        if (parts.length !== 2) {
+        // If there's no comma or it's at the very beginning, the input is invalid
+        if (firstCommaIndex === -1 || firstCommaIndex === 0) {
             return null;
         }
 
+        // Extract the parts
+        const expectedLengthPart = input.slice(0, firstCommaIndex);
+        const actualString = input.slice(firstCommaIndex + 1);
+
         // Parse the length part (should be the first part before the comma)
-        const expectedLength = parseInt(parts[0], 10);
+        const expectedLength = parseInt(expectedLengthPart, 10);
         if (isNaN(expectedLength)) {
             return null;
         }
 
-        // The second part is the actual string after the comma
-        const actualString = parts[1];
+        // The second part is the actual string after the commas
         if (actualString.length === expectedLength) {
             return actualString;
         }
@@ -471,6 +476,14 @@ define(function (require, exports, module) {
             // for the startup project. So we call manually.
             projectOpened(null, currentProjectRoot);
         }
+        ProjectManager.on("beforeAppClose", (_evt, waitPromises)=>{
+            // this is a safe exit, we should delete all restore data.
+            let exitProjectRoot = ProjectManager.getProjectRoot();
+            if(exitProjectRoot) {
+                const restoreRoot = getProjectRestoreRoot(exitProjectRoot.fullPath);
+                waitPromises.push(silentlyRemoveDirectory(restoreRoot));
+            }
+        });
     }
 
     function init() {

--- a/src/extensionsIntegrated/Phoenix/html/new-project-template.html
+++ b/src/extensionsIntegrated/Phoenix/html/new-project-template.html
@@ -1,4 +1,4 @@
-<div class="modal" style="background-color:#3C3F41; width:min(50%, 850px); height: 570px; display: flex; flex-direction: column; justify-content: space-between">
+<div class="modal new-project-modal-dialog">
     <iframe title="New Project" id="newProjectFrame" width="100%" height="100%"
             src={{newProjectURL}} style="border: 0px;visibility:hidden;" onload="this.style.visibility = 'visible';">
     </iframe>

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -3548,3 +3548,12 @@ label input {
         opacity: 1;
     }
 }
+
+.new-project-modal-dialog{
+    background-color:#3C3F41;
+    width: 750px;
+    height: 570px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between
+}

--- a/test/spec/Extn-NavigationAndHistory-integ-test.js
+++ b/test/spec/Extn-NavigationAndHistory-integ-test.js
@@ -33,7 +33,6 @@ define(function (require, exports, module) {
         const tempRestorePath = SpecRunnerUtils.getTestRoot() + "/navigationTestsRestore/";
 
         let FileViewController,     // loaded from brackets.test
-            ProjectManager,         // loaded from brackets.test;
             CommandManager,
             Commands,
             testWindow,
@@ -57,7 +56,6 @@ define(function (require, exports, module) {
             brackets            = testWindow.brackets;
             $                   = testWindow.$;
             FileViewController  = brackets.test.FileViewController;
-            ProjectManager      = brackets.test.ProjectManager;
             CommandManager      = brackets.test.CommandManager;
             Commands            = brackets.test.Commands;
             EditorManager       = brackets.test.EditorManager;
@@ -76,7 +74,6 @@ define(function (require, exports, module) {
 
         afterAll(async function () {
             FileViewController  = null;
-            ProjectManager      = null;
             testWindow = null;
             brackets = null;
             await deletePath(testPath);
@@ -124,13 +121,16 @@ define(function (require, exports, module) {
 
         }
 
+        // multiple , in file tested as we have , for `size,"content"` integrity checks
+        const unsavedTextFragment = "hello,this is ,a test";
+
         it("Should create restore folders and backup files", async function () {
             await initFileRestorer("file.js");
             let projectRestorePath = testWindow._FileRecoveryExtensionForTests.getProjectRestoreRoot(testPath);
 
             // now edit a file so that its backup is created
             let editor = EditorManager.getActiveEditor();
-            editor.document.setText("hello");
+            editor.document.setText(unsavedTextFragment);
             await SpecRunnerUtils.waitTillPathExists(projectRestorePath.fullPath, true);
             await SpecRunnerUtils.waitTillPathExists(projectRestorePath.fullPath + "file.js", false);
             await closeSession();
@@ -142,7 +142,7 @@ define(function (require, exports, module) {
 
             // now edit a file so that its backup is created
             let editor = EditorManager.getActiveEditor();
-            editor.document.setText("hello");
+            editor.document.setText(unsavedTextFragment);
             await SpecRunnerUtils.waitTillPathExists(projectRestorePath.fullPath + "toDelete1/file.js", false);
             await awaitsForDone(CommandManager.execute(Commands.FILE_SAVE_ALL), "saving all file");
             await SpecRunnerUtils.waitTillPathNotExists(projectRestorePath.fullPath + "toDelete1/file.js", false);
@@ -154,7 +154,7 @@ define(function (require, exports, module) {
             let projectRestorePath = testWindow._FileRecoveryExtensionForTests.getProjectRestoreRoot(testPath);
 
             // now edit a file so that its backup is created
-            const unsavedText = "hello" + Math.random();
+            const unsavedText = unsavedTextFragment + Math.random();
             let editor = EditorManager.getActiveEditor();
             editor.document.setText(unsavedText);
             await SpecRunnerUtils.waitTillPathExists(projectRestorePath.fullPath + "toDelete1/file.js", false);
@@ -186,7 +186,7 @@ define(function (require, exports, module) {
             let projectRestorePath = testWindow._FileRecoveryExtensionForTests.getProjectRestoreRoot(testPath);
 
             // now edit a file so that its backup is created
-            const unsavedText = "hello" + Math.random();
+            const unsavedText = unsavedTextFragment + Math.random();
             let editor = EditorManager.getActiveEditor();
             editor.document.setText(unsavedText);
             await SpecRunnerUtils.waitTillPathExists(projectRestorePath.fullPath + fileNameToRestore, false);
@@ -343,7 +343,7 @@ define(function (require, exports, module) {
             await openFile(file3);
             await _expectNavButton(false, true, "nav forward disabled due to new file open");
         }
-        
+
         it("Should navigate back and forward between text files", async function () {
             await navigateResetStack();
             await _validateNavForFiles("test.css", "test.html", "test.js");


### PR DESCRIPTION
Following changes are done to file recovery logix:

1. We should not show file recovery dialog if the user selected dont save in when exiting phcode
2. Our integrity checks saves the file as `checksum,filecontent`. but if file content itself has a comma, our logic used to break due to improper `string.split(",")` usage

### other changes
Defaulting to bigger size for new project dialog for small screens for better UX. The dialog is no longer re-sizable and gives the same ui experience in all screen sizes.
![image](https://github.com/user-attachments/assets/2bee2426-752a-4f8d-a72c-10330e64b67e)

