### PR TITLE
fix: bugsnag errors in git workflows due to race conditions

### DIFF
--- a/src/extensions/default/Git/src/Branch.js
+++ b/src/extensions/default/Git/src/Branch.js
@@ -128,6 +128,11 @@ define(function (require, exports) {
                     }
                 }
             });
+        }).catch(err => {
+            console.error("Error Getting branches", err);
+            // we need to strip all user entered info from git thrown exception for get branches which shouldn't fail,
+            // so we throw a blank error for bugsnag
+            throw new Error("Failed to get getBranches while doMerge");
         });
     }
 
@@ -168,7 +173,7 @@ define(function (require, exports) {
 
             Git.getAllBranches().catch(function (err) {
                 ErrorHandler.showError(err);
-            }).then(function (branches) {
+            }).then(function (branches = []) {
 
                 var compiledTemplate = Mustache.render(newBranchTemplate, {
                     branches: branches,
@@ -335,7 +340,7 @@ define(function (require, exports) {
 
         Git.getBranches().catch(function (err) {
             ErrorHandler.showError(err, Strings.ERROR_GETTING_BRANCH_LIST);
-        }).then(function (branches) {
+        }).then(function (branches = []) {
             branches = branches.reduce(function (arr, branch) {
                 if (!branch.currentBranch && !branch.remote) {
                     arr.push(branch.name);

--- a/src/extensions/default/Git/src/dialogs/Pull.js
+++ b/src/extensions/default/Git/src/dialogs/Pull.js
@@ -1,16 +1,16 @@
 define(function (require, exports) {
 
     // Brackets modules
-    var Dialogs = brackets.getModule("widgets/Dialogs"),
+    const Dialogs = brackets.getModule("widgets/Dialogs"),
         Mustache = brackets.getModule("thirdparty/mustache/mustache");
 
     // Local modules
-    var Preferences     = require("src/Preferences"),
+    const Preferences     = require("src/Preferences"),
         RemoteCommon    = require("src/dialogs/RemoteCommon"),
         Strings         = brackets.getModule("strings");
 
     // Templates
-    var template            = require("text!src/dialogs/templates/pull-dialog.html"),
+    const template            = require("text!src/dialogs/templates/pull-dialog.html"),
         remotesTemplate     = require("text!src/dialogs/templates/remotes-template.html");
 
     // Implementation
@@ -54,6 +54,7 @@ define(function (require, exports) {
     function show(pullConfig) {
         return new Promise((resolve, reject) => {
             pullConfig.pull = true;
+            // collectInfo never rejects
             RemoteCommon.collectInfo(pullConfig).then(()=>{
                 _show(pullConfig, resolve, reject);
             });

--- a/src/extensions/default/Git/src/dialogs/Push.js
+++ b/src/extensions/default/Git/src/dialogs/Push.js
@@ -52,6 +52,7 @@ define(function (require, exports) {
     function show(pushConfig) {
         return new Promise((resolve, reject) => {
             pushConfig.push = true;
+            // collectInfo never rejects
             RemoteCommon.collectInfo(pushConfig).then(()=>{
                 _show(pushConfig, resolve, reject);
             });

--- a/src/extensions/default/Git/src/dialogs/RemoteCommon.js
+++ b/src/extensions/default/Git/src/dialogs/RemoteCommon.js
@@ -28,6 +28,7 @@ define(function (require, exports) {
         });
     }
 
+    // this should never reject for now, just show error message and bail out
     exports.collectInfo = function (config) {
         return Git.getCurrentUpstreamBranch().then(function (upstreamBranch) {
             config.currentTrackingBranch = upstreamBranch;

--- a/src/loggerSetup.js
+++ b/src/loggerSetup.js
@@ -18,7 +18,7 @@
  *
  */
 
-/*globals Bugsnag, AppConfig, Phoenix*/
+/*globals Bugsnag, AppConfig*/
 // window.AppConfig comes from appConfig.js built by gulp scripts at build time
 
 (function(){
@@ -32,7 +32,7 @@
         "https://dev.phcode.dev", // dev url
         "https://staging.phcode.dev" // staging url
     ];
-    let isBugsnagLoggableURL = false;
+    let isBugsnagLoggableURL = false; // to test bugsnag in dev builds, set this to true
     for(let loggableURL of loggableURLS){
         if(window.location.href.startsWith(loggableURL)){
             isBugsnagLoggableURL = true;

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -1529,6 +1529,7 @@ define({
     "ERROR_NO_REMOTE_SELECTED": "No remote has been selected for {0}!",
     "ERROR_BRANCH_LIST": "Getting branch list failed",
     "ERROR_FETCH_REMOTE": "Fetching remote information failed",
+    "ERROR_PREPARING_COMMIT_DIALOG": "Preparing commit dialog failed",
     "GIT_TOAST_TITLE": "Explore Git Features in Phoenix Code",
     "GIT_TOAST_MESSAGE": "Click the Git panel icon to manage your repository. Easily commit, push, pull, and view your project history—all in one place.<br><a href='https://docs.phcode.dev/docs/Features/git'>Learn more about the Git panel →</a>",
 


### PR DESCRIPTION
The catch block was attached after a delay in some cases and errors before attaching the catch block in progress dialog used to get treated as uncaught exceptions and get logged in bugsnag fixed by modifying the timing chain and have a catch handler attached to promise at first itself.
