### PR TITLE
fix: indent guides causes 1px drift in word wrapped lines

### DIFF
--- a/src/extensionsIntegrated/indentGuides/main.js
+++ b/src/extensionsIntegrated/indentGuides/main.js
@@ -136,6 +136,7 @@ define(function (require, exports, module) {
         } else if (shouldRerender || cm.__overlayEnabled !== enabled) {
             cm.__overlayEnabled = enabled;
             _reRenderOverlay();
+            // rare event, should not happen often. log if we are debugging performance related issues.
             console.log("Refreshing indent guides");
         }
     }

--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -293,16 +293,14 @@ span.cm-emstrong {
 
 .cm-phcode-indent-guides::before {
     content: " ";
-    width: 1px;
     display: inline-block;
-    position: relative;
-    border-left: 1px solid rgba(128, 128, 128, 0.3);
+    position: absolute;
+    box-shadow: inset 1px 0 0 rgba(128, 128, 128, 0.3);
 }
 
 .cm-phcode-indent-guides-none::before {
     content: " ";
-    width: 1px;
     display: inline-block;
-    position: relative;
-    border-left: 1px solid transparent;
+    position: absolute;
+    box-shadow: none;
 }


### PR DESCRIPTION
Users reported that deeply indented HTML elements caused misalignment between the text inside elements and their corresponding tags. The issue worsened as indentation depth increased, resulting in a noticeable shift of approximately **one or two spaces** at deep indentation levels.

#### **Closes**
Fixes https://github.com/orgs/phcode-dev/discussions/2108

#### **Root Cause**
Previously, the `.cm-phcode-indent-guides::before` selector was used to create indent guides via a `border-left`:
```css
.cm-phcode-indent-guides::before {
    content: " ";
    width: 1px;
    display: inline-block;
    position: relative;
    border-left: 1px solid rgba(128, 128, 128, 0.3);
}
```
However, this approach **added a 1px tax per indentation level**, meaning that each additional indent slightly shifted the text outward. The cumulative effect of this offset became more noticeable with deeper indentation.

#### **Fix**
Replaced the `border-left` approach with an **inset `box-shadow`**, which does not affect inline layout calculations but still visually maintains the indentation guides:
```css
.cm-phcode-indent-guides {
    box-shadow: inset 1px 0 0 rgba(128, 128, 128, 0.3);
}
```
This ensures:
- No extra **inline width tax** per indentation level.
- The indentation guides remain **visually identical**.
- The text inside elements **remains properly aligned** regardless of depth.

#### **Testing**
- Verified that indentation **no longer misaligns text** at deep levels.
- Ensured **indent guides still render correctly**.
- Checked that **line wrapping behavior** remains unaffected.
- Since this is a css change for visual verification, automated tests not written as not possible, except maybe with ai image recognition in the future.
