### PR TITLE
build: add emmet into thirdparty libs. `Phoenix.libs.Emmet.expand` and `Phoenix.libs.Emmet.module`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ src/phoenix/virtualfs.js.map
 # Thirdparty libs
 !/src/thirdparty/licences
 /src/thirdparty/less.*
+/src/thirdparty/emmet.*
 /src/thirdparty/CodeMirror
 /src/thirdparty/acorn
 /src/thirdparty/tern

--- a/docs/API-Reference/widgets/NotificationUI.md
+++ b/docs/API-Reference/widgets/NotificationUI.md
@@ -48,7 +48,7 @@ The `createFromTemplate` API can be configured with numerous options. See API op
     * [.API](#module_widgets/NotificationUI..API)
     * [.NOTIFICATION_STYLES_CSS_CLASS](#module_widgets/NotificationUI..NOTIFICATION_STYLES_CSS_CLASS) : <code>enum</code>
     * [.CLOSE_REASON](#module_widgets/NotificationUI..CLOSE_REASON) : <code>enum</code>
-    * [.createFromTemplate(template, [elementID], [options])](#module_widgets/NotificationUI..createFromTemplate) ⇒ <code>Notification</code>
+    * [.createFromTemplate(title, template, [elementID], [options])](#module_widgets/NotificationUI..createFromTemplate) ⇒ <code>Notification</code>
     * [.createToastFromTemplate(title, template, [options])](#module_widgets/NotificationUI..createToastFromTemplate) ⇒ <code>Notification</code>
 
 <a name="module_widgets/NotificationUI..API"></a>
@@ -89,15 +89,16 @@ Closing notification reason.
 
 <a name="module_widgets/NotificationUI..createFromTemplate"></a>
 
-### widgets/NotificationUI.createFromTemplate(template, [elementID], [options]) ⇒ <code>Notification</code>
+### widgets/NotificationUI.createFromTemplate(title, template, [elementID], [options]) ⇒ <code>Notification</code>
 Creates a new notification popup from given template.
 The template can either be a string or a jQuery object representing a DOM node that is *not* in the current DOM.
 
 Creating a notification popup
+
+```js
 // note that you can even provide an HTML Element node with
 // custom event handlers directly here instead of HTML text.
 let notification1 = NotificationUI.createFromTemplate(
-```js
   "<div>Click me to locate the file in file tree</div>", "showInfileTree",{
       allowedPlacements: ['top', 'bottom'],
       dismissOnClick: false,
@@ -110,9 +111,10 @@ let notification1 = NotificationUI.createFromTemplate(
 
 | Param | Type | Description |
 | --- | --- | --- |
+| title | <code>string</code> | The title for the notification. |
 | template | <code>string</code> \| <code>Element</code> | A string template or HTML Element to use as the dialog HTML. |
 | [elementID] | <code>String</code> | optional id string if provided will show the notification pointing to the element.   If no element is specified, it will be managed as a generic notification. |
-| [options] | <code>Object</code> | optional, supported   * options are:   * `allowedPlacements` - Optional String array with values restricting where the notification will be shown.       Values can be a mix of `['top', 'bottom', 'left', 'right']`   * `autoCloseTimeS` - Time in seconds after which the notification should be auto closed. Default is never.   * `dismissOnClick` - when clicked, the notification is closed. Default is true(dismiss). |
+| [options] | <code>Object</code> | optional, supported   * options are:   * `allowedPlacements` - Optional String array with values restricting where the notification will be shown.       Values can be a mix of `['top', 'bottom', 'left', 'right']`   * `autoCloseTimeS` - Time in seconds after which the notification should be auto closed. Default is never.   * `dismissOnClick` - when clicked, the notification is closed. Default is true(dismiss).   * `toastStyle` - To style the toast notification for error, warning, info etc. Can be     one of `NotificationUI.NOTIFICATION_STYLES_CSS_CLASS.*` or your own css class name. |
 
 <a name="module_widgets/NotificationUI..createToastFromTemplate"></a>
 
@@ -121,10 +123,11 @@ Creates a new toast notification popup from given title and html message.
 The message can either be a string or a jQuery object representing a DOM node that is *not* in the current DOM.
 
 Creating a toast notification popup
+
+```js
 // note that you can even provide an HTML Element node with
 // custom event handlers directly here instead of HTML text.
 let notification1 = NotificationUI.createToastFromTemplate( "Title here",
-```js
   "<div>Click me to locate the file in file tree</div>", {
       dismissOnClick: false,
       autoCloseTimeS: 300 // auto close the popup after 5 minutes
@@ -138,5 +141,5 @@ let notification1 = NotificationUI.createToastFromTemplate( "Title here",
 | --- | --- | --- |
 | title | <code>string</code> | The title for the notification. |
 | template | <code>string</code> \| <code>Element</code> | A string template or HTML Element to use as the dialog HTML. |
-| [options] | <code>Object</code> | optional, supported   * options are:   * `autoCloseTimeS` - Time in seconds after which the notification should be auto closed. Default is never.   * `dismissOnClick` - when clicked, the notification is closed. Default is true(dismiss).   * `toastStyle` - To style the toast notification for error, warning, info etc. Can be     one of `NotificationUI.NOTIFICATION_STYLES_CSS_CLASS.*` or your own css class name. |
+| [options] | <code>Object</code> | optional, supported   * options are:   * `autoCloseTimeS` - Time in seconds after which the notification should be auto closed. Default is never.   * `dismissOnClick` - when clicked, the notification is closed. Default is true(dismiss).   * `toastStyle` - To style the toast notification for error, warning, info etc. Can be     one of `NotificationUI.NOTIFICATION_STYLES_CSS_CLASS.*` or your own css class name.   * `instantOpen` - To instantly open the popup without any open animation delays |
 

--- a/gulpfile.js/thirdparty-lib-copy.js
+++ b/gulpfile.js/thirdparty-lib-copy.js
@@ -114,6 +114,10 @@ let copyThirdPartyLibs = series(
     // lessjs
     copyFiles.bind(copyFiles, ['node_modules/less/dist/less.min.js', 'node_modules/less/dist/less.min.js.map'],
         'src/thirdparty'),
+    // emmet
+    copyFiles.bind(copyFiles, ['node_modules/emmet/dist/emmet.es.js'],
+        'src/thirdparty'),
+    copyLicence.bind(copyLicence, 'node_modules/emmet/LICENSE', 'emmet'),
     // bugsnag
     copyFiles.bind(copyFiles, ['node_modules/@bugsnag/browser/dist/bugsnag.min.js',
         'node_modules/@bugsnag/browser/dist/bugsnag.min.js.map'], 'src/thirdparty'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "phoenix",
-    "version": "4.0.0-0",
+    "version": "4.1.0-0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "phoenix",
-            "version": "4.0.0-0",
+            "version": "4.1.0-0",
             "dependencies": {
                 "@bugsnag/js": "^7.18.0",
                 "@floating-ui/dom": "^0.5.4",
@@ -22,6 +22,7 @@
                 "codemirror": "^5.65.16",
                 "cross-env": "^7.0.3",
                 "devicon": "^2.15.1",
+                "emmet": "^2.4.11",
                 "file-saver": "^2.0.5",
                 "idb-keyval": "^6.2.1",
                 "jshint": "^2.13.5",
@@ -41,7 +42,6 @@
             "devDependencies": {
                 "@commitlint/cli": "^16.0.2",
                 "@commitlint/config-conventional": "^16.0.0",
-                "@google-cloud/translate": "^7.0.3",
                 "@playwright/test": "^1.38.1",
                 "del": "^6.0.0",
                 "eslint": "^8.18.0",
@@ -595,6 +595,27 @@
                 "node": ">=12"
             }
         },
+        "node_modules/@emmetio/abbreviation": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.3.3.tgz",
+            "integrity": "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==",
+            "dependencies": {
+                "@emmetio/scanner": "^1.0.4"
+            }
+        },
+        "node_modules/@emmetio/css-abbreviation": {
+            "version": "2.1.8",
+            "resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.8.tgz",
+            "integrity": "sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw==",
+            "dependencies": {
+                "@emmetio/scanner": "^1.0.4"
+            }
+        },
+        "node_modules/@emmetio/scanner": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.4.tgz",
+            "integrity": "sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA=="
+        },
         "node_modules/@eslint/eslintrc": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
@@ -653,232 +674,6 @@
             "hasInstallScript": true,
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/@google-cloud/common": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-4.0.2.tgz",
-            "integrity": "sha512-LgUoPQq1CNzMAtqnIJLetj7hlzZUS+CG9mBuZthqek6+eGu3PsH2IuEbbtLSUgPZNgOgi/fWGWpbNPP7wgjF0A==",
-            "dev": true,
-            "dependencies": {
-                "@google-cloud/projectify": "^3.0.0",
-                "@google-cloud/promisify": "^3.0.0",
-                "arrify": "^2.0.1",
-                "duplexify": "^4.1.1",
-                "ent": "^2.2.0",
-                "extend": "^3.0.2",
-                "google-auth-library": "^8.0.2",
-                "retry-request": "^5.0.0",
-                "teeny-request": "^8.0.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@google-cloud/common/node_modules/arrify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-            "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@google-cloud/common/node_modules/duplexify": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
-            "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
-            "dev": true,
-            "dependencies": {
-                "end-of-stream": "^1.4.1",
-                "inherits": "^2.0.3",
-                "readable-stream": "^3.1.1",
-                "stream-shift": "^1.0.0"
-            }
-        },
-        "node_modules/@google-cloud/projectify": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-3.0.0.tgz",
-            "integrity": "sha512-HRkZsNmjScY6Li8/kb70wjGlDDyLkVk3KvoEo9uIoxSjYLJasGiCch9+PqRVDOCGUFvEIqyogl+BeqILL4OJHA==",
-            "dev": true,
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@google-cloud/promisify": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-3.0.1.tgz",
-            "integrity": "sha512-z1CjRjtQyBOYL+5Qr9DdYIfrdLBe746jRTYfaYU6MeXkqp7UfYs/jX16lFFVzZ7PGEJvqZNqYUEtb1mvDww4pA==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@google-cloud/translate": {
-            "version": "7.2.2",
-            "resolved": "https://registry.npmjs.org/@google-cloud/translate/-/translate-7.2.2.tgz",
-            "integrity": "sha512-IAJhPKotLH/OF/NzWml/byLDN+OILbs1P4k+7HNUJK618NsShFelRKzh3pRUUQA4DX0je3HaEZw9nR+5uJ6ZEg==",
-            "dev": true,
-            "dependencies": {
-                "@google-cloud/common": "^4.0.0",
-                "@google-cloud/promisify": "^3.0.0",
-                "arrify": "^2.0.0",
-                "extend": "^3.0.2",
-                "google-gax": "^3.5.8",
-                "is-html": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@google-cloud/translate/node_modules/arrify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-            "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@grpc/grpc-js": {
-            "version": "1.8.22",
-            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.22.tgz",
-            "integrity": "sha512-oAjDdN7fzbUi+4hZjKG96MR6KTEubAeMpQEb+77qy+3r0Ua5xTFuie6JOLr4ZZgl5g+W5/uRTS2M1V8mVAFPuA==",
-            "dev": true,
-            "dependencies": {
-                "@grpc/proto-loader": "^0.7.0",
-                "@types/node": ">=12.12.47"
-            },
-            "engines": {
-                "node": "^8.13.0 || >=10.10.0"
-            }
-        },
-        "node_modules/@grpc/proto-loader": {
-            "version": "0.7.8",
-            "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.8.tgz",
-            "integrity": "sha512-GU12e2c8dmdXb7XUlOgYWZ2o2i+z9/VeACkxTA/zzAe2IjclC5PnVL0lpgjhrqfpDYHzM8B1TF6pqWegMYAzlA==",
-            "dev": true,
-            "dependencies": {
-                "@types/long": "^4.0.1",
-                "lodash.camelcase": "^4.3.0",
-                "long": "^4.0.0",
-                "protobufjs": "^7.2.4",
-                "yargs": "^17.7.2"
-            },
-            "bin": {
-                "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/@grpc/proto-loader/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/@grpc/proto-loader/node_modules/cliui": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-            "dev": true,
-            "dependencies": {
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.1",
-                "wrap-ansi": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@grpc/proto-loader/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/@grpc/proto-loader/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
-        },
-        "node_modules/@grpc/proto-loader/node_modules/get-caller-file": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-            "dev": true,
-            "engines": {
-                "node": "6.* || 8.* || >= 10.*"
-            }
-        },
-        "node_modules/@grpc/proto-loader/node_modules/wrap-ansi": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
-        "node_modules/@grpc/proto-loader/node_modules/y18n": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@grpc/proto-loader/node_modules/yargs": {
-            "version": "17.7.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-            "dev": true,
-            "dependencies": {
-                "cliui": "^8.0.1",
-                "escalade": "^3.1.1",
-                "get-caller-file": "^2.0.5",
-                "require-directory": "^2.1.1",
-                "string-width": "^4.2.3",
-                "y18n": "^5.0.5",
-                "yargs-parser": "^21.1.1"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@grpc/proto-loader/node_modules/yargs-parser": {
-            "version": "21.1.1",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
             }
         },
         "node_modules/@gulp-sourcemaps/identity-map": {
@@ -1252,79 +1047,6 @@
                 "prettier": "^3.0.0"
             }
         },
-        "node_modules/@protobufjs/aspromise": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-            "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-            "dev": true
-        },
-        "node_modules/@protobufjs/base64": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-            "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-            "dev": true
-        },
-        "node_modules/@protobufjs/codegen": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-            "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-            "dev": true
-        },
-        "node_modules/@protobufjs/eventemitter": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-            "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-            "dev": true
-        },
-        "node_modules/@protobufjs/fetch": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-            "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-            "dev": true,
-            "dependencies": {
-                "@protobufjs/aspromise": "^1.1.1",
-                "@protobufjs/inquire": "^1.1.0"
-            }
-        },
-        "node_modules/@protobufjs/float": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-            "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-            "dev": true
-        },
-        "node_modules/@protobufjs/inquire": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-            "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
-            "dev": true
-        },
-        "node_modules/@protobufjs/path": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-            "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-            "dev": true
-        },
-        "node_modules/@protobufjs/pool": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-            "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-            "dev": true
-        },
-        "node_modules/@protobufjs/utf8": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-            "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
-            "dev": true
-        },
-        "node_modules/@tootallnate/once": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-            "dev": true,
-            "engines": {
-                "node": ">= 10"
-            }
-        },
         "node_modules/@tsconfig/node10": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -1349,26 +1071,10 @@
             "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
             "dev": true
         },
-        "node_modules/@types/glob": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
-            "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
-            "dev": true,
-            "dependencies": {
-                "@types/minimatch": "^5.1.2",
-                "@types/node": "*"
-            }
-        },
         "node_modules/@types/linkify-it": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
             "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-            "dev": true
-        },
-        "node_modules/@types/long": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-            "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
             "dev": true
         },
         "node_modules/@types/markdown-it": {
@@ -1385,12 +1091,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
             "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
-            "dev": true
-        },
-        "node_modules/@types/minimatch": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
-            "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
             "dev": true
         },
         "node_modules/@types/minimist": {
@@ -1417,16 +1117,6 @@
             "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
             "dev": true
         },
-        "node_modules/@types/rimraf": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.2.tgz",
-            "integrity": "sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==",
-            "dev": true,
-            "dependencies": {
-                "@types/glob": "*",
-                "@types/node": "*"
-            }
-        },
         "node_modules/@uiw/file-icons": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/@uiw/file-icons/-/file-icons-1.3.2.tgz",
@@ -1439,18 +1129,6 @@
             "dev": true,
             "engines": {
                 "node": ">=10.0.0"
-            }
-        },
-        "node_modules/abort-controller": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-            "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-            "dev": true,
-            "dependencies": {
-                "event-target-shim": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=6.5"
             }
         },
         "node_modules/accepts": {
@@ -1519,18 +1197,6 @@
             },
             "engines": {
                 "node": ">=0.4.0"
-            }
-        },
-        "node_modules/agent-base": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-            "dev": true,
-            "dependencies": {
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6.0.0"
             }
         },
         "node_modules/aggregate-error": {
@@ -2178,26 +1844,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/base64-js": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ]
-        },
         "node_modules/basic-auth": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
@@ -2215,15 +1861,6 @@
             "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
             "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
             "dev": true
-        },
-        "node_modules/bignumber.js": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz",
-            "integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==",
-            "dev": true,
-            "engines": {
-                "node": "*"
-            }
         },
         "node_modules/binary-extensions": {
             "version": "1.13.1",
@@ -2367,12 +2004,6 @@
             "engines": {
                 "node": ">=0.4.0"
             }
-        },
-        "node_modules/buffer-equal-constant-time": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-            "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-            "dev": true
         },
         "node_modules/buffer-from": {
             "version": "1.1.2",
@@ -4392,15 +4023,6 @@
                 "object.defaults": "^1.1.0"
             }
         },
-        "node_modules/ecdsa-sig-formatter": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-            "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-            "dev": true,
-            "dependencies": {
-                "safe-buffer": "^5.0.1"
-            }
-        },
         "node_modules/ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -4412,6 +4034,21 @@
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.103.tgz",
             "integrity": "sha512-c/uKWR1Z/W30Wy/sx3dkZoj4BijbXX85QKWu9jJfjho3LBAXNEGAEW3oWiGb+dotA6C6BzCTxL2/aLes7jlUeg==",
             "dev": true
+        },
+        "node_modules/emmet": {
+            "version": "2.4.11",
+            "resolved": "https://registry.npmjs.org/emmet/-/emmet-2.4.11.tgz",
+            "integrity": "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==",
+            "workspaces": [
+                "./packages/scanner",
+                "./packages/abbreviation",
+                "./packages/css-abbreviation",
+                "./"
+            ],
+            "dependencies": {
+                "@emmetio/abbreviation": "^2.3.3",
+                "@emmetio/css-abbreviation": "^2.1.8"
+            }
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
@@ -4449,12 +4086,6 @@
             "engines": {
                 "node": ">=0.6"
             }
-        },
-        "node_modules/ent": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
-            "integrity": "sha512-GHrMyVZQWvTIdDtpiEXdHZnFQKzeO09apj8Cbl4pKWy4i0Oprcq17usfDt5aO63swf0JOeMWjWQE/LzgSRuWpA==",
-            "dev": true
         },
         "node_modules/entities": {
             "version": "1.0.0",
@@ -4563,98 +4194,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/escodegen": {
-            "version": "1.14.3",
-            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-            "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
-            "dev": true,
-            "dependencies": {
-                "esprima": "^4.0.1",
-                "estraverse": "^4.2.0",
-                "esutils": "^2.0.2",
-                "optionator": "^0.8.1"
-            },
-            "bin": {
-                "escodegen": "bin/escodegen.js",
-                "esgenerate": "bin/esgenerate.js"
-            },
-            "engines": {
-                "node": ">=4.0"
-            },
-            "optionalDependencies": {
-                "source-map": "~0.6.1"
-            }
-        },
-        "node_modules/escodegen/node_modules/estraverse": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-            "dev": true,
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
-        "node_modules/escodegen/node_modules/levn": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-            "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-            "dev": true,
-            "dependencies": {
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/escodegen/node_modules/optionator": {
-            "version": "0.8.3",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-            "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-            "dev": true,
-            "dependencies": {
-                "deep-is": "~0.1.3",
-                "fast-levenshtein": "~2.0.6",
-                "levn": "~0.3.0",
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2",
-                "word-wrap": "~1.2.3"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/escodegen/node_modules/prelude-ls": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-            "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/escodegen/node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
-            "optional": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/escodegen/node_modules/type-check": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-            "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-            "dev": true,
-            "dependencies": {
-                "prelude-ls": "~1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
             }
         },
         "node_modules/eslint": {
@@ -4823,19 +4362,6 @@
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
-        "node_modules/esprima": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "dev": true,
-            "bin": {
-                "esparse": "bin/esparse.js",
-                "esvalidate": "bin/esvalidate.js"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/esquery": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
@@ -4910,15 +4436,6 @@
                 "split": "^1.0.1",
                 "stream-combiner": "^0.2.2",
                 "through": "^2.3.8"
-            }
-        },
-        "node_modules/event-target-shim": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-            "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/eventemitter3": {
@@ -5213,12 +4730,6 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-            "dev": true
-        },
-        "node_modules/fast-text-encoding": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
-            "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==",
             "dev": true
         },
         "node_modules/fastq": {
@@ -5734,54 +5245,6 @@
             "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
             "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
             "dev": true
-        },
-        "node_modules/gaxios": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.0.1.tgz",
-            "integrity": "sha512-keK47BGKHyyOVQxgcUaSaFvr3ehZYAlvhvpHXy0YB2itzZef+GqZR8TBsfVRWghdwlKrYsn+8L8i3eblF7Oviw==",
-            "dev": true,
-            "dependencies": {
-                "extend": "^3.0.2",
-                "https-proxy-agent": "^5.0.0",
-                "is-stream": "^2.0.0",
-                "node-fetch": "^2.6.7"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/gaxios/node_modules/node-fetch": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-            "dev": true,
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/gcp-metadata": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.0.0.tgz",
-            "integrity": "sha512-gfwuX3yA3nNsHSWUL4KG90UulNiq922Ukj3wLTrcnX33BB7PwB1o0ubR8KVvXu9nJH+P5w1j2SQSNNqto+H0DA==",
-            "dev": true,
-            "dependencies": {
-                "gaxios": "^5.0.0",
-                "json-bigint": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
         },
         "node_modules/get-caller-file": {
             "version": "1.0.3",
@@ -6427,142 +5890,10 @@
                 "node": ">= 0.10"
             }
         },
-        "node_modules/google-auth-library": {
-            "version": "8.5.2",
-            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-8.5.2.tgz",
-            "integrity": "sha512-FPfOSaI8n2TVXFHTP8/vAVFCXhyALj7w9/Rgefux3oeKZ/nQDNmfNTJ+lIKcoYT1cKkvMllp1Eood7Y5L+TP+A==",
-            "dev": true,
-            "dependencies": {
-                "arrify": "^2.0.0",
-                "base64-js": "^1.3.0",
-                "ecdsa-sig-formatter": "^1.0.11",
-                "fast-text-encoding": "^1.0.0",
-                "gaxios": "^5.0.0",
-                "gcp-metadata": "^5.0.0",
-                "gtoken": "^6.1.0",
-                "jws": "^4.0.0",
-                "lru-cache": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/google-auth-library/node_modules/arrify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-            "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/google-auth-library/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/google-gax": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-3.6.1.tgz",
-            "integrity": "sha512-g/lcUjGcB6DSw2HxgEmCDOrI/CByOwqRvsuUvNalHUK2iPPPlmAIpbMbl62u0YufGMr8zgE3JL7th6dCb1Ry+w==",
-            "dev": true,
-            "dependencies": {
-                "@grpc/grpc-js": "~1.8.0",
-                "@grpc/proto-loader": "^0.7.0",
-                "@types/long": "^4.0.0",
-                "@types/rimraf": "^3.0.2",
-                "abort-controller": "^3.0.0",
-                "duplexify": "^4.0.0",
-                "fast-text-encoding": "^1.0.3",
-                "google-auth-library": "^8.0.2",
-                "is-stream-ended": "^0.1.4",
-                "node-fetch": "^2.6.1",
-                "object-hash": "^3.0.0",
-                "proto3-json-serializer": "^1.0.0",
-                "protobufjs": "7.2.4",
-                "protobufjs-cli": "1.1.1",
-                "retry-request": "^5.0.0"
-            },
-            "bin": {
-                "compileProtos": "build/tools/compileProtos.js",
-                "minifyProtoJson": "build/tools/minify.js"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/google-gax/node_modules/duplexify": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
-            "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
-            "dev": true,
-            "dependencies": {
-                "end-of-stream": "^1.4.1",
-                "inherits": "^2.0.3",
-                "readable-stream": "^3.1.1",
-                "stream-shift": "^1.0.0"
-            }
-        },
-        "node_modules/google-gax/node_modules/node-fetch": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-            "dev": true,
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/google-p12-pem": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-4.0.1.tgz",
-            "integrity": "sha512-WPkN4yGtz05WZ5EhtlxNDWPhC4JIic6G8ePitwUWy4l+XPVYec+a0j0Ts47PDtW59y3RwAhUd9/h9ZZ63px6RQ==",
-            "dev": true,
-            "dependencies": {
-                "node-forge": "^1.3.1"
-            },
-            "bin": {
-                "gp12-pem": "build/src/bin/gp12-pem.js"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
         "node_modules/graceful-fs": {
             "version": "4.2.8",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
             "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
-        },
-        "node_modules/gtoken": {
-            "version": "6.1.2",
-            "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-6.1.2.tgz",
-            "integrity": "sha512-4ccGpzz7YAr7lxrT2neugmXQ3hP9ho2gcaityLVkiUecAiwiy60Ii8gRbZeOsXV19fYaRjgBSshs8kXw+NKCPQ==",
-            "dev": true,
-            "dependencies": {
-                "gaxios": "^5.0.1",
-                "google-p12-pem": "^4.0.0",
-                "jws": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
         },
         "node_modules/gulp": {
             "version": "4.0.2",
@@ -7575,18 +6906,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/html-tags": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.2.0.tgz",
-            "integrity": "sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/htmlparser2": {
             "version": "3.8.3",
             "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
@@ -7661,20 +6980,6 @@
                 "node": ">=8.0.0"
             }
         },
-        "node_modules/http-proxy-agent": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-            "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-            "dev": true,
-            "dependencies": {
-                "@tootallnate/once": "2",
-                "agent-base": "6",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/http-server": {
             "version": "14.1.0",
             "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.0.tgz",
@@ -7700,19 +7005,6 @@
             },
             "engines": {
                 "node": ">=12"
-            }
-        },
-        "node_modules/https-proxy-agent": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-            "dev": true,
-            "dependencies": {
-                "agent-base": "6",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/human-signals": {
@@ -8043,18 +7335,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/is-html": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-html/-/is-html-2.0.0.tgz",
-            "integrity": "sha512-S+OpgB5i7wzIue/YSE5hg0e5ZYfG3hhpNh9KGl6ayJ38p7ED6wxQLd1TV91xHpcTvw90KMJ9EwN3F/iNflHBVg==",
-            "dev": true,
-            "dependencies": {
-                "html-tags": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/is-negated-glob": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
@@ -8149,12 +7429,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/is-stream-ended": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.4.tgz",
-            "integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw==",
-            "dev": true
         },
         "node_modules/is-svg": {
             "version": "2.1.0",
@@ -8492,15 +7766,6 @@
                 "node": ">=0.8.0"
             }
         },
-        "node_modules/json-bigint": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-            "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-            "dev": true,
-            "dependencies": {
-                "bignumber.js": "^9.0.0"
-            }
-        },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -8586,27 +7851,6 @@
             "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.1.0.tgz",
             "integrity": "sha512-qpcRocdkUmf+UTNBYx5w6dexX5J31AKK1OmPwH630a83DdVVUIngk55RSAiIGpQyoH0dlr872VHfPjnQnK1qDQ==",
             "dev": true
-        },
-        "node_modules/jwa": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
-            "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
-            "dev": true,
-            "dependencies": {
-                "buffer-equal-constant-time": "1.0.1",
-                "ecdsa-sig-formatter": "1.0.11",
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "node_modules/jws": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-            "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
-            "dev": true,
-            "dependencies": {
-                "jwa": "^2.0.0",
-                "safe-buffer": "^5.0.1"
-            }
         },
         "node_modules/kind-of": {
             "version": "6.0.3",
@@ -8982,12 +8226,6 @@
             "dependencies": {
                 "lodash.keys": "~2.4.1"
             }
-        },
-        "node_modules/long": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-            "dev": true
         },
         "node_modules/loud-rejection": {
             "version": "1.6.0",
@@ -9700,15 +8938,6 @@
             "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
             "dev": true
         },
-        "node_modules/node-forge": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-            "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
-            "dev": true,
-            "engines": {
-                "node": ">= 6.13.0"
-            }
-        },
         "node_modules/node.extend": {
             "version": "1.1.8",
             "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.8.tgz",
@@ -9858,15 +9087,6 @@
             },
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/object-hash": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
-            "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-            "dev": true,
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/object-inspect": {
@@ -10857,76 +10077,6 @@
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
         },
-        "node_modules/proto3-json-serializer": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-1.1.0.tgz",
-            "integrity": "sha512-SjXwUWe/vANGs/mJJTbw5++7U67nwsymg7qsoPtw6GiXqw3kUy8ByojrlEdVE2efxAdKreX8WkDafxvYW95ZQg==",
-            "dev": true,
-            "dependencies": {
-                "protobufjs": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/protobufjs": {
-            "version": "7.2.4",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
-            "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
-            "dev": true,
-            "hasInstallScript": true,
-            "dependencies": {
-                "@protobufjs/aspromise": "^1.1.2",
-                "@protobufjs/base64": "^1.1.2",
-                "@protobufjs/codegen": "^2.0.4",
-                "@protobufjs/eventemitter": "^1.1.0",
-                "@protobufjs/fetch": "^1.1.0",
-                "@protobufjs/float": "^1.0.2",
-                "@protobufjs/inquire": "^1.1.0",
-                "@protobufjs/path": "^1.1.2",
-                "@protobufjs/pool": "^1.1.0",
-                "@protobufjs/utf8": "^1.1.0",
-                "@types/node": ">=13.7.0",
-                "long": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/protobufjs-cli": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/protobufjs-cli/-/protobufjs-cli-1.1.1.tgz",
-            "integrity": "sha512-VPWMgIcRNyQwWUv8OLPyGQ/0lQY/QTQAVN5fh+XzfDwsVw1FZ2L3DM/bcBf8WPiRz2tNpaov9lPZfNcmNo6LXA==",
-            "dev": true,
-            "dependencies": {
-                "chalk": "^4.0.0",
-                "escodegen": "^1.13.0",
-                "espree": "^9.0.0",
-                "estraverse": "^5.1.0",
-                "glob": "^8.0.0",
-                "jsdoc": "^4.0.0",
-                "minimist": "^1.2.0",
-                "semver": "^7.1.2",
-                "tmp": "^0.2.1",
-                "uglify-js": "^3.7.7"
-            },
-            "bin": {
-                "pbjs": "bin/pbjs",
-                "pbts": "bin/pbts"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "peerDependencies": {
-                "protobufjs": "^7.0.0"
-            }
-        },
-        "node_modules/protobufjs/node_modules/long": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
-            "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w==",
-            "dev": true
-        },
         "node_modules/proxy-middleware": {
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/proxy-middleware/-/proxy-middleware-0.5.1.tgz",
@@ -11580,19 +10730,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.12"
-            }
-        },
-        "node_modules/retry-request": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-5.0.2.tgz",
-            "integrity": "sha512-wfI3pk7EE80lCIXprqh7ym48IHYdwmAAzESdbU8Q9l7pnRCk9LEhpbOTNKjz6FARLm/Bl5m+4F0ABxOkYUujSQ==",
-            "dev": true,
-            "dependencies": {
-                "debug": "^4.1.1",
-                "extend": "^3.0.2"
-            },
-            "engines": {
-                "node": ">=12"
             }
         },
         "node_modules/reusify": {
@@ -12355,15 +11492,6 @@
                 "through": "~2.3.4"
             }
         },
-        "node_modules/stream-events": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
-            "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
-            "dev": true,
-            "dependencies": {
-                "stubs": "^3.0.0"
-            }
-        },
         "node_modules/stream-exhaust": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
@@ -12476,12 +11604,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/stubs": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
-            "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
-            "dev": true
-        },
         "node_modules/supports-color": {
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -12545,42 +11667,6 @@
             "integrity": "sha512-2wsvQ+4GwBvLPLWsNfLCDYGsW6xb7aeC6utq2Qh0PFwgEy7K7dsma9Jsmb2zSQj7GvYAyUGSntLtsv++GmgL1A==",
             "engines": {
                 "node": ">=0.6"
-            }
-        },
-        "node_modules/teeny-request": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-8.0.1.tgz",
-            "integrity": "sha512-q1yTwqoS5aH1pjur3kBbI+wFpiAswdVirHMB3pYT5x/B0d+ulYdrruB/xVtbTEaxJemHu5aTbh11rsOLlFk/ZQ==",
-            "dev": true,
-            "dependencies": {
-                "http-proxy-agent": "^5.0.0",
-                "https-proxy-agent": "^5.0.0",
-                "node-fetch": "^2.6.1",
-                "stream-events": "^1.0.5",
-                "uuid": "^8.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/teeny-request/node_modules/node-fetch": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-            "dev": true,
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
             }
         },
         "node_modules/tern": {
@@ -12820,18 +11906,6 @@
                 "node": "*"
             }
         },
-        "node_modules/tmp": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-            "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-            "dev": true,
-            "dependencies": {
-                "rimraf": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8.17.0"
-            }
-        },
         "node_modules/to-absolute-glob": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
@@ -12940,12 +12014,6 @@
             "engines": {
                 "node": ">=0.6"
             }
-        },
-        "node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-            "dev": true
         },
         "node_modules/trim-newlines": {
             "version": "1.0.0",
@@ -13358,15 +12426,6 @@
                 "node": ">= 0.4.0"
             }
         },
-        "node_modules/uuid": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-            "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
-            "dev": true,
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
-        },
         "node_modules/v8-compile-cache": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -13547,12 +12606,6 @@
                 "node >=0.1.95"
             ]
         },
-        "node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "dev": true
-        },
         "node_modules/websocket-driver": {
             "version": "0.7.4",
             "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
@@ -13598,16 +12651,6 @@
             },
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "dev": true,
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
             }
         },
         "node_modules/whet.extend": {
@@ -14317,6 +13360,27 @@
                 "@jridgewell/trace-mapping": "0.3.9"
             }
         },
+        "@emmetio/abbreviation": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.3.3.tgz",
+            "integrity": "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==",
+            "requires": {
+                "@emmetio/scanner": "^1.0.4"
+            }
+        },
+        "@emmetio/css-abbreviation": {
+            "version": "2.1.8",
+            "resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.8.tgz",
+            "integrity": "sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw==",
+            "requires": {
+                "@emmetio/scanner": "^1.0.4"
+            }
+        },
+        "@emmetio/scanner": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.4.tgz",
+            "integrity": "sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA=="
+        },
         "@eslint/eslintrc": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
@@ -14368,181 +13432,6 @@
             "version": "6.1.2",
             "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.1.2.tgz",
             "integrity": "sha512-XwWADtfdSN73/udaFm+1mnGIj/ShDZNFMe/PRoqv3FhQ4GNI2PUN70yFTPsjq65Lw2C9i4TG5/hTbxXIXVCiqQ=="
-        },
-        "@google-cloud/common": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-4.0.2.tgz",
-            "integrity": "sha512-LgUoPQq1CNzMAtqnIJLetj7hlzZUS+CG9mBuZthqek6+eGu3PsH2IuEbbtLSUgPZNgOgi/fWGWpbNPP7wgjF0A==",
-            "dev": true,
-            "requires": {
-                "@google-cloud/projectify": "^3.0.0",
-                "@google-cloud/promisify": "^3.0.0",
-                "arrify": "^2.0.1",
-                "duplexify": "^4.1.1",
-                "ent": "^2.2.0",
-                "extend": "^3.0.2",
-                "google-auth-library": "^8.0.2",
-                "retry-request": "^5.0.0",
-                "teeny-request": "^8.0.0"
-            },
-            "dependencies": {
-                "arrify": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-                    "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-                    "dev": true
-                },
-                "duplexify": {
-                    "version": "4.1.2",
-                    "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
-                    "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
-                    "dev": true,
-                    "requires": {
-                        "end-of-stream": "^1.4.1",
-                        "inherits": "^2.0.3",
-                        "readable-stream": "^3.1.1",
-                        "stream-shift": "^1.0.0"
-                    }
-                }
-            }
-        },
-        "@google-cloud/projectify": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-3.0.0.tgz",
-            "integrity": "sha512-HRkZsNmjScY6Li8/kb70wjGlDDyLkVk3KvoEo9uIoxSjYLJasGiCch9+PqRVDOCGUFvEIqyogl+BeqILL4OJHA==",
-            "dev": true
-        },
-        "@google-cloud/promisify": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-3.0.1.tgz",
-            "integrity": "sha512-z1CjRjtQyBOYL+5Qr9DdYIfrdLBe746jRTYfaYU6MeXkqp7UfYs/jX16lFFVzZ7PGEJvqZNqYUEtb1mvDww4pA==",
-            "dev": true
-        },
-        "@google-cloud/translate": {
-            "version": "7.2.2",
-            "resolved": "https://registry.npmjs.org/@google-cloud/translate/-/translate-7.2.2.tgz",
-            "integrity": "sha512-IAJhPKotLH/OF/NzWml/byLDN+OILbs1P4k+7HNUJK618NsShFelRKzh3pRUUQA4DX0je3HaEZw9nR+5uJ6ZEg==",
-            "dev": true,
-            "requires": {
-                "@google-cloud/common": "^4.0.0",
-                "@google-cloud/promisify": "^3.0.0",
-                "arrify": "^2.0.0",
-                "extend": "^3.0.2",
-                "google-gax": "^3.5.8",
-                "is-html": "^2.0.0"
-            },
-            "dependencies": {
-                "arrify": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-                    "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-                    "dev": true
-                }
-            }
-        },
-        "@grpc/grpc-js": {
-            "version": "1.8.22",
-            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.22.tgz",
-            "integrity": "sha512-oAjDdN7fzbUi+4hZjKG96MR6KTEubAeMpQEb+77qy+3r0Ua5xTFuie6JOLr4ZZgl5g+W5/uRTS2M1V8mVAFPuA==",
-            "dev": true,
-            "requires": {
-                "@grpc/proto-loader": "^0.7.0",
-                "@types/node": ">=12.12.47"
-            }
-        },
-        "@grpc/proto-loader": {
-            "version": "0.7.8",
-            "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.8.tgz",
-            "integrity": "sha512-GU12e2c8dmdXb7XUlOgYWZ2o2i+z9/VeACkxTA/zzAe2IjclC5PnVL0lpgjhrqfpDYHzM8B1TF6pqWegMYAzlA==",
-            "dev": true,
-            "requires": {
-                "@types/long": "^4.0.1",
-                "lodash.camelcase": "^4.3.0",
-                "long": "^4.0.0",
-                "protobufjs": "^7.2.4",
-                "yargs": "^17.7.2"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^2.0.1"
-                    }
-                },
-                "cliui": {
-                    "version": "8.0.1",
-                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-                    "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-                    "dev": true,
-                    "requires": {
-                        "string-width": "^4.2.0",
-                        "strip-ansi": "^6.0.1",
-                        "wrap-ansi": "^7.0.0"
-                    }
-                },
-                "color-convert": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "dev": true,
-                    "requires": {
-                        "color-name": "~1.1.4"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-                    "dev": true
-                },
-                "get-caller-file": {
-                    "version": "2.0.5",
-                    "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-                    "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-                    "dev": true
-                },
-                "wrap-ansi": {
-                    "version": "7.0.0",
-                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-                    "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.0.0",
-                        "string-width": "^4.1.0",
-                        "strip-ansi": "^6.0.0"
-                    }
-                },
-                "y18n": {
-                    "version": "5.0.8",
-                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-                    "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-                    "dev": true
-                },
-                "yargs": {
-                    "version": "17.7.2",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-                    "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-                    "dev": true,
-                    "requires": {
-                        "cliui": "^8.0.1",
-                        "escalade": "^3.1.1",
-                        "get-caller-file": "^2.0.5",
-                        "require-directory": "^2.1.1",
-                        "string-width": "^4.2.3",
-                        "y18n": "^5.0.5",
-                        "yargs-parser": "^21.1.1"
-                    }
-                },
-                "yargs-parser": {
-                    "version": "21.1.1",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-                    "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-                    "dev": true
-                }
-            }
         },
         "@gulp-sourcemaps/identity-map": {
             "version": "2.0.1",
@@ -14824,76 +13713,6 @@
                 "php-parser": "^3.1.5"
             }
         },
-        "@protobufjs/aspromise": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-            "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-            "dev": true
-        },
-        "@protobufjs/base64": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-            "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-            "dev": true
-        },
-        "@protobufjs/codegen": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-            "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-            "dev": true
-        },
-        "@protobufjs/eventemitter": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-            "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-            "dev": true
-        },
-        "@protobufjs/fetch": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-            "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-            "dev": true,
-            "requires": {
-                "@protobufjs/aspromise": "^1.1.1",
-                "@protobufjs/inquire": "^1.1.0"
-            }
-        },
-        "@protobufjs/float": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-            "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-            "dev": true
-        },
-        "@protobufjs/inquire": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-            "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
-            "dev": true
-        },
-        "@protobufjs/path": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-            "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-            "dev": true
-        },
-        "@protobufjs/pool": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-            "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-            "dev": true
-        },
-        "@protobufjs/utf8": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-            "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
-            "dev": true
-        },
-        "@tootallnate/once": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-            "dev": true
-        },
         "@tsconfig/node10": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -14918,26 +13737,10 @@
             "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
             "dev": true
         },
-        "@types/glob": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
-            "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
-            "dev": true,
-            "requires": {
-                "@types/minimatch": "^5.1.2",
-                "@types/node": "*"
-            }
-        },
         "@types/linkify-it": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
             "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-            "dev": true
-        },
-        "@types/long": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-            "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
             "dev": true
         },
         "@types/markdown-it": {
@@ -14954,12 +13757,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
             "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
-            "dev": true
-        },
-        "@types/minimatch": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
-            "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
             "dev": true
         },
         "@types/minimist": {
@@ -14986,16 +13783,6 @@
             "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
             "dev": true
         },
-        "@types/rimraf": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.2.tgz",
-            "integrity": "sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==",
-            "dev": true,
-            "requires": {
-                "@types/glob": "*",
-                "@types/node": "*"
-            }
-        },
         "@uiw/file-icons": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/@uiw/file-icons/-/file-icons-1.3.2.tgz",
@@ -15006,15 +13793,6 @@
             "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.8.tgz",
             "integrity": "sha512-PrJx38EfpitFhwmILRl37jAdBlsww6AZ6rRVK4QS7T7RHLhX7mSs647sTmgr9GIxe3qjXdesmomEgbgaokrVFg==",
             "dev": true
-        },
-        "abort-controller": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-            "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-            "dev": true,
-            "requires": {
-                "event-target-shim": "^5.0.0"
-            }
         },
         "accepts": {
             "version": "1.3.7",
@@ -15061,15 +13839,6 @@
             "dev": true,
             "requires": {
                 "acorn": "^8.11.0"
-            }
-        },
-        "agent-base": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-            "dev": true,
-            "requires": {
-                "debug": "4"
             }
         },
         "aggregate-error": {
@@ -15588,12 +14357,6 @@
                 }
             }
         },
-        "base64-js": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "dev": true
-        },
         "basic-auth": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
@@ -15607,12 +14370,6 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
             "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
-            "dev": true
-        },
-        "bignumber.js": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz",
-            "integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==",
             "dev": true
         },
         "binary-extensions": {
@@ -15730,12 +14487,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
             "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
-            "dev": true
-        },
-        "buffer-equal-constant-time": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-            "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
             "dev": true
         },
         "buffer-from": {
@@ -17348,15 +16099,6 @@
                 "object.defaults": "^1.1.0"
             }
         },
-        "ecdsa-sig-formatter": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-            "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-            "dev": true,
-            "requires": {
-                "safe-buffer": "^5.0.1"
-            }
-        },
         "ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -17368,6 +16110,15 @@
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.103.tgz",
             "integrity": "sha512-c/uKWR1Z/W30Wy/sx3dkZoj4BijbXX85QKWu9jJfjho3LBAXNEGAEW3oWiGb+dotA6C6BzCTxL2/aLes7jlUeg==",
             "dev": true
+        },
+        "emmet": {
+            "version": "2.4.11",
+            "resolved": "https://registry.npmjs.org/emmet/-/emmet-2.4.11.tgz",
+            "integrity": "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==",
+            "requires": {
+                "@emmetio/abbreviation": "^2.3.3",
+                "@emmetio/css-abbreviation": "^2.1.8"
+            }
         },
         "emoji-regex": {
             "version": "8.0.0",
@@ -17399,12 +16150,6 @@
                 "object-assign": "^4.0.1",
                 "tapable": "^0.2.3"
             }
-        },
-        "ent": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
-            "integrity": "sha512-GHrMyVZQWvTIdDtpiEXdHZnFQKzeO09apj8Cbl4pKWy4i0Oprcq17usfDt5aO63swf0JOeMWjWQE/LzgSRuWpA==",
-            "dev": true
         },
         "entities": {
             "version": "1.0.0",
@@ -17498,73 +16243,6 @@
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
             "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
             "dev": true
-        },
-        "escodegen": {
-            "version": "1.14.3",
-            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-            "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
-            "dev": true,
-            "requires": {
-                "esprima": "^4.0.1",
-                "estraverse": "^4.2.0",
-                "esutils": "^2.0.2",
-                "optionator": "^0.8.1",
-                "source-map": "~0.6.1"
-            },
-            "dependencies": {
-                "estraverse": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-                    "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-                    "dev": true
-                },
-                "levn": {
-                    "version": "0.3.0",
-                    "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-                    "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-                    "dev": true,
-                    "requires": {
-                        "prelude-ls": "~1.1.2",
-                        "type-check": "~0.3.2"
-                    }
-                },
-                "optionator": {
-                    "version": "0.8.3",
-                    "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-                    "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-                    "dev": true,
-                    "requires": {
-                        "deep-is": "~0.1.3",
-                        "fast-levenshtein": "~2.0.6",
-                        "levn": "~0.3.0",
-                        "prelude-ls": "~1.1.2",
-                        "type-check": "~0.3.2",
-                        "word-wrap": "~1.2.3"
-                    }
-                },
-                "prelude-ls": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-                    "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
-                    "dev": true
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true,
-                    "optional": true
-                },
-                "type-check": {
-                    "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-                    "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-                    "dev": true,
-                    "requires": {
-                        "prelude-ls": "~1.1.2"
-                    }
-                }
-            }
         },
         "eslint": {
             "version": "8.19.0",
@@ -17699,12 +16377,6 @@
                 "eslint-visitor-keys": "^3.3.0"
             }
         },
-        "esprima": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "dev": true
-        },
         "esquery": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
@@ -17765,12 +16437,6 @@
                 "stream-combiner": "^0.2.2",
                 "through": "^2.3.8"
             }
-        },
-        "event-target-shim": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-            "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-            "dev": true
         },
         "eventemitter3": {
             "version": "4.0.7",
@@ -18017,12 +16683,6 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-            "dev": true
-        },
-        "fast-text-encoding": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
-            "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==",
             "dev": true
         },
         "fastq": {
@@ -18439,39 +17099,6 @@
             "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
             "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
             "dev": true
-        },
-        "gaxios": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.0.1.tgz",
-            "integrity": "sha512-keK47BGKHyyOVQxgcUaSaFvr3ehZYAlvhvpHXy0YB2itzZef+GqZR8TBsfVRWghdwlKrYsn+8L8i3eblF7Oviw==",
-            "dev": true,
-            "requires": {
-                "extend": "^3.0.2",
-                "https-proxy-agent": "^5.0.0",
-                "is-stream": "^2.0.0",
-                "node-fetch": "^2.6.7"
-            },
-            "dependencies": {
-                "node-fetch": {
-                    "version": "2.7.0",
-                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-                    "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-                    "dev": true,
-                    "requires": {
-                        "whatwg-url": "^5.0.0"
-                    }
-                }
-            }
-        },
-        "gcp-metadata": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.0.0.tgz",
-            "integrity": "sha512-gfwuX3yA3nNsHSWUL4KG90UulNiq922Ukj3wLTrcnX33BB7PwB1o0ubR8KVvXu9nJH+P5w1j2SQSNNqto+H0DA==",
-            "dev": true,
-            "requires": {
-                "gaxios": "^5.0.0",
-                "json-bigint": "^1.0.0"
-            }
         },
         "get-caller-file": {
             "version": "1.0.3",
@@ -18965,110 +17592,10 @@
                 "sparkles": "^1.0.0"
             }
         },
-        "google-auth-library": {
-            "version": "8.5.2",
-            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-8.5.2.tgz",
-            "integrity": "sha512-FPfOSaI8n2TVXFHTP8/vAVFCXhyALj7w9/Rgefux3oeKZ/nQDNmfNTJ+lIKcoYT1cKkvMllp1Eood7Y5L+TP+A==",
-            "dev": true,
-            "requires": {
-                "arrify": "^2.0.0",
-                "base64-js": "^1.3.0",
-                "ecdsa-sig-formatter": "^1.0.11",
-                "fast-text-encoding": "^1.0.0",
-                "gaxios": "^5.0.0",
-                "gcp-metadata": "^5.0.0",
-                "gtoken": "^6.1.0",
-                "jws": "^4.0.0",
-                "lru-cache": "^6.0.0"
-            },
-            "dependencies": {
-                "arrify": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-                    "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-                    "dev": true
-                },
-                "lru-cache": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-                    "dev": true,
-                    "requires": {
-                        "yallist": "^4.0.0"
-                    }
-                }
-            }
-        },
-        "google-gax": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-3.6.1.tgz",
-            "integrity": "sha512-g/lcUjGcB6DSw2HxgEmCDOrI/CByOwqRvsuUvNalHUK2iPPPlmAIpbMbl62u0YufGMr8zgE3JL7th6dCb1Ry+w==",
-            "dev": true,
-            "requires": {
-                "@grpc/grpc-js": "~1.8.0",
-                "@grpc/proto-loader": "^0.7.0",
-                "@types/long": "^4.0.0",
-                "@types/rimraf": "^3.0.2",
-                "abort-controller": "^3.0.0",
-                "duplexify": "^4.0.0",
-                "fast-text-encoding": "^1.0.3",
-                "google-auth-library": "^8.0.2",
-                "is-stream-ended": "^0.1.4",
-                "node-fetch": "^2.6.1",
-                "object-hash": "^3.0.0",
-                "proto3-json-serializer": "^1.0.0",
-                "protobufjs": "7.2.4",
-                "protobufjs-cli": "1.1.1",
-                "retry-request": "^5.0.0"
-            },
-            "dependencies": {
-                "duplexify": {
-                    "version": "4.1.2",
-                    "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
-                    "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
-                    "dev": true,
-                    "requires": {
-                        "end-of-stream": "^1.4.1",
-                        "inherits": "^2.0.3",
-                        "readable-stream": "^3.1.1",
-                        "stream-shift": "^1.0.0"
-                    }
-                },
-                "node-fetch": {
-                    "version": "2.7.0",
-                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-                    "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-                    "dev": true,
-                    "requires": {
-                        "whatwg-url": "^5.0.0"
-                    }
-                }
-            }
-        },
-        "google-p12-pem": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-4.0.1.tgz",
-            "integrity": "sha512-WPkN4yGtz05WZ5EhtlxNDWPhC4JIic6G8ePitwUWy4l+XPVYec+a0j0Ts47PDtW59y3RwAhUd9/h9ZZ63px6RQ==",
-            "dev": true,
-            "requires": {
-                "node-forge": "^1.3.1"
-            }
-        },
         "graceful-fs": {
             "version": "4.2.8",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
             "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
-        },
-        "gtoken": {
-            "version": "6.1.2",
-            "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-6.1.2.tgz",
-            "integrity": "sha512-4ccGpzz7YAr7lxrT2neugmXQ3hP9ho2gcaityLVkiUecAiwiy60Ii8gRbZeOsXV19fYaRjgBSshs8kXw+NKCPQ==",
-            "dev": true,
-            "requires": {
-                "gaxios": "^5.0.1",
-                "google-p12-pem": "^4.0.0",
-                "jws": "^4.0.0"
-            }
         },
         "gulp": {
             "version": "4.0.2",
@@ -19909,12 +18436,6 @@
                 "whatwg-encoding": "^2.0.0"
             }
         },
-        "html-tags": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.2.0.tgz",
-            "integrity": "sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg==",
-            "dev": true
-        },
         "htmlparser2": {
             "version": "3.8.3",
             "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
@@ -19987,17 +18508,6 @@
                 "requires-port": "^1.0.0"
             }
         },
-        "http-proxy-agent": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-            "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-            "dev": true,
-            "requires": {
-                "@tootallnate/once": "2",
-                "agent-base": "6",
-                "debug": "4"
-            }
-        },
         "http-server": {
             "version": "14.1.0",
             "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.0.tgz",
@@ -20017,16 +18527,6 @@
                 "secure-compare": "3.0.1",
                 "union": "~0.5.0",
                 "url-join": "^4.0.1"
-            }
-        },
-        "https-proxy-agent": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-            "dev": true,
-            "requires": {
-                "agent-base": "6",
-                "debug": "4"
             }
         },
         "human-signals": {
@@ -20270,15 +18770,6 @@
                 "is-extglob": "^2.1.1"
             }
         },
-        "is-html": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-html/-/is-html-2.0.0.tgz",
-            "integrity": "sha512-S+OpgB5i7wzIue/YSE5hg0e5ZYfG3hhpNh9KGl6ayJ38p7ED6wxQLd1TV91xHpcTvw90KMJ9EwN3F/iNflHBVg==",
-            "dev": true,
-            "requires": {
-                "html-tags": "^3.0.0"
-            }
-        },
         "is-negated-glob": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
@@ -20342,12 +18833,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
             "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-            "dev": true
-        },
-        "is-stream-ended": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.4.tgz",
-            "integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw==",
             "dev": true
         },
         "is-svg": {
@@ -20599,15 +19084,6 @@
                 }
             }
         },
-        "json-bigint": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-            "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-            "dev": true,
-            "requires": {
-                "bignumber.js": "^9.0.0"
-            }
-        },
         "json-parse-even-better-errors": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -20684,27 +19160,6 @@
             "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.1.0.tgz",
             "integrity": "sha512-qpcRocdkUmf+UTNBYx5w6dexX5J31AKK1OmPwH630a83DdVVUIngk55RSAiIGpQyoH0dlr872VHfPjnQnK1qDQ==",
             "dev": true
-        },
-        "jwa": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
-            "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
-            "dev": true,
-            "requires": {
-                "buffer-equal-constant-time": "1.0.1",
-                "ecdsa-sig-formatter": "1.0.11",
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "jws": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-            "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
-            "dev": true,
-            "requires": {
-                "jwa": "^2.0.0",
-                "safe-buffer": "^5.0.1"
-            }
         },
         "kind-of": {
             "version": "6.0.3",
@@ -21043,12 +19498,6 @@
             "requires": {
                 "lodash.keys": "~2.4.1"
             }
-        },
-        "long": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-            "dev": true
         },
         "loud-rejection": {
             "version": "1.6.0",
@@ -21628,12 +20077,6 @@
             "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
             "dev": true
         },
-        "node-forge": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-            "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
-            "dev": true
-        },
         "node.extend": {
             "version": "1.1.8",
             "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.8.tgz",
@@ -21752,12 +20195,6 @@
                     }
                 }
             }
-        },
-        "object-hash": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
-            "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-            "dev": true
         },
         "object-inspect": {
             "version": "1.12.0",
@@ -22562,61 +20999,6 @@
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
         },
-        "proto3-json-serializer": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-1.1.0.tgz",
-            "integrity": "sha512-SjXwUWe/vANGs/mJJTbw5++7U67nwsymg7qsoPtw6GiXqw3kUy8ByojrlEdVE2efxAdKreX8WkDafxvYW95ZQg==",
-            "dev": true,
-            "requires": {
-                "protobufjs": "^7.0.0"
-            }
-        },
-        "protobufjs": {
-            "version": "7.2.4",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
-            "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
-            "dev": true,
-            "requires": {
-                "@protobufjs/aspromise": "^1.1.2",
-                "@protobufjs/base64": "^1.1.2",
-                "@protobufjs/codegen": "^2.0.4",
-                "@protobufjs/eventemitter": "^1.1.0",
-                "@protobufjs/fetch": "^1.1.0",
-                "@protobufjs/float": "^1.0.2",
-                "@protobufjs/inquire": "^1.1.0",
-                "@protobufjs/path": "^1.1.2",
-                "@protobufjs/pool": "^1.1.0",
-                "@protobufjs/utf8": "^1.1.0",
-                "@types/node": ">=13.7.0",
-                "long": "^5.0.0"
-            },
-            "dependencies": {
-                "long": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
-                    "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w==",
-                    "dev": true
-                }
-            }
-        },
-        "protobufjs-cli": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/protobufjs-cli/-/protobufjs-cli-1.1.1.tgz",
-            "integrity": "sha512-VPWMgIcRNyQwWUv8OLPyGQ/0lQY/QTQAVN5fh+XzfDwsVw1FZ2L3DM/bcBf8WPiRz2tNpaov9lPZfNcmNo6LXA==",
-            "dev": true,
-            "requires": {
-                "chalk": "^4.0.0",
-                "escodegen": "^1.13.0",
-                "espree": "^9.0.0",
-                "estraverse": "^5.1.0",
-                "glob": "^8.0.0",
-                "jsdoc": "^4.0.0",
-                "minimist": "^1.2.0",
-                "semver": "^7.1.2",
-                "tmp": "^0.2.1",
-                "uglify-js": "^3.7.7"
-            }
-        },
         "proxy-middleware": {
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/proxy-middleware/-/proxy-middleware-0.5.1.tgz",
@@ -23140,16 +21522,6 @@
             "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
             "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
             "dev": true
-        },
-        "retry-request": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-5.0.2.tgz",
-            "integrity": "sha512-wfI3pk7EE80lCIXprqh7ym48IHYdwmAAzESdbU8Q9l7pnRCk9LEhpbOTNKjz6FARLm/Bl5m+4F0ABxOkYUujSQ==",
-            "dev": true,
-            "requires": {
-                "debug": "^4.1.1",
-                "extend": "^3.0.2"
-            }
         },
         "reusify": {
             "version": "1.0.4",
@@ -23777,15 +22149,6 @@
                 "through": "~2.3.4"
             }
         },
-        "stream-events": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
-            "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
-            "dev": true,
-            "requires": {
-                "stubs": "^3.0.0"
-            }
-        },
         "stream-exhaust": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
@@ -23868,12 +22231,6 @@
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true
         },
-        "stubs": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
-            "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
-            "dev": true
-        },
         "supports-color": {
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -23922,30 +22279,6 @@
             "version": "0.2.9",
             "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.9.tgz",
             "integrity": "sha512-2wsvQ+4GwBvLPLWsNfLCDYGsW6xb7aeC6utq2Qh0PFwgEy7K7dsma9Jsmb2zSQj7GvYAyUGSntLtsv++GmgL1A=="
-        },
-        "teeny-request": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-8.0.1.tgz",
-            "integrity": "sha512-q1yTwqoS5aH1pjur3kBbI+wFpiAswdVirHMB3pYT5x/B0d+ulYdrruB/xVtbTEaxJemHu5aTbh11rsOLlFk/ZQ==",
-            "dev": true,
-            "requires": {
-                "http-proxy-agent": "^5.0.0",
-                "https-proxy-agent": "^5.0.0",
-                "node-fetch": "^2.6.1",
-                "stream-events": "^1.0.5",
-                "uuid": "^8.0.0"
-            },
-            "dependencies": {
-                "node-fetch": {
-                    "version": "2.7.0",
-                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-                    "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-                    "dev": true,
-                    "requires": {
-                        "whatwg-url": "^5.0.0"
-                    }
-                }
-            }
         },
         "tern": {
             "version": "0.24.3",
@@ -24152,15 +22485,6 @@
             "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
             "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA=="
         },
-        "tmp": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-            "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-            "dev": true,
-            "requires": {
-                "rimraf": "^3.0.0"
-            }
-        },
         "to-absolute-glob": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
@@ -24251,12 +22575,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
             "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-            "dev": true
-        },
-        "tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
             "dev": true
         },
         "trim-newlines": {
@@ -24568,12 +22886,6 @@
             "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
             "dev": true
         },
-        "uuid": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-            "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
-            "dev": true
-        },
         "v8-compile-cache": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -24730,12 +23042,6 @@
             "integrity": "sha1-6NugkbdFZ5mjr1eXi5hud+EyBAY=",
             "dev": true
         },
-        "webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "dev": true
-        },
         "websocket-driver": {
             "version": "0.7.4",
             "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
@@ -24771,16 +23077,6 @@
                         "safer-buffer": ">= 2.1.2 < 3.0.0"
                     }
                 }
-            }
-        },
-        "whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "dev": true,
-            "requires": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
             }
         },
         "whet.extend": {

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
         "codemirror": "^5.65.16",
         "cross-env": "^7.0.3",
         "devicon": "^2.15.1",
+        "emmet": "^2.4.11",
         "file-saver": "^2.0.5",
         "idb-keyval": "^6.2.1",
         "jshint": "^2.13.5",

--- a/src-node/package-lock.json
+++ b/src-node/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@phcode/node-core",
-    "version": "4.0.1-0",
+    "version": "4.1.0-0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@phcode/node-core",
-            "version": "4.0.1-0",
+            "version": "4.1.0-0",
             "license": "GNU-AGPL3.0",
             "dependencies": {
                 "@phcode/fs": "^3.0.1",

--- a/src/phoenix/shell.js
+++ b/src/phoenix/shell.js
@@ -29,6 +29,7 @@
 import initVFS from "./init_vfs.js";
 import ERR_CODES from "./errno.js";
 import { LRUCache } from '../thirdparty/no-minify/lru-cache.js';
+import * as Emmet from '../thirdparty/emmet.es.js';
 
 initVFS();
 
@@ -99,6 +100,10 @@ async function openURLInPhoenixWindow(url, {
 
 Phoenix.libs = {
     LRUCache,
+    Emmet: {
+        expand: Emmet.default,
+        module: Emmet
+    },
     hljs: window.hljs,
     iconv: fs.utils.iconv,
     picomatch: fs.utils.picomatch

--- a/src/thirdparty/licences/emmet.markdown
+++ b/src/thirdparty/licences/emmet.markdown
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Sergey Chikuyonok <serge.che@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
The lib is now globally available via:
1. `Phoenix.libs.Emmet.expand` for the default exported main api and
2. `Phoenix.libs.Emmet.module` for all other apis in Emmet