### PR TITLE
Emmet Integration for stylesheets

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -121,6 +121,7 @@ define(function (require, exports, module) {
     // load modules for later use
     require("utils/Global");
     require("editor/CSSInlineEditor");
+    require("preferences/AllPreferences");
     require("project/WorkingSetSort");
     require("search/QuickOpen");
     require("search/QuickOpenHelper");

--- a/src/extensions/default/CSSCodeHints/main.js
+++ b/src/extensions/default/CSSCodeHints/main.js
@@ -687,6 +687,12 @@ define(function (require, exports, module) {
             this.editor.setCursorPos(newCursor);
         }
 
+        // If the current line ends with a semicolon, the CSS property is fully specified,
+        // so we don't need to continue showing hints for its value.
+        if(this.editor.getLine(start.line).trim().endsWith(';')) {
+            keepHints = false;
+        }
+
         return keepHints;
     };
 

--- a/src/extensions/default/CSSCodeHints/main.js
+++ b/src/extensions/default/CSSCodeHints/main.js
@@ -66,6 +66,13 @@ define(function (require, exports, module) {
     const cssWideKeywords = ['initial', 'inherit', 'unset', 'var()', 'calc()'];
     let computedProperties, computedPropertyKeys;
 
+    // Stores a list of all CSS properties along with their corresponding MDN URLs.
+    // This is used by Emmet code hints to ensure users can still access MDN documentation.
+    // the Emmet icon serves as a clickable link that redirects to the MDN page for the property (if available).
+    // This object follows the structure:
+    // { PROPERTY_NAME: MDN_URL }
+    const MDN_PROPERTIES_URLS = {};
+
     PreferencesManager.definePreference("codehint.CssPropHints", "boolean", true, {
         description: Strings.DESCRIPTION_CSS_PROP_HINTS
     });
@@ -380,6 +387,7 @@ define(function (require, exports, module) {
                 const propertyKey = computedPropertyKeys[resultItem.sourceIndex];
                 if(properties[propertyKey] && properties[propertyKey].MDN_URL){
                     resultItem.MDN_URL = properties[propertyKey].MDN_URL;
+                    MDN_PROPERTIES_URLS[propertyKey] = resultItem.MDN_URL;
                 }
             }
 
@@ -413,7 +421,13 @@ define(function (require, exports, module) {
 
                         // this displays an emmet icon at the side of the hint
                         // this gives an idea to the user that the hint is coming from Emmet
-                        let $icon = $(`<span class="emmet-css-code-hint">Emmet</span>`);
+                        let $icon = $(`<a class="emmet-css-code-hint" style="text-decoration: none">Emmet</a>`);
+
+                        // if MDN_URL is available for the property, add the href attribute to redirect to mdn
+                        if(MDN_PROPERTIES_URLS[expandedAbbr]) {
+                            $icon.attr("href", MDN_PROPERTIES_URLS[expandedAbbr]);
+                            $icon.attr("title", Strings.DOCS_MORE_LINK_MDN_TITLE);
+                        }
 
                         const $emmetHintObj = $("<span>")
                             .addClass("brackets-css-hints brackets-hints")
@@ -486,7 +500,7 @@ define(function (require, exports, module) {
      * Checks whether the expandedAbbr has any number.
      * For instance: `m0` expands to `margin: 0;`, so we need to display the whole thing in the code hint
      * Here, we also make sure that abbreviations which has `#`, `,` should not be included, because
-     * * `color` expands to `color: #000;` or `color: rgb(0, 0, 0)`. So this actually has numbers, but we don't want to display this.
+     * `color` expands to `color: #000;` or `color: rgb(0, 0, 0)`. So this actually has numbers, but we don't want to display this.
      *
      * @param {String} expandedAbbr the expanded abbr returned by EXPAND_ABBR emmet api
      * @returns {boolean} true if expandedAbbr has numbers (and doesn't include '#') otherwise false.

--- a/src/extensions/default/CSSCodeHints/main.js
+++ b/src/extensions/default/CSSCodeHints/main.js
@@ -687,9 +687,11 @@ define(function (require, exports, module) {
             this.editor.setCursorPos(newCursor);
         }
 
-        // If the current line ends with a semicolon, the CSS property is fully specified,
+        // If the cursor is just after a semicolon that means that,
+        // the CSS property is fully specified,
         // so we don't need to continue showing hints for its value.
-        if(this.editor.getLine(start.line).trim().endsWith(';')) {
+        const cursorPos = this.editor.getCursorPos();
+        if(this.editor.getCharacterAtPosition({line: cursorPos.line, ch: cursorPos.ch - 1}) === ';') {
             keepHints = false;
         }
 

--- a/src/extensions/default/CSSCodeHints/main.js
+++ b/src/extensions/default/CSSCodeHints/main.js
@@ -407,12 +407,35 @@ define(function (require, exports, module) {
                             expandedAbbr = expandedAbbr.split(':')[0];
                         }
 
+                        // token is required for highlighting the matched part. It gives access to
+                        // stringRanges property. Refer to `formatHints()` function in this file for more detail
+                        const [token] = StringMatch.codeHintsSort(needle, [expandedAbbr]);
+
                         // this displays an emmet icon at the side of the hint
                         // this gives an idea to the user that the hint is coming from Emmet
                         let $icon = $(`<span class="emmet-css-code-hint">Emmet</span>`);
 
-                        const $emmetHintObj = $(`<span data-val='${expandedAbbr}'></span>`).addClass("brackets-css-hints brackets-hints");
-                        $emmetHintObj.text(expandedAbbr);
+                        const $emmetHintObj = $("<span>")
+                            .addClass("brackets-css-hints brackets-hints")
+                            .attr("data-val", expandedAbbr);
+
+                        // for highlighting the already-typed characters
+                        if (token.stringRanges) {
+                            token.stringRanges.forEach(function (range) {
+                                if (range.matched) {
+                                    $emmetHintObj.append($("<span>")
+                                        .text(range.text)
+                                        .addClass("matched-hint"));
+                                } else {
+                                    $emmetHintObj.append(range.text);
+                                }
+                            });
+                        } else {
+                            // fallback
+                            $emmetHintObj.text(expandedAbbr);
+                        }
+
+                        // add the emmet icon to the final hint object
                         $emmetHintObj.append($icon);
 
                         if(pushedHints) {
@@ -434,8 +457,6 @@ define(function (require, exports, module) {
                     // pass
                 }
             }
-
-
 
             return {
                 hints: pushedHints,

--- a/src/extensions/default/CSSCodeHints/unittests.js
+++ b/src/extensions/default/CSSCodeHints/unittests.js
@@ -110,6 +110,10 @@ define(function (require, exports, module) {
             expect(hintList[0]).toBe(expectedFirstHint);
         }
 
+        function verifySecondAttrHint(hintList, expectedSecondHint) {
+            expect(hintList.indexOf("div")).toBe(-1);
+            expect(hintList[1]).toBe(expectedSecondHint);
+        }
 
         function selectHint(provider, expectedHint, implicitChar) {
             var hintList = expectHints(provider, implicitChar);
@@ -172,6 +176,14 @@ define(function (require, exports, module) {
                 var hintList = expectHints(CSSCodeHints.cssPropHintProvider);
                 verifyAttrHints(hintList, "bottom");  // filtered on "b" ,
                 // bottom should come at top as it is coming from emmet, and it has the highest priority
+            });
+
+            it("should list the second prop-name hint starting with 'b'", function () {
+                testEditor.setCursorPos({ line: 6, ch: 2 });
+
+                var hintList = expectHints(CSSCodeHints.cssPropHintProvider);
+                verifySecondAttrHint(hintList, "background-color");  // filtered on "b" ,
+                // background-color should be displayed at second. as first will be bottom coming from emmet
             });
 
             it("should list all prop-name hints starting with 'bord' ", function () {
@@ -243,6 +255,15 @@ define(function (require, exports, module) {
                 testEditor = null;
                 testDocument = null;
             });
+
+            it("should expand m0 to margin: 0; when Emmet hint is used", function () {
+                testDocument.replaceRange("m0", { line: 6, ch: 2 });
+                testEditor.setCursorPos({ line: 6, ch: 4 });
+
+                selectHint(CSSCodeHints.cssPropHintProvider, "margin: 0;");
+                expect(testDocument.getLine(6)).toBe(" margin: 0;");
+            });
+
 
             it("should insert colon prop-name selected", function () {
                 // insert semicolon after previous rule to avoid incorrect tokenizing
@@ -460,6 +481,13 @@ define(function (require, exports, module) {
 
                 var hintList = expectHints(CSSCodeHints.cssPropHintProvider);
                 verifyAttrHints(hintList, "bottom");  // filtered on "b"
+            });
+
+            it("should list the second prop-name hint starting with 'b' for style value context", function () {
+                testEditor.setCursorPos({ line: 6, ch: 2 });
+
+                var hintList = expectHints(CSSCodeHints.cssPropHintProvider);
+                verifySecondAttrHint(hintList, "background-color");  // second result when filtered on "b"
             });
 
             it("should list all prop-name hints starting with 'bord' for style value context", function () {

--- a/src/extensions/default/CSSCodeHints/unittests.js
+++ b/src/extensions/default/CSSCodeHints/unittests.js
@@ -170,8 +170,8 @@ define(function (require, exports, module) {
                 testEditor.setCursorPos({ line: 6, ch: 2 });
 
                 var hintList = expectHints(CSSCodeHints.cssPropHintProvider);
-                verifyAttrHints(hintList, "background-color");  // filtered on "b" ,
-                // background color should come at top as its boosted for UX
+                verifyAttrHints(hintList, "bottom");  // filtered on "b" ,
+                // bottom should come at top as it is coming from emmet, and it has the highest priority
             });
 
             it("should list all prop-name hints starting with 'bord' ", function () {
@@ -459,7 +459,7 @@ define(function (require, exports, module) {
                 testEditor.setCursorPos({ line: 6, ch: 2 });
 
                 var hintList = expectHints(CSSCodeHints.cssPropHintProvider);
-                verifyAttrHints(hintList, "background-color");  // filtered on "b"
+                verifyAttrHints(hintList, "bottom");  // filtered on "b"
             });
 
             it("should list all prop-name hints starting with 'bord' for style value context", function () {

--- a/src/extensionsIntegrated/Emmet/emmet-snippets.js
+++ b/src/extensionsIntegrated/Emmet/emmet-snippets.js
@@ -1,0 +1,245 @@
+/*
+ * GNU AGPL-3.0 License
+ *
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
+ * Original work Copyright (c) 2024 [emmet.io](https://github.com/emmetio/brackets-emmet).
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
+ */
+
+
+/**
+ * Emmet Snippets Configuration
+ *
+ * This file defines the configuration for Emmet snippet expansion.
+ * It contains four main exports:
+ *
+ * 1. **markupSnippets**: An object that maps abbreviation keys to their expanded HTML markup.
+ *    These are all the abbreviations that can be expanded into something other than the usual tags.
+ *    When an abbreviation matching one of the markup snippets is passed to Emmet, it knows how to expand it.
+ *
+ * 2. **htmlTags**: An array of standard HTML tags that are expanded by default.
+ *    This list helps determine whether an abbreviation corresponds to a valid HTML element.
+ *    Although Emmet can expand any text as an HTML tag,
+ *    doing so would trigger code hints for every piece of text in the editor.
+ *    So, we maintain a list of standard tags;
+ *    only when an abbreviation matches one of these does Emmet display the code hints.
+ *
+ * 3. **positiveSymbols**: An array of symbols that, when present in an abbreviation,
+ *    indicate that the abbreviation is eligible for expansion.
+ *    Examples include `.`, `#`, `>`, `+`, etc., which are used for classes, IDs, nesting,
+ *    sibling selectors, attributes, and more.
+ *
+ * 4. **negativeSymbols**: An array of sequences that indicate a word should NOT be expanded.
+ *    For example, the sequence `</` (which begins a closing tag) signals
+ *    that the abbreviation should be ignored for expansion.
+ */
+define(function (require, exports, module) {
+
+
+    const markupSnippets = {
+        "a": "a[href]",
+        "a:blank": "a[href='http://${0}' target='_blank' rel='noopener noreferrer']",
+        "a:link": "a[href='http://${0}']",
+        "a:mail": "a[href='mailto:${0}']",
+        "a:tel": "a[href='tel:+${0}']",
+        "abbr": "abbr[title]",
+        "acr|acronym": "acronym[title]",
+        "base": "base[href]/",
+        "basefont": "basefont/",
+        "br": "br/",
+        "frame": "frame/",
+        "hr": "hr/",
+        "bdo": "bdo[dir]",
+        "bdo:r": "bdo[dir=rtl]",
+        "bdo:l": "bdo[dir=ltr]",
+        "col": "col/",
+        "link": "link[rel=stylesheet href]/",
+        "link:css": "link[href='${1:style}.css']",
+        "link:print": "link[href='${1:print}.css' media=print]",
+        "link:favicon": "link[rel='shortcut icon' type=image/x-icon href='${1:favicon.ico}']",
+        "link:mf|link:manifest": "link[rel='manifest' href='${1:manifest.json}']",
+        "link:touch": "link[rel=apple-touch-icon href='${1:favicon.png}']",
+        "link:rss": "link[rel=alternate type=application/rss+xml title=RSS href='${1:rss.xml}']",
+        "link:atom": "link[rel=alternate type=application/atom+xml title=Atom href='${1:atom.xml}']",
+        "link:im|link:import": "link[rel=import href='${1:component}.html']",
+        "meta": "meta/",
+        "meta:utf": "meta[http-equiv=Content-Type content='text/html;charset=UTF-8']",
+        "meta:vp": "meta[name=viewport content='width=${1:device-width}, initial-scale=${2:1.0}']",
+        "meta:compat": "meta[http-equiv=X-UA-Compatible content='${1:IE=7}']",
+        "meta:edge": "meta:compat[content='${1:ie=edge}']",
+        "meta:redirect": "meta[http-equiv=refresh content='0; url=${1:http://example.com}']",
+        "meta:refresh": "meta[http-equiv=refresh content='${1:5}']",
+        "meta:kw": "meta[name=keywords content]",
+        "meta:desc": "meta[name=description content]",
+        "style": "style",
+        "script": "script",
+        "script:src": "script[src]",
+        "script:module": "script[type=module src]",
+        "img": "img[src alt]/",
+        "img:s|img:srcset": "img[srcset src alt]",
+        "img:z|img:sizes": "img[sizes srcset src alt]",
+        "picture": "picture",
+        "src|source": "source/",
+        "src:sc|source:src": "source[src type]",
+        "src:s|source:srcset": "source[srcset]",
+        "src:t|source:type": "source[srcset type='${1:image/}']",
+        "src:z|source:sizes": "source[sizes srcset]",
+        "src:m|source:media": "source[media='(${1:min-width: })' srcset]",
+        "src:mt|source:media:type": "source:media[type='${2:image/}']",
+        "src:mz|source:media:sizes": "source:media[sizes srcset]",
+        "src:zt|source:sizes:type": "source[sizes srcset type='${1:image/}']",
+        "iframe": "iframe[src frameborder=0]",
+        "embed": "embed[src type]/",
+        "object": "object[data type]",
+        "param": "param[name value]/",
+        "map": "map[name]",
+        "area": "area[shape coords href alt]/",
+        "area:d": "area[shape=default]",
+        "area:c": "area[shape=circle]",
+        "area:r": "area[shape=rect]",
+        "area:p": "area[shape=poly]",
+        "form": "form[action]",
+        "form:get": "form[method=get]",
+        "form:post": "form[method=post]",
+        "label": "label[for]",
+        "input": "input[type=${1:text}]/",
+        "inp": "input[name=${1} id=${1}]",
+        "input:h|input:hidden": "input[type=hidden name]",
+        "input:t|input:text": "inp[type=text]",
+        "input:search": "inp[type=search]",
+        "input:email": "inp[type=email]",
+        "input:url": "inp[type=url]",
+        "input:p|input:password": "inp[type=password]",
+        "input:datetime": "inp[type=datetime]",
+        "input:date": "inp[type=date]",
+        "input:datetime-local": "inp[type=datetime-local]",
+        "input:month": "inp[type=month]",
+        "input:week": "inp[type=week]",
+        "input:time": "inp[type=time]",
+        "input:tel": "inp[type=tel]",
+        "input:number": "inp[type=number]",
+        "input:color": "inp[type=color]",
+        "input:c|input:checkbox": "inp[type=checkbox]",
+        "input:r|input:radio": "inp[type=radio]",
+        "input:range": "inp[type=range]",
+        "input:f|input:file": "inp[type=file]",
+        "input:s|input:submit": "input[type=submit value]",
+        "input:i|input:image": "input[type=image src alt]",
+        "input:b|input:btn|input:button": "input[type=button value]",
+        "input:reset": "input:button[type=reset]",
+        "isindex": "isindex/",
+        "select": "select[name=${1} id=${1}]",
+        "select:d|select:disabled": "select[disabled.]",
+        "opt|option": "option[value]",
+        "textarea": "textarea[name=${1} id=${1}]",
+        "tarea:c|textarea:cols": "textarea[name=${1} id=${1} cols=${2:30}]",
+        "tarea:r|textarea:rows": "textarea[name=${1} id=${1} rows=${3:10}]",
+        "tarea:cr|textarea:cols:rows": "textarea[name=${1} id=${1} cols=${2:30} rows=${3:10}]",
+        "marquee": "marquee[behavior direction]",
+        "menu:c|menu:context": "menu[type=context]",
+        "menu:t|menu:toolbar": "menu[type=toolbar]",
+        "video": "video[src]",
+        "audio": "audio[src]",
+        "html:xml": "html[xmlns=http://www.w3.org/1999/xhtml]",
+        "keygen": "keygen/",
+        "command": "command/",
+        "btn:s|button:s|button:submit": "button[type=submit]",
+        "btn:r|button:r|button:reset": "button[type=reset]",
+        "btn:b|button:b|button:button": "button[type=button]",
+        "btn:d|button:d|button:disabled": "button[disabled.]",
+        "fst:d|fset:d|fieldset:d|fieldset:disabled": "fieldset[disabled.]",
+
+        "bq": "blockquote",
+        "fig": "figure",
+        "figc": "figcaption",
+        "pic": "picture",
+        "ifr": "iframe",
+        "emb": "embed",
+        "obj": "object",
+        "cap": "caption",
+        "colg": "colgroup",
+        "fst": "fieldset",
+        "btn": "button",
+        "optg": "optgroup",
+        "tarea": "textarea",
+        "leg": "legend",
+        "sect": "section",
+        "art": "article",
+        "hdr": "header",
+        "ftr": "footer",
+        "adr": "address",
+        "dlg": "dialog",
+        "str": "strong",
+        "prog": "progress",
+        "mn": "main",
+        "tem": "template",
+        "fset": "fieldset",
+        "datal": "datalist",
+        "kg": "keygen",
+        "out": "output",
+        "det": "details",
+        "sum": "summary",
+        "cmd": "command",
+        "data": "data[value]",
+        "meter": "meter[value]",
+        "time": "time[datetime]",
+
+        "ri:d|ri:dpr": "img:s",
+        "ri:v|ri:viewport": "img:z",
+        "ri:a|ri:art": "pic>src:m+img",
+        "ri:t|ri:type": "pic>src:t+img",
+
+        "!!!": "{<!DOCTYPE html>}",
+        "doc": "html[lang=${lang}]>(head>meta[charset=${charset}]+meta:vp+title{${1:Document}})+body",
+        "!|html:5": "!!!+doc",
+
+        "c": "{<!-- ${0} -->}",
+        "cc:ie": "{<!--[if IE]>${0}<![endif]-->}",
+        "cc:noie": "{<!--[if !IE]><!-->${0}<!--<![endif]-->}"
+    };
+
+
+    const htmlTags = [
+        "a", "abbr", "address", "area", "article", "aside", "audio", "b", "base",
+        "bdi", "bdo", "blockquote", "body", "br", "button", "canvas", "caption",
+        "cite", "code", "col", "colgroup", "data", "datalist", "dd", "del",
+        "details", "dfn", "dialog", "div", "dl", "dt", "em", "embed", "fieldset",
+        "figcaption", "figure", "footer", "form", "h1", "h2", "h3", "h4", "h5",
+        "h6", "head", "header", "hgroup", "hr", "html", "i", "iframe", "img",
+        "input", "ins", "kbd", "label", "legend", "li", "link", "main", "map",
+        "mark", "meta", "meter", "nav", "noscript", "object", "ol", "optgroup",
+        "option", "output", "p", "param", "picture", "pre", "progress", "q",
+        "rp", "rt", "ruby", "s", "samp", "script", "section", "select", "small",
+        "source", "span", "strong", "style", "sub", "summary", "sup", "table",
+        "tbody", "td", "template", "textarea", "tfoot", "th", "thead", "time",
+        "title", "tr", "track", "u", "ul", "var", "video", "wbr"
+    ];
+
+
+    const positiveSymbols = [
+        '.', '#', '!', '>', '+', '^', '*', '[', ']', '{', '}', '(', ')', '&'
+    ];
+
+
+    const negativeSymbols = [
+        '</'
+    ];
+
+    exports.markupSnippets = markupSnippets;
+    exports.htmlTags = htmlTags;
+    exports.positiveSymbols = positiveSymbols;
+    exports.negativeSymbols = negativeSymbols;
+});
+

--- a/src/extensionsIntegrated/Emmet/main.js
+++ b/src/extensionsIntegrated/Emmet/main.js
@@ -1,0 +1,544 @@
+/*
+ * GNU AGPL-3.0 License
+ *
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
+ * Original work Copyright (c) 2024 [emmet.io](https://github.com/emmetio/brackets-emmet).
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
+ */
+
+
+define(function (require, exports, module) {
+    const AppInit = require("utils/AppInit");
+    const PreferencesManager = require("preferences/PreferencesManager");
+    const Strings = require("strings");
+    const CodeHintManager = require("editor/CodeHintManager");
+    const {
+        markupSnippets,
+        htmlTags,
+        positiveSymbols,
+        negativeSymbols
+    } = require('./emmet-snippets');
+
+
+    /**
+     * The Emmet api's
+     */
+    const EXPAND_ABBR = Phoenix.libs.Emmet.expand;
+    // const EMMET = Phoenix.libs.Emmet.module;
+
+
+    /**
+     * A list of all the markup snippets that can be expanded.
+     * For ex: 'link:css', 'iframe'
+     * They expand differently as compared to normal tags.
+     * Refer to `./emmet-snippets.js` file for more info.
+     */
+    const markupSnippetsList = Object.keys(markupSnippets);
+
+
+    // For preferences settings, to toggle this feature on/off
+    const PREFERENCES_EMMET = "emmet";
+    let enabled = true; // by default:- on
+
+    PreferencesManager.definePreference(PREFERENCES_EMMET, "boolean", enabled, {
+        description: Strings.DESCRIPTION_EMMET
+    });
+
+
+    /**
+     * @constructor
+     */
+    function EmmetMarkupHints() {
+    }
+
+
+    /**
+     * Checks whether hints are available for the current word where cursor is present.
+     *
+     * @param {Editor} editor - the editor instance
+     * @param {String} implicitChar - unused param [didn't remove, as we might need it in future]
+     * @returns {Boolean} - true if the abbr can be expanded otherwise false.
+     */
+    EmmetMarkupHints.prototype.hasHints = function (editor, implicitChar) {
+        if (enabled) {
+            this.editor = editor;
+
+            const wordObj = getWordBeforeCursor(editor);
+            const config = createConfig(editor);
+            if (config && config.syntax === "html") {
+
+                // make sure we donot have empty spaces
+                if (wordObj.word.trim()) {
+
+                    const expandedAbbr = isExpandable(editor, wordObj.word, config);
+                    if (expandedAbbr) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    };
+
+
+    /**
+     * Returns the Emmet hint for the current word before the cursor.
+     * The hint element will have an appended "Emmet" icon at bottom-rigth to indicate it's an Emmet abbreviation.
+     *
+     * @param {String} implicitChar - unused param [didn't remove, as we might need it in future]
+     */
+    EmmetMarkupHints.prototype.getHints = function (implicitChar) {
+        const wordObj = getWordBeforeCursor(this.editor);
+        const config = createConfig(this.editor);
+
+        // Check if the abbreviation is expandable
+        const expandedAbbr = isExpandable(this.editor, wordObj.word, config);
+        if (!expandedAbbr) {
+            return null;
+        }
+
+        // Create the formatted hint element with an appended Emmet icon
+        const formattedHint = formatEmmetHint(wordObj.word);
+
+        return {
+            hints: [formattedHint],
+            match: null,
+            selectInitial: true,
+            defaultDescriptionWidth: true,
+            handleWideResults: false
+        };
+    };
+
+
+    /**
+     * Formats an Emmet abbreviation hint by appending an icon.
+     *
+     * @param {string} abbr - The Emmet abbreviation.
+     * @returns {jQuery} - A jQuery element representing the formatted hint.
+     */
+    function formatEmmetHint(abbr) {
+        // Create the main container for the hint text.
+        var $hint = $("<span>")
+            .addClass("emmet-hint")
+            .text(abbr);
+
+        // style in brackets_patterns_override.less file
+        let $icon = $(`<span class="emmet-code-hint">Emmet</span>`);
+
+        // Append the icon to the hint element
+        $hint.append($icon);
+
+        return $hint;
+    }
+
+
+    /**
+     * Responsible for updating the abbr with the expanded text in the editor.
+     * This function calls helper functions for this as there are,
+     * lot of complex cases that should be taken care of.
+     */
+    EmmetMarkupHints.prototype.insertHint = function () {
+        const wordObj = getWordBeforeCursor(this.editor);
+        const config = createConfig(this.editor);
+        const expandedAbbr = isExpandable(this.editor, wordObj.word, config);
+        updateAbbrInEditor(this.editor, wordObj, expandedAbbr);
+        return false;
+    };
+
+
+    /**
+     * Responsible to create the configuration based on the file type
+     * Config is an object with two properties, type & snytax
+     * This is required by the Emmet API to distinguish between HTML & Stylesheets
+     *
+     * @param {Editor} editor - The editor instance
+     * @returns {Object | False} Object with two properties 'syntax' and 'type'
+     */
+    function createConfig(editor) {
+        const fileType = editor.document.getLanguage().getId();
+
+        if (fileType === "html" || fileType === "php" || fileType === "jsp") {
+            return { syntax: "html", type: "markup" };
+        }
+
+        if (fileType === "css" || fileType === "scss" || fileType === "less") {
+            return { syntax: "css", type: "stylesheet" };
+        }
+
+        return false;
+    }
+
+
+    /**
+     * Determines whether a given character is allowed as part of an Emmet abbreviation
+     *
+     * @param {String} char - The character to test
+     * @param {Boolean} insideBraces - Flag indicating if we are inside braces (e.g. {} or [])
+     * @returns True if the character is valid for an abbreviation
+     */
+    function isEmmetChar(char, insideBraces) {
+        // Valid abbreviation characters: letters, digits, and some punctuation
+        // Adjust this regex or the list as needed for your implementation
+        const validPattern = /[a-zA-Z0-9:+*<>()/!$\-@#}{]/;
+        const specialChars = new Set(['.', '#', '[', ']', '"', '=', ':', ',', '-']);
+        return validPattern.test(char) || specialChars.has(char) || (insideBraces && char === ' ');
+    }
+
+
+    /**
+     * Scans backwards from the given cursor position on a line to locate the start of the Emmet abbreviation
+     *
+     * @param {String} line - The full text of the current line
+     * @param {Number} cursorCh - The cursor's character (column) position on that line
+     * @returns The index (column) where the abbreviation starts
+     */
+    function findAbbreviationStart(line, cursorCh) {
+        let start = cursorCh;
+        let insideBraces = false;
+
+        // If the cursor is right before a closing brace, adjust it to be "inside" the braces
+        if (line.charAt(start) === '}' || line.charAt(start) === ']') {
+            start--;
+            insideBraces = true;
+        }
+
+        // Walk backwards from the cursor to find the boundary of the abbreviation
+        while (start > 0) {
+            const char = line.charAt(start - 1);
+
+            // Update our "inside braces" state based on the character
+            if (char === '}' || char === ']') {
+                insideBraces = true;
+            } else if (char === '{' || char === '[') {
+                insideBraces = false;
+            }
+
+            // If the character is valid as part of an Emmet abbreviation, continue scanning backwards
+            if (isEmmetChar(char, insideBraces)) {
+                start--;
+            } else {
+                break;
+            }
+        }
+        return start;
+    }
+
+
+    /**
+     * Retrieves the Emmet abbreviation (i.e. the word before the cursor) from the current editor state
+     *
+     * @param {Editor} editor - The editor instance
+     * @returns An object with the abbreviation and its start/end positions
+     *
+     * Format:
+     * {
+     *   word: string,             // the extracted abbreviation
+     *   start: { line: number, ch: number },
+     *   end: { line: number, ch: number }
+     * }
+     */
+    function getWordBeforeCursor(editor) {
+        const pos = editor.getCursorPos();
+        const lineText = editor.document.getLine(pos.line);
+
+        // to determine where the abbreviation starts on the line
+        const abbreviationStart = findAbbreviationStart(lineText, pos.ch);
+
+        // Optionally, adjust the end position if the cursor is immediately before a closing brace.
+        let abbreviationEnd = pos.ch;
+        if (lineText.charAt(abbreviationEnd) === '}' || lineText.charAt(abbreviationEnd) === ']') {
+            abbreviationEnd++;
+        }
+
+        const word = lineText.substring(abbreviationStart, abbreviationEnd);
+
+        return {
+            word: word,
+            start: { line: pos.line, ch: abbreviationStart },
+            end: { line: pos.line, ch: abbreviationEnd }
+        };
+    }
+
+
+    /**
+     * Calculate the indentation level for the current line
+     *
+     * @param {Editor} editor - the editor instance
+     * @param {Object} position - position object with line number
+     * @returns {String} - the indentation string
+     */
+    function getLineIndentation(editor, position) {
+        const line = editor.document.getLine(position.line);
+        const match = line.match(/^\s*/);
+        return match ? match[0] : '';
+    }
+
+
+    /**
+     * Adds proper indentation to multiline Emmet expansion
+     *
+     * @param {String} expandedText - the expanded Emmet abbreviation
+     * @param {String} baseIndent - the base indentation string
+     * @returns {String} - properly indented text
+     */
+    function addIndentation(expandedText, baseIndent) {
+        // Split into lines, preserve empty lines
+        const lines = expandedText.split(/(\r\n|\n)/g);
+
+        // Process each line
+        let result = '';
+        let isFirstLine = true;
+
+        for (let i = 0; i < lines.length; i++) {
+            const line = lines[i];
+
+            // If it's a newline character, just add it
+            if (line === '\n' || line === '\r\n') {
+                result += line;
+                continue;
+            }
+
+            // Skip indenting empty lines
+            if (line.trim() === '') {
+                result += line;
+                continue;
+            }
+
+            // Don't indent the first line as it inherits the current indent
+            if (isFirstLine) {
+                result += line;
+                isFirstLine = false;
+            } else {
+                // Add base indent plus the existing indent in the expanded text
+                result += baseIndent + line;
+            }
+        }
+
+        return result;
+    }
+
+
+
+    /**
+     * Find the position where cursor should be placed after expansion
+     * Looks for patterns like '><', '""', ''
+     *
+     * @param {Editor} editor - The editor instance
+     * @param {String} indentedAbbr - the indented abbreviation
+     * @param {Object} startPos - Starting position {line, ch} of the expansion
+     * @returns {Object | false} - Cursor position {line, ch} or false if no pattern found
+     */
+    function findCursorPosition(editor, indentedAbbr, startPos) {
+        const totalLines = startPos.line + indentedAbbr.split('\n').length;
+
+        for (let i = startPos.line; i < totalLines; i++) {
+            const line = editor.document.getLine(i);
+
+            for (let j = 0; j < line.length - 1; j++) {
+                const pair = line[j] + line[j + 1];
+
+                if (pair === '""' || pair === "''") {
+                    return { line: i, ch: j + 1 };
+                }
+            }
+            for (let j = 0; j < line.length - 1; j++) {
+                const pair = line[j] + line[j + 1];
+
+                if (pair === '><') {
+                    return { line: i, ch: j + 1 };
+                }
+            }
+        }
+
+        // Look for opening and closing tag pairs with empty line in between
+        // <body>
+        //      |
+        // </body>
+        // here in such scenarios, we want the cursor to be placed in between
+        // Look for opening and closing tag pairs with empty line in between
+        for (let i = startPos.line; i < totalLines; i++) {
+            const line = editor.document.getLine(i).trim();
+            if (line.endsWith('>') && line.includes('<') && !line.includes('</')) {
+                if (editor.document.getLine(i + 1) && !editor.document.getLine(i + 1).trim()) {
+                    const tempLine = editor.document.getLine(i + 2);
+                    if (tempLine) {
+                        const trimmedTempLine = tempLine.trim();
+                        if (trimmedTempLine.includes('</') && trimmedTempLine.startsWith('<')) {
+                            // Get the current line's indentation by counting spaces/tabs
+                            const openingTagLine = editor.document.getLine(i);
+                            const indentMatch = openingTagLine.match(/^[\s\t]*/)[0];
+                            // Add 4 more spaces (or equivalent tab) for inner content
+                            const extraIndent = '    ';  // 4 spaces for additional indentation
+
+                            return {
+                                line: i + 1,
+                                ch: indentMatch.length + extraIndent.length
+                            };
+                        }
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+
+
+    /**
+     * This function is responsible to replace the abbreviation in the editor,
+     * with its expanded version
+     *
+     * @param {Editor} editor - the editor instance
+     * @param {Object} wordObj -  an object in the format :
+     * {
+     *      word: "",   // the word before the cursor
+     *      start: {line: Number, ch: Number},
+     *      end: {line: Number, ch: Number}
+     * }
+     * @param {String} expandedAbbr - the expanded version of abbr that will replace the abbr
+     */
+    function updateAbbrInEditor(editor, wordObj, expandedAbbr) {
+        // Get the current line's indentation
+        const baseIndent = getLineIndentation(editor, wordObj.start);
+
+        // Add proper indentation to the expanded abbreviation
+        const indentedAbbr = addIndentation(expandedAbbr, baseIndent);
+
+        // Handle the special case for braces
+        // this check is added because in some situations such as
+        // `ul>li{Hello}` and the cursor is before the closing braces right after 'o',
+        // then when this is expanded it results in an extra closing braces at the end.
+        // so we remove the extra closing brace from the end
+        if (wordObj.word.includes('{') || wordObj.word.includes('[')) {
+            const pos = editor.getCursorPos();
+            const line = editor.document.getLine(pos.line);
+            const char = line.charAt(wordObj.end.ch);
+            const charsNext = line.charAt(wordObj.end.ch + 1);
+
+            if (char === '}' || char === ']') {
+                wordObj.end.ch += 1;
+            }
+
+            // sometimes at the end we get `"]` as extra with some abbreviations.
+            if (char === '"' && charsNext && charsNext === ']') {
+                wordObj.end.ch += 2;
+            }
+
+        }
+
+        // Replace the abbreviation
+        editor.document.replaceRange(
+            indentedAbbr,
+            wordObj.start,
+            wordObj.end
+        );
+
+        // Calculate and set the new cursor position
+        const cursorPos = findCursorPosition(editor, indentedAbbr, wordObj.start);
+        if (cursorPos) {
+            editor.setCursorPos(cursorPos.line, cursorPos.ch);
+        }
+    }
+
+
+    /**
+     * This function checks whether the abbreviation can be expanded or not.
+     * There are a lot of cases to check:
+     * There should not be any negative symbols
+     * The abbr should be either in htmlTags or in markupSnippetsList
+     * For other cases such as 'ul>li', we will check if there is any,
+     * positive word. This is done to handle complex abbreviations such as,
+     * 'ul>li' or 'li*3{Hello}'. So we check if the word includes any positive symbols.
+     *
+     * @param {Editor} editor - the editor instance
+     * @param {String} word - the abbr
+     * @param {Object} config - the config object, to make sure it is a valid file type,
+     * refer to createConfig function for more info about config object.
+     * @returns {String | false} - returns the expanded abbr, and if cannot be expanded, returns false
+     */
+    function isExpandable(editor, word, config) {
+
+        // make sure that word doesn't contain any negativeSymbols
+        if (negativeSymbols.some(symbol => word.includes(symbol))) {
+            return false;
+        }
+
+        // the word must be either in markupSnippetsList, htmlList or it must have a positive symbol
+        // convert to lowercase only for `htmlTags` because HTML tag names are case-insensitive,
+        // but `markupSnippetsList` expands abbreviations in a non-tag manner,
+        // where the expanded abbreviation is already in lowercase.
+        if (markupSnippetsList.includes(word) ||
+            htmlTags.includes(word.toLowerCase()) ||
+            positiveSymbols.some(symbol => word.includes(symbol))) {
+
+            try {
+                const expanded = EXPAND_ABBR(word, config);
+                return expanded;
+            } catch (error) {
+
+                // emmet api throws an error when abbr contains unclosed quotes, handling that case
+                const pos = editor.getCursorPos();
+                const line = editor.document.getLine(pos.line);
+                const nextChar = line.charAt(pos.ch);
+
+                if (nextChar) {
+                    // If the next character is a quote, add quote to abbr
+                    if (nextChar === '"' || nextChar === "'") {
+                        const modifiedWord = word + nextChar;
+
+                        try {
+                            const expandedModified = EXPAND_ABBR(modifiedWord, config);
+                            return expandedModified;
+                        } catch (innerError) {
+                            // If it still fails, return false
+                            return false;
+                        }
+                    }
+                }
+
+                // If no quote is found or expansion fails, return false
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+
+    /**
+     * Checks for preference changes, to enable/disable the feature
+     */
+    function preferenceChanged() {
+        const value = PreferencesManager.get(PREFERENCES_EMMET);
+        enabled = value;
+    }
+
+    AppInit.appReady(function () {
+        // Set up preferences
+        PreferencesManager.on("change", PREFERENCES_EMMET, preferenceChanged);
+        preferenceChanged();
+
+        var emmetMarkupHints = new EmmetMarkupHints();
+        CodeHintManager.registerHintProvider(emmetMarkupHints, ["html", "php", "jsp"], 2);
+
+    });
+});
+
+
+
+
+

--- a/src/extensionsIntegrated/loader.js
+++ b/src/extensionsIntegrated/loader.js
@@ -43,4 +43,5 @@ define(function (require, exports, module) {
     require("./HtmlTagSyncEdit/main");
     require("./indentGuides/main");
     require("./CSSColorPreview/main");
+    require("./Emmet/main");
 });

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -1264,6 +1264,9 @@ define({
     "DESCRIPTION_HIDE_FIRST": "true to show the first Indent Guide line else false.",
     "DESCRIPTION_CSS_COLOR_PREVIEW": "true to display color previews in the gutter, else false.",
 
+    // Emmet
+    "DESCRIPTION_EMMET": "true to enable Emmet, else false.",
+
     // Git extension
     "ENABLE_GIT": "Enable Git",
     "ACTION": "Action",

--- a/src/preferences/AllPreferences.js
+++ b/src/preferences/AllPreferences.js
@@ -1,0 +1,50 @@
+/*
+ * GNU AGPL-3.0 License
+ *
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
+ * Original work Copyright (c) 2012 - 2021 Adobe Systems Incorporated. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
+ *
+ */
+
+/*
+ * This file houses all the preferences used across Phoenix.
+ *
+ * To use:
+ * ```
+ * const AllPreferences = brackets.getModule("preferences/AllPreferences");
+ * function preferenceChanged() {
+       enabled = PreferencesManager.get(AllPreferences.EMMET);
+   }
+ * PreferencesManager.on("change", AllPreferences.EMMET, preferenceChanged);
+   preferenceChanged();
+ * ```
+ */
+
+define(function (require, exports, module) {
+    const PreferencesManager = require("preferences/PreferencesManager");
+    const Strings = require("strings");
+
+    // list of all the preferences
+    const PREFERENCES_LIST = {
+        EMMET: "emmet"
+    };
+
+    PreferencesManager.definePreference(PREFERENCES_LIST.EMMET, "boolean", true, {
+        description: Strings.DESCRIPTION_EMMET
+    });
+
+    module.exports = PREFERENCES_LIST;
+});

--- a/src/styles/brackets_core_ui_variables.less
+++ b/src/styles/brackets_core_ui_variables.less
@@ -272,3 +272,7 @@
 @dark-bc-codehint-desc:              #2c2c2c;
 @dark-bc-codehint-desc-type-details: #46a0f5;
 @dark-bc-codehint-desc-documentation:#b1b1b1;
+
+// CSS Codehint icon
+@css-codehint-icon:                 #2ea56c;
+@dark-css-codehint-icon:            #146a41;

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -709,6 +709,24 @@ a:focus {
     }
 }
 
+.emmet-css-code-hint {
+  visibility: hidden;
+}
+
+.highlight .emmet-css-code-hint {
+  visibility: visible;
+  position: absolute;
+  right: 8px;
+  font-size: 0.7em;
+  font-weight: bold;
+  margin-top: 2px;
+  letter-spacing: 0.3px;
+  color: #2ea56c !important;
+  .dark& {
+    color: #146a41 !important;
+  }
+}
+
 #codehint-desc {
 	background: @bc-codehint-desc;
 	position: absolute;

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -725,6 +725,17 @@ a:focus {
   .dark& {
     color: @dark-css-codehint-icon !important;
   }
+
+.emmet-code-hint {
+    position: absolute;
+    font-size: 0.5em;
+    font-weight: bold;
+    right: 4px;
+    bottom: 0px;
+    color: #2ea56c !important;
+    .dark& {
+        color: #146a41 !important;
+    }
 }
 
 #codehint-desc {

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -709,17 +709,19 @@ a:focus {
     }
 }
 
+
+
 .emmet-css-code-hint {
   visibility: hidden;
 }
 
-.highlight .emmet-css-code-hint {
+.codehint-menu .dropdown-menu li .highlight .emmet-css-code-hint {
   visibility: visible;
   position: absolute;
-  right: 8px;
-  font-size: 0.7em;
-  font-weight: bold;
-  margin-top: 2px;
+  right: 0;
+  margin-top: -2px;
+  font-size: 0.85em !important;
+  font-weight: @font-weight-semibold;
   letter-spacing: 0.3px;
   color: #2ea56c !important;
   .dark& {

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -703,13 +703,11 @@ a:focus {
     position: absolute;
     right: 0;
     margin-top:-2px;
-    color: #2ea56c !important;
+    color: @css-codehint-icon  !important;
     .dark& {
-        color: #146a41 !important;
+        color: @dark-css-codehint-icon !important;
     }
 }
-
-
 
 .emmet-css-code-hint {
   visibility: hidden;
@@ -723,9 +721,9 @@ a:focus {
   font-size: 0.85em !important;
   font-weight: @font-weight-semibold;
   letter-spacing: 0.3px;
-  color: #2ea56c !important;
+  color: @css-codehint-icon !important;
   .dark& {
-    color: #146a41 !important;
+    color: @dark-css-codehint-icon !important;
   }
 }
 


### PR DESCRIPTION
This PR adds built-in Emmet support for CSS, LESS, SCSS to Phoenix.

When an abbreviation can be expanded into a CSS property, we display that property as a code hint with the highest priority. A small "emmet" icon is shown at the right of the hint to indicate that the hint is coming from Emmet.



https://github.com/user-attachments/assets/7a59b077-9d7d-476f-9e68-269b9f9aa9f3



