### PR TITLE
Emmet Integration

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -121,6 +121,7 @@ define(function (require, exports, module) {
     // load modules for later use
     require("utils/Global");
     require("editor/CSSInlineEditor");
+    require("preferences/AllPreferences");
     require("project/WorkingSetSort");
     require("search/QuickOpen");
     require("search/QuickOpenHelper");

--- a/src/extensions/default/HTMLCodeHints/emmet-snippets.js
+++ b/src/extensions/default/HTMLCodeHints/emmet-snippets.js
@@ -1,0 +1,246 @@
+/*
+ * GNU AGPL-3.0 License
+ *
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
+ * Original work Copyright (c) 2024 [emmet.io](https://github.com/emmetio/brackets-emmet).
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
+ */
+
+
+/**
+ * Emmet Snippets Configuration
+ *
+ * This file defines the configuration for Emmet snippet expansion.
+ * It contains four main exports:
+ *
+ * 1. **markupSnippets**: An object that maps abbreviation keys to their expanded HTML markup.
+ *    These are all the abbreviations that can be expanded into something other than the usual tags.
+ *    When an abbreviation matching one of the markup snippets is passed to Emmet, it knows how to expand it.
+ *  These are sourced from `thirdparty/emmet.es.js`. To update this in future, refer to that file.
+ *
+ *
+ * 2. **htmlTags**: An array of standard HTML tags that are expanded by default.
+ *    This list helps determine whether an abbreviation corresponds to a valid HTML element.
+ *    Although Emmet can expand any text as an HTML tag,
+ *    doing so would trigger code hints for every piece of text in the editor.
+ *    So, we maintain a list of standard tags;
+ *    only when an abbreviation matches one of these does Emmet display the code hints.
+ *
+ * 3. **positiveSymbols**: An array of symbols that, when present in an abbreviation,
+ *    indicate that the abbreviation is eligible for expansion.
+ *    Examples include `.`, `#`, `>`, `+`, etc., which are used for classes, IDs, nesting,
+ *    sibling selectors, attributes, and more.
+ *
+ * 4. **negativeSymbols**: An array of sequences that indicate a word should NOT be expanded.
+ *    For example, the sequence `</` (which begins a closing tag) signals
+ *    that the abbreviation should be ignored for expansion.
+ */
+define(function (require, exports, module) {
+
+
+    const markupSnippets = {
+        "a": "a[href]",
+        "a:blank": "a[href='http://${0}' target='_blank' rel='noopener noreferrer']",
+        "a:link": "a[href='http://${0}']",
+        "a:mail": "a[href='mailto:${0}']",
+        "a:tel": "a[href='tel:+${0}']",
+        "abbr": "abbr[title]",
+        "acr|acronym": "acronym[title]",
+        "base": "base[href]/",
+        "basefont": "basefont/",
+        "br": "br/",
+        "frame": "frame/",
+        "hr": "hr/",
+        "bdo": "bdo[dir]",
+        "bdo:r": "bdo[dir=rtl]",
+        "bdo:l": "bdo[dir=ltr]",
+        "col": "col/",
+        "link": "link[rel=stylesheet href]/",
+        "link:css": "link[href='${1:style}.css']",
+        "link:print": "link[href='${1:print}.css' media=print]",
+        "link:favicon": "link[rel='shortcut icon' type=image/x-icon href='${1:favicon.ico}']",
+        "link:mf|link:manifest": "link[rel='manifest' href='${1:manifest.json}']",
+        "link:touch": "link[rel=apple-touch-icon href='${1:favicon.png}']",
+        "link:rss": "link[rel=alternate type=application/rss+xml title=RSS href='${1:rss.xml}']",
+        "link:atom": "link[rel=alternate type=application/atom+xml title=Atom href='${1:atom.xml}']",
+        "link:im|link:import": "link[rel=import href='${1:component}.html']",
+        "meta": "meta/",
+        "meta:utf": "meta[http-equiv=Content-Type content='text/html;charset=UTF-8']",
+        "meta:vp": "meta[name=viewport content='width=${1:device-width}, initial-scale=${2:1.0}']",
+        "meta:compat": "meta[http-equiv=X-UA-Compatible content='${1:IE=7}']",
+        "meta:edge": "meta:compat[content='${1:ie=edge}']",
+        "meta:redirect": "meta[http-equiv=refresh content='0; url=${1:http://example.com}']",
+        "meta:refresh": "meta[http-equiv=refresh content='${1:5}']",
+        "meta:kw": "meta[name=keywords content]",
+        "meta:desc": "meta[name=description content]",
+        "style": "style",
+        "script": "script",
+        "script:src": "script[src]",
+        "script:module": "script[type=module src]",
+        "img": "img[src alt]/",
+        "img:s|img:srcset": "img[srcset src alt]",
+        "img:z|img:sizes": "img[sizes srcset src alt]",
+        "picture": "picture",
+        "src|source": "source/",
+        "src:sc|source:src": "source[src type]",
+        "src:s|source:srcset": "source[srcset]",
+        "src:t|source:type": "source[srcset type='${1:image/}']",
+        "src:z|source:sizes": "source[sizes srcset]",
+        "src:m|source:media": "source[media='(${1:min-width: })' srcset]",
+        "src:mt|source:media:type": "source:media[type='${2:image/}']",
+        "src:mz|source:media:sizes": "source:media[sizes srcset]",
+        "src:zt|source:sizes:type": "source[sizes srcset type='${1:image/}']",
+        "iframe": "iframe[src frameborder=0]",
+        "embed": "embed[src type]/",
+        "object": "object[data type]",
+        "param": "param[name value]/",
+        "map": "map[name]",
+        "area": "area[shape coords href alt]/",
+        "area:d": "area[shape=default]",
+        "area:c": "area[shape=circle]",
+        "area:r": "area[shape=rect]",
+        "area:p": "area[shape=poly]",
+        "form": "form[action]",
+        "form:get": "form[method=get]",
+        "form:post": "form[method=post]",
+        "label": "label[for]",
+        "input": "input[type=${1:text}]/",
+        "inp": "input[name=${1} id=${1}]",
+        "input:h|input:hidden": "input[type=hidden name]",
+        "input:t|input:text": "inp[type=text]",
+        "input:search": "inp[type=search]",
+        "input:email": "inp[type=email]",
+        "input:url": "inp[type=url]",
+        "input:p|input:password": "inp[type=password]",
+        "input:datetime": "inp[type=datetime]",
+        "input:date": "inp[type=date]",
+        "input:datetime-local": "inp[type=datetime-local]",
+        "input:month": "inp[type=month]",
+        "input:week": "inp[type=week]",
+        "input:time": "inp[type=time]",
+        "input:tel": "inp[type=tel]",
+        "input:number": "inp[type=number]",
+        "input:color": "inp[type=color]",
+        "input:c|input:checkbox": "inp[type=checkbox]",
+        "input:r|input:radio": "inp[type=radio]",
+        "input:range": "inp[type=range]",
+        "input:f|input:file": "inp[type=file]",
+        "input:s|input:submit": "input[type=submit value]",
+        "input:i|input:image": "input[type=image src alt]",
+        "input:b|input:btn|input:button": "input[type=button value]",
+        "input:reset": "input:button[type=reset]",
+        "isindex": "isindex/",
+        "select": "select[name=${1} id=${1}]",
+        "select:d|select:disabled": "select[disabled.]",
+        "opt|option": "option[value]",
+        "textarea": "textarea[name=${1} id=${1}]",
+        "tarea:c|textarea:cols": "textarea[name=${1} id=${1} cols=${2:30}]",
+        "tarea:r|textarea:rows": "textarea[name=${1} id=${1} rows=${3:10}]",
+        "tarea:cr|textarea:cols:rows": "textarea[name=${1} id=${1} cols=${2:30} rows=${3:10}]",
+        "marquee": "marquee[behavior direction]",
+        "menu:c|menu:context": "menu[type=context]",
+        "menu:t|menu:toolbar": "menu[type=toolbar]",
+        "video": "video[src]",
+        "audio": "audio[src]",
+        "html:xml": "html[xmlns=http://www.w3.org/1999/xhtml]",
+        "keygen": "keygen/",
+        "command": "command/",
+        "btn:s|button:s|button:submit": "button[type=submit]",
+        "btn:r|button:r|button:reset": "button[type=reset]",
+        "btn:b|button:b|button:button": "button[type=button]",
+        "btn:d|button:d|button:disabled": "button[disabled.]",
+        "fst:d|fset:d|fieldset:d|fieldset:disabled": "fieldset[disabled.]",
+
+        "bq": "blockquote",
+        "fig": "figure",
+        "figc": "figcaption",
+        "pic": "picture",
+        "ifr": "iframe",
+        "emb": "embed",
+        "obj": "object",
+        "cap": "caption",
+        "colg": "colgroup",
+        "fst": "fieldset",
+        "btn": "button",
+        "optg": "optgroup",
+        "tarea": "textarea",
+        "leg": "legend",
+        "sect": "section",
+        "art": "article",
+        "hdr": "header",
+        "ftr": "footer",
+        "adr": "address",
+        "dlg": "dialog",
+        "str": "strong",
+        "prog": "progress",
+        "mn": "main",
+        "tem": "template",
+        "fset": "fieldset",
+        "datal": "datalist",
+        "kg": "keygen",
+        "out": "output",
+        "det": "details",
+        "sum": "summary",
+        "cmd": "command",
+        "data": "data[value]",
+        "meter": "meter[value]",
+        "time": "time[datetime]",
+
+        "ri:d|ri:dpr": "img:s",
+        "ri:v|ri:viewport": "img:z",
+        "ri:a|ri:art": "pic>src:m+img",
+        "ri:t|ri:type": "pic>src:t+img",
+
+        "!!!": "{<!DOCTYPE html>}",
+        "doc": "html[lang=${lang}]>(head>meta[charset=${charset}]+meta:vp+title{${1:Document}})+body",
+        "!|html:5": "!!!+doc",
+
+        "c": "{<!-- ${0} -->}",
+        "cc:ie": "{<!--[if IE]>${0}<![endif]-->}",
+        "cc:noie": "{<!--[if !IE]><!-->${0}<!--<![endif]-->}"
+    };
+
+
+    const htmlTags = [
+        "a", "abbr", "address", "area", "article", "aside", "audio", "b", "base",
+        "bdi", "bdo", "blockquote", "body", "br", "button", "canvas", "caption",
+        "cite", "code", "col", "colgroup", "data", "datalist", "dd", "del",
+        "details", "dfn", "dialog", "div", "dl", "dt", "em", "embed", "fieldset",
+        "figcaption", "figure", "footer", "form", "h1", "h2", "h3", "h4", "h5",
+        "h6", "head", "header", "hgroup", "hr", "html", "i", "iframe", "img",
+        "input", "ins", "kbd", "label", "legend", "li", "link", "main", "map",
+        "mark", "meta", "meter", "nav", "noscript", "object", "ol", "optgroup",
+        "option", "output", "p", "param", "picture", "pre", "progress", "q",
+        "rp", "rt", "ruby", "s", "samp", "script", "section", "select", "small",
+        "source", "span", "strong", "style", "sub", "summary", "sup", "table",
+        "tbody", "td", "template", "textarea", "tfoot", "th", "thead", "time",
+        "title", "tr", "track", "u", "ul", "var", "video", "wbr"
+    ];
+
+
+    const positiveSymbols = [
+        '.', '#', '!', '>', '+', '^', '*', '[', ']', '{', '}', '(', ')', '&'
+    ];
+
+
+    const negativeSymbols = [
+        '</'
+    ];
+
+    exports.markupSnippets = markupSnippets;
+    exports.htmlTags = htmlTags;
+    exports.positiveSymbols = positiveSymbols;
+    exports.negativeSymbols = negativeSymbols;
+});

--- a/src/extensions/default/HTMLCodeHints/main.js
+++ b/src/extensions/default/HTMLCodeHints/main.js
@@ -33,6 +33,7 @@ define(function (require, exports, module) {
         CSSUtils            = brackets.getModule("language/CSSUtils"),
         StringMatch         = brackets.getModule("utils/StringMatch"),
         LiveDevelopment     = brackets.getModule("LiveDevelopment/main"),
+        AllPreferences      = brackets.getModule("preferences/AllPreferences"),
         KeyEvent            = brackets.getModule("utils/KeyEvent"),
         Metrics             = brackets.getModule("utils/Metrics"),
         HTMLTags            = require("text!HtmlTags.json"),
@@ -41,6 +42,28 @@ define(function (require, exports, module) {
         XHTMLTemplate       = require("text!template.xhtml");
 
     require("./html-lint");
+
+    const {
+        markupSnippets,
+        htmlTags,
+        positiveSymbols,
+        negativeSymbols
+    } = require('./emmet-snippets');
+
+    /**
+     * The Emmet api's
+     */
+    const EXPAND_ABBR = Phoenix.libs.Emmet.expand;
+
+    /**
+     * A list of all the markup snippets that can be expanded.
+     * For ex: 'link:css', 'iframe'
+     * They expand differently as compared to normal tags.
+     * Refer to `./emmet-snippets.js` file for more info.
+     */
+    const markupSnippetsList = Object.keys(markupSnippets);
+    let enabled = true; // whether Emmet is enabled or not in preferences
+
 
     let tags,
         attributes;
@@ -52,6 +75,452 @@ define(function (require, exports, module) {
     PreferencesManager.definePreference("codehint.AttrHints", "boolean", true, {
         description: Strings.DESCRIPTION_ATTR_HINTS
     });
+
+    /**
+     * @constructor
+     */
+    function EmmetMarkupHints() {
+    }
+
+
+    /**
+     * Checks whether hints are available for the current word where cursor is present.
+     *
+     * @param {Editor} editor - the editor instance
+     * @param {String} implicitChar - unused param [didn't remove, as we might need it in future]
+     * @returns {Boolean} - true if the abbr can be expanded otherwise false.
+     */
+    EmmetMarkupHints.prototype.hasHints = function (editor, implicitChar) {
+        if (enabled) {
+            this.editor = editor;
+
+            const wordObj = getWordBeforeCursor(editor);
+            // make sure we donot have empty spaces
+            if (wordObj.word.trim()) {
+
+                const expandedAbbr = isExpandable(editor, wordObj.word);
+                if (expandedAbbr) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    };
+
+
+    /**
+     * Returns the Emmet hint for the current word before the cursor.
+     * The hint element will have an appended "Emmet" icon at bottom-rigth to indicate it's an Emmet abbreviation.
+     *
+     * @param {String} implicitChar - unused param [didn't remove, as we might need it in future]
+     */
+    EmmetMarkupHints.prototype.getHints = function (implicitChar) {
+        const wordObj = getWordBeforeCursor(this.editor);
+
+        // Check if the abbreviation is expandable
+        const expandedAbbr = isExpandable(this.editor, wordObj.word);
+        if (!expandedAbbr) {
+            return null;
+        }
+
+        // Create the formatted hint element with an appended Emmet icon
+        const formattedHint = formatEmmetHint(wordObj.word);
+
+        return {
+            hints: [formattedHint],
+            match: null,
+            selectInitial: true,
+            defaultDescriptionWidth: true,
+            handleWideResults: false
+        };
+    };
+
+
+    /**
+     * Formats an Emmet abbreviation hint by appending an icon.
+     *
+     * @param {string} abbr - The Emmet abbreviation.
+     * @returns {jQuery} - A jQuery element representing the formatted hint.
+     */
+    function formatEmmetHint(abbr) {
+        // Create the main container for the hint text.
+        var $hint = $("<span>")
+            .addClass("emmet-hint")
+            .text(abbr);
+
+        // style in brackets_patterns_override.less file
+        let $icon = $(`<span class="emmet-code-hint">Emmet</span>`);
+
+        // Append the icon to the hint element
+        $hint.append($icon);
+
+        return $hint;
+    }
+
+
+    /**
+     * Responsible for updating the abbr with the expanded text in the editor.
+     * This function calls helper functions for this as there are,
+     * lot of complex cases that should be taken care of.
+     */
+    EmmetMarkupHints.prototype.insertHint = function () {
+        const wordObj = getWordBeforeCursor(this.editor);
+        const expandedAbbr = isExpandable(this.editor, wordObj.word);
+        updateAbbrInEditor(this.editor, wordObj, expandedAbbr);
+        return false;
+    };
+
+
+    /**
+     * Determines whether a given character is allowed as part of an Emmet abbreviation
+     *
+     * @param {String} char - The character to test
+     * @param {Boolean} insideBraces - Flag indicating if we are inside braces (e.g. {} or [])
+     * @returns True if the character is valid for an abbreviation
+     */
+    function isEmmetChar(char, insideBraces) {
+        // Valid abbreviation characters: letters, digits, and some punctuation
+        // Adjust this regex or the list as needed for your implementation
+        const validPattern = /[a-zA-Z0-9:+*<>()/!$\-@#}{]/;
+        const specialChars = new Set(['.', '#', '[', ']', '"', '=', ':', ',', '-']);
+        return validPattern.test(char) || specialChars.has(char) || (insideBraces && char === ' ');
+    }
+
+
+    /**
+     * Scans backwards from the given cursor position on a line to locate the start of the Emmet abbreviation
+     *
+     * @param {String} line - The full text of the current line
+     * @param {Number} cursorCh - The cursor's character (column) position on that line
+     * @returns The index (column) where the abbreviation starts
+     */
+    function findAbbreviationStart(line, cursorCh) {
+        let start = cursorCh;
+        let insideBraces = false;
+
+        // If the cursor is right before a closing brace, adjust it to be "inside" the braces
+        if (line.charAt(start) === '}' || line.charAt(start) === ']') {
+            start--;
+            insideBraces = true;
+        }
+
+        // Walk backwards from the cursor to find the boundary of the abbreviation
+        while (start > 0) {
+            const char = line.charAt(start - 1);
+
+            // Update our "inside braces" state based on the character
+            if (char === '}' || char === ']') {
+                insideBraces = true;
+            } else if (char === '{' || char === '[') {
+                insideBraces = false;
+            }
+
+            // If the character is valid as part of an Emmet abbreviation, continue scanning backwards
+            if (isEmmetChar(char, insideBraces)) {
+                start--;
+            } else {
+                break;
+            }
+        }
+        return start;
+    }
+
+
+    /**
+     * Retrieves the Emmet abbreviation (i.e. the word before the cursor) from the current editor state
+     *
+     * @param {Editor} editor - The editor instance
+     * @returns An object with the abbreviation and its start/end positions
+     *
+     * Format:
+     * {
+     *   word: string,             // the extracted abbreviation
+     *   start: { line: number, ch: number },
+     *   end: { line: number, ch: number }
+     * }
+     */
+    function getWordBeforeCursor(editor) {
+        const pos = editor.getCursorPos();
+        const lineText = editor.document.getLine(pos.line);
+
+        // to determine where the abbreviation starts on the line
+        const abbreviationStart = findAbbreviationStart(lineText, pos.ch);
+
+        // Optionally, adjust the end position if the cursor is immediately before a closing brace.
+        let abbreviationEnd = pos.ch;
+        if (lineText.charAt(abbreviationEnd) === '}' || lineText.charAt(abbreviationEnd) === ']') {
+            abbreviationEnd++;
+        }
+
+        const word = lineText.substring(abbreviationStart, abbreviationEnd);
+
+        return {
+            word: word,
+            start: { line: pos.line, ch: abbreviationStart },
+            end: { line: pos.line, ch: abbreviationEnd }
+        };
+    }
+
+
+    /**
+     * Calculate the indentation level for the current line
+     *
+     * @param {Editor} editor - the editor instance
+     * @param {Object} position - position object with line number
+     * @returns {String} - the indentation string
+     */
+    function getLineIndentation(editor, position) {
+        const line = editor.document.getLine(position.line);
+        const match = line.match(/^\s*/);
+        return match ? match[0] : '';
+    }
+
+
+    /**
+     * Adds proper indentation to multiline Emmet expansion
+     *
+     * @param {String} expandedText - the expanded Emmet abbreviation
+     * @param {String} baseIndent - the base indentation string
+     * @returns {String} - properly indented text
+     */
+    function addIndentation(expandedText, baseIndent) {
+        // Split into lines, preserve empty lines
+        const lines = expandedText.split(/(\r\n|\n)/g);
+
+        // Process each line
+        let result = '';
+        let isFirstLine = true;
+
+        for (let i = 0; i < lines.length; i++) {
+            const line = lines[i];
+
+            // If it's a newline character, just add it
+            if (line === '\n' || line === '\r\n') {
+                result += line;
+                continue;
+            }
+
+            // Skip indenting empty lines
+            if (line.trim() === '') {
+                result += line;
+                continue;
+            }
+
+            // Don't indent the first line as it inherits the current indent
+            if (isFirstLine) {
+                result += line;
+                isFirstLine = false;
+            } else {
+                // Add base indent plus the existing indent in the expanded text
+                result += baseIndent + line;
+            }
+        }
+
+        return result;
+    }
+
+
+
+    /**
+     * Find the position where cursor should be placed after expansion
+     * Looks for patterns like '><', '""', ''
+     *
+     * @param {Editor} editor - The editor instance
+     * @param {String} indentedAbbr - the indented abbreviation
+     * @param {Object} startPos - Starting position {line, ch} of the expansion
+     * @returns {Object | false} - Cursor position {line, ch} or false if no pattern found
+     */
+    function findCursorPosition(editor, indentedAbbr, startPos) {
+        const totalLines = startPos.line + indentedAbbr.split('\n').length;
+
+        for (let i = startPos.line; i < totalLines; i++) {
+            const line = editor.document.getLine(i);
+
+            for (let j = 0; j < line.length - 1; j++) {
+                const pair = line[j] + line[j + 1];
+
+                if (pair === '""' || pair === "''") {
+                    return { line: i, ch: j + 1 };
+                }
+            }
+            for (let j = 0; j < line.length - 1; j++) {
+                const pair = line[j] + line[j + 1];
+
+                if (pair === '><') {
+                    return { line: i, ch: j + 1 };
+                }
+            }
+        }
+
+        // Look for opening and closing tag pairs with empty line in between
+        // <body>
+        //      |
+        // </body>
+        // here in such scenarios, we want the cursor to be placed in between
+        // Look for opening and closing tag pairs with empty line in between
+        for (let i = startPos.line; i < totalLines; i++) {
+            const line = editor.document.getLine(i).trim();
+            if (line.endsWith('>') && line.includes('<') && !line.includes('</')) {
+                if (editor.document.getLine(i + 1) && !editor.document.getLine(i + 1).trim()) {
+                    const tempLine = editor.document.getLine(i + 2);
+                    if (tempLine) {
+                        const trimmedTempLine = tempLine.trim();
+                        if (trimmedTempLine.includes('</') && trimmedTempLine.startsWith('<')) {
+                            // Get the current line's indentation by counting spaces/tabs
+                            const openingTagLine = editor.document.getLine(i);
+                            const indentMatch = openingTagLine.match(/^[\s\t]*/)[0];
+                            // Add 4 more spaces (or equivalent tab) for inner content
+                            const extraIndent = '    ';  // 4 spaces for additional indentation
+
+                            return {
+                                line: i + 1,
+                                ch: indentMatch.length + extraIndent.length
+                            };
+                        }
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+
+
+    /**
+     * This function is responsible to replace the abbreviation in the editor,
+     * with its expanded version
+     *
+     * @param {Editor} editor - the editor instance
+     * @param {Object} wordObj -  an object in the format :
+     * {
+     *      word: "",   // the word before the cursor
+     *      start: {line: Number, ch: Number},
+     *      end: {line: Number, ch: Number}
+     * }
+     * @param {String} expandedAbbr - the expanded version of abbr that will replace the abbr
+     */
+    function updateAbbrInEditor(editor, wordObj, expandedAbbr) {
+        // Get the current line's indentation
+        const baseIndent = getLineIndentation(editor, wordObj.start);
+
+        // Add proper indentation to the expanded abbreviation
+        const indentedAbbr = addIndentation(expandedAbbr, baseIndent);
+
+        // Handle the special case for braces
+        // this check is added because in some situations such as
+        // `ul>li{Hello}` and the cursor is before the closing braces right after 'o',
+        // then when this is expanded it results in an extra closing braces at the end.
+        // so we remove the extra closing brace from the end
+        if (wordObj.word.includes('{') || wordObj.word.includes('[')) {
+            const pos = editor.getCursorPos();
+            const line = editor.document.getLine(pos.line);
+            const char = line.charAt(wordObj.end.ch);
+            const charsNext = line.charAt(wordObj.end.ch + 1);
+
+            if (char === '}' || char === ']') {
+                wordObj.end.ch += 1;
+            }
+
+            // sometimes at the end we get `"]` as extra with some abbreviations.
+            if (char === '"' && charsNext && charsNext === ']') {
+                wordObj.end.ch += 2;
+            }
+
+        }
+
+        // Replace the abbreviation
+        editor.document.replaceRange(
+            indentedAbbr,
+            wordObj.start,
+            wordObj.end
+        );
+
+        // Calculate and set the new cursor position
+        const cursorPos = findCursorPosition(editor, indentedAbbr, wordObj.start);
+        if (cursorPos) {
+            editor.setCursorPos(cursorPos.line, cursorPos.ch);
+        }
+    }
+
+
+    /**
+     * This function checks whether the abbreviation can be expanded or not.
+     * There are a lot of cases to check:
+     * There should not be any negative symbols
+     * The abbr should be either in htmlTags or in markupSnippetsList
+     * For other cases such as 'ul>li', we will check if there is any,
+     * positive word. This is done to handle complex abbreviations such as,
+     * 'ul>li' or 'li*3{Hello}'. So we check if the word includes any positive symbols.
+     *
+     * @param {Editor} editor - the editor instance
+     * @param {String} word - the abbr
+     * @returns {String | false} - returns the expanded abbr, and if cannot be expanded, returns false
+     */
+    function isExpandable(editor, word) {
+        const pos = editor.getCursorPos();
+        const line = editor.document.getLine(pos.line);
+
+        // to prevent hints from appearing in <!DOCTYPE html> line. Also to prevent hints from appearing in comments
+        if(line.includes('<!')) {
+            return false;
+        }
+
+        // to show emmet hint when either a single or three exclamation mark(s) is present
+        if (line.includes('!!') && !line.includes('!!!')) {
+            return false;
+        }
+
+        // if more than three, then don't show emmet hint
+        if(line.includes('!!!!')) {
+            return false;
+        }
+
+        // make sure that word doesn't contain any negativeSymbols
+        if (negativeSymbols.some(symbol => word.includes(symbol))) {
+            return false;
+        }
+
+        // the word must be either in markupSnippetsList, htmlList or it must have a positive symbol
+        // convert to lowercase only for `htmlTags` because HTML tag names are case-insensitive,
+        // but `markupSnippetsList` expands abbreviations in a non-tag manner,
+        // where the expanded abbreviation is already in lowercase.
+        if (markupSnippetsList.includes(word) ||
+            htmlTags.includes(word.toLowerCase()) ||
+            positiveSymbols.some(symbol => word.includes(symbol))) {
+
+            try {
+                const expanded = EXPAND_ABBR(word, { syntax: "html", type: "markup" });
+                return expanded;
+            } catch (error) {
+
+                // emmet api throws an error when abbr contains unclosed quotes, handling that case
+                const nextChar = line.charAt(pos.ch);
+
+                if (nextChar) {
+                    // If the next character is a quote, add quote to abbr
+                    if (nextChar === '"' || nextChar === "'") {
+                        const modifiedWord = word + nextChar;
+
+                        try {
+                            const expandedModified = EXPAND_ABBR(modifiedWord, { syntax: "html", type: "markup" });
+                            return expandedModified;
+                        } catch (innerError) {
+                            // If it still fails, return false
+                            return false;
+                        }
+                    }
+                }
+
+                // If no quote is found or expansion fails, return false
+                return false;
+            }
+        }
+
+        return false;
+    }
+
 
     /**
      * @constructor
@@ -733,6 +1202,14 @@ define(function (require, exports, module) {
         });
     };
 
+    /**
+     * Checks for preference changes, to enable/disable Emmet
+     */
+    function preferenceChanged() {
+        enabled = PreferencesManager.get(AllPreferences.EMMET);
+    }
+
+
     AppInit.appReady(function () {
         // Parse JSON files
         tags = JSON.parse(HTMLTags);
@@ -746,7 +1223,14 @@ define(function (require, exports, module) {
         CodeHintManager.registerHintProvider(attrHints, ["html"], 0);
         NewFileContentManager.registerContentProvider(newDocContentProvider, ["html"], 0);
 
+        PreferencesManager.on("change", AllPreferences.EMMET, preferenceChanged);
+        preferenceChanged();
+
+        var emmetMarkupHints = new EmmetMarkupHints();
+        CodeHintManager.registerHintProvider(emmetMarkupHints, ["html", "php", "jsp"], 0);
+
         // For unit testing
+        exports.emmetHintProvider = emmetMarkupHints;
         exports.tagHintProvider = tagHints;
         exports.attrHintProvider = attrHints;
     });

--- a/src/extensions/default/HTMLCodeHints/unittests.js
+++ b/src/extensions/default/HTMLCodeHints/unittests.js
@@ -94,6 +94,14 @@ define(function (require, exports, module) {
             expect(hintList[0]).toBe(expectedFirstHint);
         }
 
+        // Helper function for testing cursor position
+        function fixPos(pos) {
+            if (!("sticky" in pos)) {
+                pos.sticky = null;
+            }
+            return pos;
+        }
+
 
         describe("Tag hint provider", function () {
 
@@ -681,6 +689,128 @@ define(function (require, exports, module) {
                 selectHint(HTMLCodeHints.attrHintProvider, "rtl");
                 expect(testDocument.getLine(7)).toBe("  <a dir=\"rtl\"><span class=\"foo\"></span></a>");
                 expectCursorAt({ line: 7, ch: 14 });          // cursor after the inserted value
+            });
+        });
+
+
+        describe("Emmet hint provider", function () {
+
+            it("should display emmet hint and expand to boilerplate code on ! press", function () {
+
+                let emmetBoilerPlate = [
+                    "<!DOCTYPE html>",
+                    "<html lang=\"en\">",
+                    "<head>",
+                    "	<meta charset=\"UTF-8\">",
+                    "	<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">",
+                    "	<title>Document</title>",
+                    "</head>",
+                    "<body>",
+                    "	",
+                    "</body>",
+                    "</html>"
+                ];
+
+                testDocument.setText("!");
+                testEditor.setCursorPos({ line: 0, ch: 1 });
+                const hints = expectHints(HTMLCodeHints.emmetHintProvider);
+
+                // get the hintText from the code hint
+                const hintText = hints[0][0].textContent;
+                expect(hintText).toBe("!Emmet"); // this should be same as the setText plus the Emmet
+
+                // also test after inserting the hint
+                HTMLCodeHints.emmetHintProvider.insertHint(hints[0]);
+
+                for(let i = 0; i <= 10; i++) {
+                    expect(testDocument.getLine(i)).toBe(emmetBoilerPlate[i]);
+                }
+
+                // make sure the cursor is between the body tag
+                expect(fixPos(testEditor.getCursorPos())).toEql(fixPos({line: 8, ch: 1}));
+            });
+
+
+            it("should display emmet hint and expand to doctype html initial line on !!! press", function () {
+
+                let emmetBoilerPlate = "<!DOCTYPE html>";
+
+                testDocument.setText("!!!");
+                testEditor.setCursorPos({ line: 0, ch: 3 });
+                const hints = expectHints(HTMLCodeHints.emmetHintProvider);
+
+                const hintText = hints[0][0].textContent;
+                expect(hintText).toBe("!!!Emmet");
+
+                HTMLCodeHints.emmetHintProvider.insertHint(hints[0]);
+                expect(testDocument.getLine(0)).toBe(emmetBoilerPlate);
+
+                expect(fixPos(testEditor.getCursorPos())).toEql(fixPos({line: 0, ch: 15}));
+            });
+
+            it("should not display hints when two or more than three exclamation marks are present", function () {
+                testDocument.setText("!!");
+                testEditor.setCursorPos({ line: 0, ch: 2 });
+                expectNoHints(HTMLCodeHints.emmetHintProvider);
+
+                testDocument.setText("!!!!");
+                testEditor.setCursorPos({ line: 0, ch: 4 });
+                expectNoHints(HTMLCodeHints.emmetHintProvider);
+            });
+
+            it("should not display emmet hints on < key press", function () {
+                testDocument.setText("<");
+                testEditor.setCursorPos({ line: 0, ch: 1 });
+                expectNoHints(HTMLCodeHints.emmetHintProvider);
+            });
+
+            it("should add class name id name if abbr contains . and #", function () {
+                testDocument.setText("div.hello#world");
+                testEditor.setCursorPos({ line: 0, ch: 15 });
+
+                const hints = expectHints(HTMLCodeHints.emmetHintProvider);
+
+                const hintText = hints[0][0].textContent;
+                expect(hintText).toBe("div.hello#worldEmmet");
+
+                HTMLCodeHints.emmetHintProvider.insertHint(hints[0]);
+                expect(testDocument.getLine(0)).toBe("<div class=\"hello\" id=\"world\"></div>");
+
+                expect(fixPos(testEditor.getCursorPos())).toEql(fixPos({line: 0, ch: 30}));
+            });
+
+            it("./# should expand to a div with empty class/id name and set cursor in between quotes", function() {
+                testDocument.setText(".");
+                testEditor.setCursorPos({ line: 0, ch: 1 });
+                let hints = expectHints(HTMLCodeHints.emmetHintProvider);
+
+                HTMLCodeHints.emmetHintProvider.insertHint(hints[0]);
+                expect(fixPos(testEditor.getCursorPos())).toEql(fixPos({line: 0, ch: 12}));
+
+                testDocument.setText("#");
+                testEditor.setCursorPos({ line: 0, ch: 1 });
+                hints = expectHints(HTMLCodeHints.emmetHintProvider);
+
+                HTMLCodeHints.emmetHintProvider.insertHint(hints[0]);
+                expect(fixPos(testEditor.getCursorPos())).toEql(fixPos({line: 0, ch: 9}));
+            });
+
+            it("should expand emmet snippet with * and {}", function() {
+                const emmetSnippetResult = "<ul>\n" +
+                    "	<li>hello world</li>\n" +
+                    "	<li>hello world</li>\n" +
+                    "	<li>hello world</li>\n" +
+                    "	<li>hello world</li>\n" +
+                    "</ul>";
+                testDocument.setText("ul>li*4{hello world}");
+                testEditor.setCursorPos({ line: 0, ch: 19 });
+                const hints = expectHints(HTMLCodeHints.emmetHintProvider);
+
+                const hintText = hints[0][0].textContent;
+                expect(hintText).toBe("ul>li*4{hello world}Emmet");
+
+                HTMLCodeHints.emmetHintProvider.insertHint(hints[0]);
+                expect(testDocument.getText()).toBe(emmetSnippetResult);
             });
         });
 

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -1264,6 +1264,9 @@ define({
     "DESCRIPTION_HIDE_FIRST": "true to show the first Indent Guide line else false.",
     "DESCRIPTION_CSS_COLOR_PREVIEW": "true to display color previews in the gutter, else false.",
 
+    // Emmet
+    "DESCRIPTION_EMMET": "true to enable Emmet, else false.",
+
     // Git extension
     "ENABLE_GIT": "Enable Git",
     "ACTION": "Action",

--- a/src/preferences/AllPreferences.js
+++ b/src/preferences/AllPreferences.js
@@ -1,0 +1,50 @@
+/*
+ * GNU AGPL-3.0 License
+ *
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
+ * Original work Copyright (c) 2012 - 2021 Adobe Systems Incorporated. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
+ *
+ */
+
+/*
+ * This file houses all the preferences used across Phoenix.
+ *
+ * To use:
+ * ```
+ * const AllPreferences = brackets.getModule("preferences/AllPreferences");
+ * function preferenceChanged() {
+       enabled = PreferencesManager.get(AllPreferences.EMMET);
+   }
+ * PreferencesManager.on("change", AllPreferences.EMMET, preferenceChanged);
+   preferenceChanged();
+ * ```
+ */
+
+   define(function (require, exports, module) {
+    const PreferencesManager = require("preferences/PreferencesManager");
+    const Strings = require("strings");
+
+    // list of all the preferences
+    const PREFERENCES_LIST = {
+        EMMET: "emmet"
+    };
+
+    PreferencesManager.definePreference(PREFERENCES_LIST.EMMET, "boolean", true, {
+        description: Strings.DESCRIPTION_EMMET
+    });
+
+    module.exports = PREFERENCES_LIST;
+});

--- a/src/styles/brackets_core_ui_variables.less
+++ b/src/styles/brackets_core_ui_variables.less
@@ -41,7 +41,7 @@
  */
 
 
-:root {
+ :root {
   --bc-toast-danger-bg-color: #FF5C33;
   --bc-toast-error-bg-color: #f74687;
   --bc-toast-success-bg-color: #82b839;
@@ -272,3 +272,7 @@
 @dark-bc-codehint-desc:              #2c2c2c;
 @dark-bc-codehint-desc-type-details: #46a0f5;
 @dark-bc-codehint-desc-documentation:#b1b1b1;
+
+// CSS Codehint icon
+@css-codehint-icon:                 #2ea56c;
+@dark-css-codehint-icon:            #146a41;

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -703,9 +703,39 @@ a:focus {
     position: absolute;
     right: 0;
     margin-top:-2px;
-    color: #2ea56c !important;
+    color: @css-codehint-icon  !important;
     .dark& {
-        color: #146a41 !important;
+        color: @dark-css-codehint-icon !important;
+    }
+}
+
+.emmet-css-code-hint {
+  visibility: hidden;
+}
+
+.codehint-menu .dropdown-menu li .highlight .emmet-css-code-hint {
+  visibility: visible;
+  position: absolute;
+  right: 0;
+  margin-top: -2px;
+  font-size: 0.85em !important;
+  font-weight: @font-weight-semibold;
+  letter-spacing: 0.3px;
+  color: @css-codehint-icon !important;
+  .dark& {
+    color: @dark-css-codehint-icon !important;
+  }
+}
+
+.emmet-code-hint {
+    position: absolute;
+    font-size: 0.85em;
+    font-weight: @font-weight-semibold;
+    right: 4px;
+    bottom: 0px;
+    color: @css-codehint-icon !important;
+    .dark& {
+        color: @dark-css-codehint-icon !important;
     }
 }
 

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -248,6 +248,7 @@ define(function (require, exports, module) {
     require("worker/ExtensionsWorker");
     require("thirdparty/tinycolor");
     require("widgets/NotificationUI");
+    require("preferences/AllPreferences");
 
     // Load modules that self-register and just need to get included in the test-runner window
     require("document/ChangedDocumentTracker");


### PR DESCRIPTION
NB: Full commit history in https://github.com/phcode-dev/phoenix/pull/2129 , this was re-raised as some rebase conflicts could not be fixed easily.

This PR adds built-in Emmet support to Phoenix.

* Displays code hints when an abbreviation can be expanded. (Code hints felt crucial—without them, most users might not realize that Phoenix supports Emmet by default.) A small "emmet" icon is shown at the bottom-right of the hint to indicate that the hint is coming from Emmet.
* Places the cursor at the correct position after expansion, in a manner that users can directly start typing.
* Preserves indentation to match the surrounding code.
* Users can enable/disable from preferences file.

https://github.com/user-attachments/assets/546c62fe-36fc-4227-a50f-e443daad3bb3

