### PR TITLE
feat: suggest previously used colors in file

### DIFF
--- a/src/extensions/default/CSSCodeHints/main.js
+++ b/src/extensions/default/CSSCodeHints/main.js
@@ -582,7 +582,8 @@ define(function (require, exports, module) {
      * Checks whether the expandedAbbr has any number.
      * For instance: `m0` expands to `margin: 0;`, so we need to display the whole thing in the code hint
      * Here, we also make sure that abbreviations which has `#`, `,` should not be included, because
-     * `color` expands to `color: #000;` or `color: rgb(0, 0, 0)`. So this actually has numbers, but we don't want to display this.
+     * `color` expands to `color: #000;` or `color: rgb(0, 0, 0)`.
+     * So this actually has numbers, but we don't want to display this.
      *
      * @param {String} expandedAbbr the expanded abbr returned by EXPAND_ABBR emmet api
      * @returns {boolean} true if expandedAbbr has numbers (and doesn't include '#') otherwise false.
@@ -738,12 +739,18 @@ define(function (require, exports, module) {
 
             var parenMatch = hint.match(/\(.*?\)/);
             if (parenMatch) {
-                // value has (...), so place cursor inside opening paren
-                // and keep hints open
-                adjustCursor = true;
-                newCursor = { line: cursor.line,
-                    ch: start.ch + parenMatch.index + 1 };
-                keepHints = true;
+                // Only adjust cursor for non-color values
+                if (!hint.startsWith('rgb') &&
+                    !hint.startsWith('rgba') &&
+                    !hint.startsWith('hsl') &&
+                    !hint.startsWith('hsla')) {
+                    // value has (...), so place cursor inside opening paren
+                    // and keep hints open
+                    adjustCursor = true;
+                    newCursor = { line: cursor.line,
+                        ch: start.ch + parenMatch.index + 1 };
+                    keepHints = true;
+                }
             }
         }
 

--- a/src/extensions/default/CSSCodeHints/main.js
+++ b/src/extensions/default/CSSCodeHints/main.js
@@ -416,9 +416,6 @@ define(function (require, exports, module) {
                     })
                 );
 
-                valueArray = valueArray.concat(ColorUtils.COLOR_NAMES.map(function (color) {
-                    return { text: color, color: color };
-                }));
                 valueArray.push("transparent", "currentColor");
             }
 

--- a/test/spec/LiveDevelopmentMultiBrowser-test.js
+++ b/test/spec/LiveDevelopmentMultiBrowser-test.js
@@ -25,20 +25,20 @@ define(function (require, exports, module) {
 
 
     const SpecRunnerUtils = require("spec/SpecRunnerUtils"),
-        KeyEvent                = require("utils/KeyEvent"),
-        StringUtils      = require("utils/StringUtils");
+        KeyEvent = require("utils/KeyEvent"),
+        StringUtils = require("utils/StringUtils");
 
     describe("livepreview:MultiBrowser Live Preview", function () {
 
         async function _waitForIframeSrc(name) {
-            await awaitsFor(()=>{
+            await awaitsFor(() => {
                 let outerIFrame = testWindow.document.getElementById("panel-live-preview-frame");
                 let srcURL = new URL(outerIFrame.src);
                 return srcURL.pathname.endsWith(name) === true;
             }, "waiting for name- " + name);
         }
 
-        if(Phoenix.isTestWindowPlaywright && !Phoenix.browser.desktop.isChromeBased) {
+        if (Phoenix.isTestWindowPlaywright && !Phoenix.browser.desktop.isChromeBased) {
             it("All tests requiring virtual server is disabled in playwright/firefox/safari", async function () {
                 // we dont spawn virtual server in iframe playwright linux/safari as playwright linux/safari fails badly
                 // we dont need virtual server for tests except for live preview and custom extension load tests,
@@ -92,25 +92,26 @@ define(function (require, exports, module) {
                 // In tauri, we use node server, so this limitation doesn't apply in tauri, and we stick to iframes.
                 const useWindowInsteadOfIframe = (Phoenix.browser.desktop.isFirefox && !window.__TAURI__);
                 testWindow = await SpecRunnerUtils.createTestWindowAndRun({
-                    forceReload: false, useWindowInsteadOfIframe});
+                    forceReload: false, useWindowInsteadOfIframe
+                });
                 brackets = testWindow.brackets;
                 DocumentManager = brackets.test.DocumentManager;
                 LiveDevMultiBrowser = brackets.test.LiveDevMultiBrowser;
                 LiveDevProtocol = brackets.test.LiveDevProtocol;
-                CommandManager      = brackets.test.CommandManager;
-                Commands            = brackets.test.Commands;
-                EditorManager       = brackets.test.EditorManager;
-                WorkspaceManager    = brackets.test.WorkspaceManager;
-                BeautificationManager       = brackets.test.BeautificationManager;
-                PreferencesManager       = brackets.test.PreferencesManager;
-                NativeApp       = brackets.test.NativeApp;
-                Dialogs       = brackets.test.Dialogs;
-                MainViewManager       = brackets.test.MainViewManager;
+                CommandManager = brackets.test.CommandManager;
+                Commands = brackets.test.Commands;
+                EditorManager = brackets.test.EditorManager;
+                WorkspaceManager = brackets.test.WorkspaceManager;
+                BeautificationManager = brackets.test.BeautificationManager;
+                PreferencesManager = brackets.test.PreferencesManager;
+                NativeApp = brackets.test.NativeApp;
+                Dialogs = brackets.test.Dialogs;
+                MainViewManager = brackets.test.MainViewManager;
                 savedNativeAppOpener = NativeApp.openURLInDefaultBrowser;
 
                 await SpecRunnerUtils.loadProjectInTestWindow(testFolder);
-                await SpecRunnerUtils.deletePathAsync(testFolder+"/.phcode.json", true);
-                if(!WorkspaceManager.isPanelVisible('live-preview-panel')){
+                await SpecRunnerUtils.deletePathAsync(testFolder + "/.phcode.json", true);
+                if (!WorkspaceManager.isPanelVisible('live-preview-panel')) {
                     await awaitsForDone(CommandManager.execute(Commands.FILE_LIVE_FILE_PREVIEW));
                 }
             }
@@ -122,9 +123,9 @@ define(function (require, exports, module) {
             testWindow = null;
             brackets = null;
             LiveDevMultiBrowser = null;
-            CommandManager      = null;
-            Commands            = null;
-            EditorManager       = null;
+            CommandManager = null;
+            Commands = null;
+            EditorManager = null;
             MainViewManager = null;
             savedNativeAppOpener = null;
             Dialogs = null;
@@ -247,8 +248,8 @@ define(function (require, exports, module) {
             await awaitsFor(
                 function isArabicTextProperlyRendered() {
                     LiveDevProtocol.evaluate(`document.getElementById('arabic-text').textContent`)
-                        .done((response)=>{
-                            result = JSON.parse(response.result||"");
+                        .done((response) => {
+                            result = JSON.parse(response.result || "");
                         });
                     return result === " 1 يناير 2021 بواسطة ";
                 },
@@ -261,8 +262,8 @@ define(function (require, exports, module) {
 
         function _isRelatedStyleSheet(liveDoc, fileName) {
             let relatedSheets = Object.keys(liveDoc.getRelated().stylesheets);
-            for(let relatedPath of relatedSheets){
-                if(relatedPath.endsWith(fileName)) {
+            for (let relatedPath of relatedSheets) {
+                if (relatedPath.endsWith(fileName)) {
                     return true;
                 }
             }
@@ -277,9 +278,9 @@ define(function (require, exports, module) {
 
             liveDoc = LiveDevMultiBrowser.getCurrentLiveDoc();
 
-            let curDoc =  DocumentManager.getCurrentDocument();
+            let curDoc = DocumentManager.getCurrentDocument();
 
-            curDoc.replaceRange('<link href="blank.css" rel="stylesheet">\n', {line: 8, ch: 0});
+            curDoc.replaceRange('<link href="blank.css" rel="stylesheet">\n', { line: 8, ch: 0 });
 
             await awaitsFor(
                 function relatedDocsReceived() {
@@ -327,7 +328,7 @@ define(function (require, exports, module) {
 
             await awaitsForDone(SpecRunnerUtils.openProjectFiles(["simple1.css"]),
                 "SpecRunnerUtils.openProjectFiles simple1.css");
-            curDoc =  DocumentManager.getCurrentDocument();
+            curDoc = DocumentManager.getCurrentDocument();
             localText = curDoc.getText();
             localText += styleTextAdd;
             curDoc.setText(localText);
@@ -352,7 +353,7 @@ define(function (require, exports, module) {
 
             await awaitsForDone(SpecRunnerUtils.openProjectFiles(["sub/test.css"]),
                 "SpecRunnerUtils.openProjectFiles simple1.css");
-            curDoc =  DocumentManager.getCurrentDocument();
+            curDoc = DocumentManager.getCurrentDocument();
             localText = curDoc.getText();
             localText += "\n .testClass { background-color:#090; }\n";
             curDoc.setText(localText);
@@ -383,14 +384,14 @@ define(function (require, exports, module) {
                 50
             );
 
-            let curDoc =  DocumentManager.getCurrentDocument();
+            let curDoc = DocumentManager.getCurrentDocument();
             curDoc.replaceRange(editText, location);
             let result;
             await awaitsFor(
                 function isTextChanged() {
                     LiveDevProtocol.evaluate(`document.getElementById('${verifyID}').textContent`)
-                        .done((response)=>{
-                            result = JSON.parse(response.result||"");
+                        .done((response) => {
+                            result = JSON.parse(response.result || "");
                         });
                     return result === verifyText;
                 },
@@ -405,7 +406,7 @@ define(function (require, exports, module) {
                 "SpecRunnerUtils.openProjectFiles simple1.html");
 
             await waitsForLiveDevelopmentToOpen();
-            await _editFileAndVerifyLivePreview("simple1.html", {line: 11, ch: 45}, 'hello world ',
+            await _editFileAndVerifyLivePreview("simple1.html", { line: 11, ch: 45 }, 'hello world ',
                 "testId", "Brackets is hello world awesome!");
             await endPreviewSession();
         }, 30000);
@@ -418,19 +419,19 @@ define(function (require, exports, module) {
             await awaitsForDone(SpecRunnerUtils.openProjectFiles(["simple1.html"]),
                 "simple1.html");
 
-            await awaitsFor(()=> LiveDevMultiBrowser.status === LiveDevMultiBrowser.STATUS_ACTIVE,
+            await awaitsFor(() => LiveDevMultiBrowser.status === LiveDevMultiBrowser.STATUS_ACTIVE,
                 "status active");
 
-            let curDoc =  DocumentManager.getCurrentDocument();
+            let curDoc = DocumentManager.getCurrentDocument();
 
             // add a class
-            curDoc.replaceRange("addClass ", {line: 11, ch: 22});
+            curDoc.replaceRange("addClass ", { line: 11, ch: 22 });
             let hasClass;
             await awaitsFor(
                 function isClassChanged() {
                     LiveDevProtocol.evaluate(`document.getElementById('testId').classList.contains("addClass")`)
-                        .done((response)=>{
-                            hasClass = JSON.parse(response.result||"");
+                        .done((response) => {
+                            hasClass = JSON.parse(response.result || "");
                         });
                     return hasClass;
                 },
@@ -440,12 +441,12 @@ define(function (require, exports, module) {
             );
 
             // remove a class
-            curDoc.replaceRange("", {line: 11, ch: 22}, {line: 11, ch: 31});
+            curDoc.replaceRange("", { line: 11, ch: 22 }, { line: 11, ch: 31 });
             await awaitsFor(
                 function isClassChanged() {
                     LiveDevProtocol.evaluate(`document.getElementById('testId').classList.contains("addClass")`)
-                        .done((response)=>{
-                            hasClass = JSON.parse(response.result||"");
+                        .done((response) => {
+                            hasClass = JSON.parse(response.result || "");
                         });
                     return hasClass;
                 },
@@ -465,19 +466,19 @@ define(function (require, exports, module) {
             await awaitsForDone(SpecRunnerUtils.openProjectFiles(["simple1.html"]),
                 "simple1.html");
 
-            await awaitsFor(()=> LiveDevMultiBrowser.status === LiveDevMultiBrowser.STATUS_ACTIVE,
+            await awaitsFor(() => LiveDevMultiBrowser.status === LiveDevMultiBrowser.STATUS_ACTIVE,
                 "status active");
 
-            let curDoc =  DocumentManager.getCurrentDocument();
+            let curDoc = DocumentManager.getCurrentDocument();
 
             // add an attribute
-            curDoc.replaceRange(' hello="world" ', {line: 11, ch: 15});
+            curDoc.replaceRange(' hello="world" ', { line: 11, ch: 15 });
             let result;
             await awaitsFor(
                 function isAttributeAdded() {
                     LiveDevProtocol.evaluate(`document.getElementById('testId').getAttribute("hello")`)
-                        .done((response)=>{
-                            result = JSON.parse(response.result||"");
+                        .done((response) => {
+                            result = JSON.parse(response.result || "");
                         });
                     return result === "world";
                 },
@@ -487,12 +488,12 @@ define(function (require, exports, module) {
             );
 
             // remove the attribute
-            curDoc.replaceRange("", {line: 11, ch: 15}, {line: 11, ch: 30});
+            curDoc.replaceRange("", { line: 11, ch: 15 }, { line: 11, ch: 30 });
             await awaitsFor(
                 function isClassChanged() {
                     LiveDevProtocol.evaluate(`document.getElementById('testId').getAttribute("hello")`)
-                        .done((response)=>{
-                            result = JSON.parse(response.result||"");
+                        .done((response) => {
+                            result = JSON.parse(response.result || "");
                         });
                     return result !== "world";
                 },
@@ -516,15 +517,15 @@ define(function (require, exports, module) {
             }, "codehints to be shown");
 
             await awaitsFor(function () {
-                for(let hint of expectedSomeHintsArray){
-                    if(!testWindow.$(".codehint-menu").text().includes(hint)){
+                for (let hint of expectedSomeHintsArray) {
+                    if (!testWindow.$(".codehint-menu").text().includes(hint)) {
                         return false;
                     }
                 }
                 return true;
             }, "expected hints to be there");
         }
-        
+
         async function _waitForLivePreviewElementColor(elementID, color) {
             let result;
             await awaitsFor(
@@ -548,10 +549,10 @@ define(function (require, exports, module) {
             await awaitsForDone(SpecRunnerUtils.openProjectFiles(["inline-style.html"]),
                 "inline-style.html");
 
-            await awaitsFor(()=> LiveDevMultiBrowser.status === LiveDevMultiBrowser.STATUS_ACTIVE,
+            await awaitsFor(() => LiveDevMultiBrowser.status === LiveDevMultiBrowser.STATUS_ACTIVE,
                 "status active");
 
-            await _openCodeHints({line: 9, ch: 18}, ["red"]);
+            await _openCodeHints({ line: 9, ch: 18 }, ["red"]);
 
             let editor = EditorManager.getActiveEditor();
             const initialHistoryLength = editor.getHistory().done.length;
@@ -603,7 +604,7 @@ define(function (require, exports, module) {
             expect(editor.getToken().string).toBe("mediumvioletred");
 
             // the undo history should be just one above
-            expect(editor.getHistory().done.length).toBe(expectedHistoryLength +3);
+            expect(editor.getHistory().done.length).toBe(expectedHistoryLength + 3);
             await endPreviewSession();
         }, 30000);
 
@@ -613,26 +614,30 @@ define(function (require, exports, module) {
 
             await waitsForLiveDevelopmentToOpen();
 
-            await awaitsFor(()=> LiveDevMultiBrowser.status === LiveDevMultiBrowser.STATUS_ACTIVE,
+            await awaitsFor(() => LiveDevMultiBrowser.status === LiveDevMultiBrowser.STATUS_ACTIVE,
                 "status active");
 
             await awaitsForDone(SpecRunnerUtils.openProjectFiles(["simple1.css"]),
                 "simple1.css");
 
-            await _openCodeHints({line: 3, ch: 8}, ["antiquewhite"]);
+            await _openCodeHints({ line: 3, ch: 8 }, ["antiquewhite"]);
 
             let editor = EditorManager.getActiveEditor();
             const initialHistoryLength = editor.getHistory().done.length;
             SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_DOWN, "keydown", testWindow.document.body);
             await awaitsFor(function () {
-                return editor.getSelectedText() === "antiquewhite";
-            }, "expected live hints to update selection to antiquewhite");
-            await _waitForLivePreviewElementColor("testId", "rgb(250, 235, 215)"); // antiquewhite
+                // #090 is the content from simple1.css file
+                // this appears as the 2nd item in the codehint menu, from "suggest previously used color" feature
+                return editor.getSelectedText() === "#090";
+            }, "expected live hints to update selection to #090");
+            await _waitForLivePreviewElementColor("testId", "rgb(0, 153, 0)");
             SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_DOWN, "keydown", testWindow.document.body);
             await awaitsFor(function () {
-                return editor.getSelectedText() === "aqua";
-            }, "expected live hints to update selection to aqua");
-            await _waitForLivePreviewElementColor("testId", "rgb(0, 255, 255)"); //aqua
+                return editor.getSelectedText() === "aliceblue";
+            }, "expected live hints to update selection to aliceblue");
+
+            await _waitForLivePreviewElementColor("testId", "rgb(240, 248, 255)"); // aliceblue
+
             return initialHistoryLength;
         }
 
@@ -668,10 +673,10 @@ define(function (require, exports, module) {
                 return editor.getSelectedText() === "";
             }, "to restore the text to old state");
             // check if we have the new value
-            expect(editor.getToken().string).toBe("aqua");
+            expect(editor.getToken().string).toBe("aliceblue");
 
             // the undo history should be just one above
-            expect(editor.getHistory().done.length).toBe(expectedHistoryLength +3);
+            expect(editor.getHistory().done.length).toBe(expectedHistoryLength + 3);
             await endPreviewSession();
         }, 30000);
 
@@ -681,7 +686,7 @@ define(function (require, exports, module) {
                 async function isColorChanged() {
                     const response = await LiveDevProtocol.evaluate(
                         `document.getElementById('${elementID}').classList.contains('${classExpected}')`);
-                    result = JSON.parse(response.result||"");
+                    result = JSON.parse(response.result || "");
                     return result === true;
                 },
                 `element #${elementID} to have class ${classExpected}`,
@@ -690,13 +695,13 @@ define(function (require, exports, module) {
             );
         }
 
-        async function _livePreviewCodeHintsHTMLCSSClass(onlyOnce, position = {line: 15, ch: 24}) {
+        async function _livePreviewCodeHintsHTMLCSSClass(onlyOnce, position = { line: 15, ch: 24 }) {
             await awaitsForDone(SpecRunnerUtils.openProjectFiles(["inline-style.html"]),
                 "SpecRunnerUtils.openProjectFiles inline-style.html");
 
             await waitsForLiveDevelopmentToOpen();
 
-            await awaitsFor(()=> LiveDevMultiBrowser.status === LiveDevMultiBrowser.STATUS_ACTIVE,
+            await awaitsFor(() => LiveDevMultiBrowser.status === LiveDevMultiBrowser.STATUS_ACTIVE,
                 "status active");
 
             await _openCodeHints(position, ["testClass2", "testClass"]);
@@ -713,7 +718,7 @@ define(function (require, exports, module) {
             }, "expected live hints to update selection to next code hint");
             let newSelectedCodeHint = $($(".code-hints-list-item .highlight .brackets-html-hints")).text();
             await _waitForLivePreviewElementClass("testId", newSelectedCodeHint);
-            if(onlyOnce){
+            if (onlyOnce) {
                 return initialHistoryLength;
             }
             SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_DOWN, "keydown", testWindow.document.body);
@@ -751,7 +756,7 @@ define(function (require, exports, module) {
 
         it("should Live preview push html css class code hints selection changes to browser", async function () {
             //<p id="testId" class="t<cursor>estClass ">Brackets is awesome!</p>
-            await _testAtPos({line: 15, ch: 24});
+            await _testAtPos({ line: 15, ch: 24 });
             let editor = EditorManager.getActiveEditor();
             expect(editor.getToken().string).toBe('"testClass "');
             await endPreviewSession();
@@ -759,7 +764,7 @@ define(function (require, exports, module) {
 
         it("should Live preview push html css class code hints on empty input selection changes to browser", async function () {
             //<p id="testId" class="testClass <cursor>">Brackets is awesome!</p>
-            await _testAtPos({line: 15, ch: 32});
+            await _testAtPos({ line: 15, ch: 32 });
             let editor = EditorManager.getActiveEditor();
             expect(editor.getToken().string).toBe('"testClass "');
             await endPreviewSession();
@@ -767,7 +772,7 @@ define(function (require, exports, module) {
 
         it("should Live preview push html css class code hints selection changes to browser and commit", async function () {
             //<p id="testId" class="t<cursor>estClass ">Brackets is awesome!</p>
-            await _testAtPos({line: 15, ch: 24}, KeyEvent.DOM_VK_RETURN, true, 3);
+            await _testAtPos({ line: 15, ch: 24 }, KeyEvent.DOM_VK_RETURN, true, 3);
             let editor = EditorManager.getActiveEditor();
             expect(editor.getToken().string).toBe('"testClass2 "');
             await endPreviewSession();
@@ -775,7 +780,7 @@ define(function (require, exports, module) {
 
         it("should Live preview push html css class code hints on empty input selection changes to browser and commit", async function () {
             //<p id="testId" class="testClass <cursor>">Brackets is awesome!</p>
-            const selectedHint = await _testAtPos({line: 15, ch: 32},  KeyEvent.DOM_VK_RETURN, true, 2);
+            const selectedHint = await _testAtPos({ line: 15, ch: 32 }, KeyEvent.DOM_VK_RETURN, true, 2);
             let editor = EditorManager.getActiveEditor();
             expect(editor.getToken().string).toBe(`"testClass ${selectedHint}"`);
             await endPreviewSession();
@@ -786,12 +791,12 @@ define(function (require, exports, module) {
                 "SpecRunnerUtils.openProjectFiles simple1.html");
 
             await waitsForLiveDevelopmentToOpen();
-            await _editFileAndVerifyLivePreview("simple1.html", {line: 11, ch: 45}, 'hello world ',
+            await _editFileAndVerifyLivePreview("simple1.html", { line: 11, ch: 45 }, 'hello world ',
                 "testId", "Brackets is hello world awesome!");
-            await _editFileAndVerifyLivePreview("simple2.html", {line: 11, ch: 45}, 'hello world ',
+            await _editFileAndVerifyLivePreview("simple2.html", { line: 11, ch: 45 }, 'hello world ',
                 "simpId", "Brackets is hello world awesome!");
             // now switch back to old file
-            await _editFileAndVerifyLivePreview("simple1.html", {line: 11, ch: 45}, 'hello world ',
+            await _editFileAndVerifyLivePreview("simple1.html", { line: 11, ch: 45 }, 'hello world ',
                 "testId", "Brackets is hello world hello world awesome!");
             await endPreviewSession();
         }, 30000);
@@ -801,7 +806,7 @@ define(function (require, exports, module) {
                 "SpecRunnerUtils.openProjectFiles simple1.html");
 
             await waitsForLiveDevelopmentToOpen();
-            await _editFileAndVerifyLivePreview("simple1.html", {line: 11, ch: 45}, 'hello world ',
+            await _editFileAndVerifyLivePreview("simple1.html", { line: 11, ch: 45 }, 'hello world ',
                 "testId", "Brackets is hello world awesome!");
 
             await awaitsForDone(SpecRunnerUtils.openProjectFiles(["readme.md"]),
@@ -818,7 +823,7 @@ define(function (require, exports, module) {
             expect(srcURL.pathname.endsWith(SVG_IMAGE_PATH)).toBeTrue();
 
             // now switch back to old file
-            await _editFileAndVerifyLivePreview("simple1.html", {line: 11, ch: 45}, 'hello world ',
+            await _editFileAndVerifyLivePreview("simple1.html", { line: 11, ch: 45 }, 'hello world ',
                 "testId", "Brackets is hello world hello world awesome!");
             await endPreviewSession();
         }, 30000);
@@ -828,7 +833,7 @@ define(function (require, exports, module) {
                 "SpecRunnerUtils.openProjectFiles simple1.html");
 
             await waitsForLiveDevelopmentToOpen();
-            await _editFileAndVerifyLivePreview("simple1.html", {line: 11, ch: 45}, 'hello world ',
+            await _editFileAndVerifyLivePreview("simple1.html", { line: 11, ch: 45 }, 'hello world ',
                 "testId", "Brackets is hello world awesome!");
 
             await awaitsForDone(SpecRunnerUtils.openProjectFiles(["sub/icon_chevron.png"]),
@@ -845,7 +850,7 @@ define(function (require, exports, module) {
                 "SpecRunnerUtils.openProjectFiles simple1.html");
 
             await waitsForLiveDevelopmentToOpen();
-            await _editFileAndVerifyLivePreview("simple1.html", {line: 11, ch: 45}, 'hello world ',
+            await _editFileAndVerifyLivePreview("simple1.html", { line: 11, ch: 45 }, 'hello world ',
                 "testId", "Brackets is hello world awesome!");
 
             let iFrame = testWindow.document.getElementById("panel-live-preview-frame");
@@ -891,7 +896,7 @@ define(function (require, exports, module) {
 
         async function triggerEscapeKeyEvent() {
             // Create a new KeyboardEvent
-            const jsExec= `document.getElementById("inputText").dispatchEvent(new KeyboardEvent("keydown", {
+            const jsExec = `document.getElementById("inputText").dispatchEvent(new KeyboardEvent("keydown", {
                 key: "Escape",
                 keyCode: 27, // keyCode for Escape key
                 code: "Escape",
@@ -922,7 +927,7 @@ define(function (require, exports, module) {
                 "SpecRunnerUtils.openProjectFiles simple1.html");
 
             await waitsForLiveDevelopmentToOpen();
-            await _editFileAndVerifyLivePreview("simple1.html", {line: 11, ch: 45}, 'hello world ',
+            await _editFileAndVerifyLivePreview("simple1.html", { line: 11, ch: 45 }, 'hello world ',
                 "testId", "Brackets is hello world awesome!");
 
             let iFrame = testWindow.document.getElementById("panel-live-preview-frame");
@@ -958,7 +963,7 @@ define(function (require, exports, module) {
                 "SpecRunnerUtils.openProjectFiles simple1.html");
 
             await waitsForLiveDevelopmentToOpen();
-            await _editFileAndVerifyLivePreview("simple1.html", {line: 11, ch: 45}, 'hello world ',
+            await _editFileAndVerifyLivePreview("simple1.html", { line: 11, ch: 45 }, 'hello world ',
                 "testId", "Brackets is hello world awesome!");
 
             let iFrame = testWindow.document.getElementById("panel-live-preview-frame");
@@ -1024,7 +1029,7 @@ define(function (require, exports, module) {
 
         it("should embedded html live previews be able to open urls in external browser for a target=_blank", async function () {
             // test is only for tauri. In browser, browser handles the anchor tags
-            if(!Phoenix.isNativeApp) {
+            if (!Phoenix.isNativeApp) {
                 return;
             }
             let openURLRequested;
@@ -1058,10 +1063,10 @@ define(function (require, exports, module) {
                 await awaitsFor(function () {
                     $dlg = testWindow.$(".modal.instance");
                     return $dlg.length > 0;
-                },  "dialog to appear");
+                }, "dialog to appear");
             }
             // test is only for tauri. In browser, browser handles the anchor tags
-            if(!Phoenix.isNativeApp) {
+            if (!Phoenix.isNativeApp) {
                 return;
             }
             let openURLRequested;
@@ -1076,7 +1081,7 @@ define(function (require, exports, module) {
             let iFrame = testWindow.document.getElementById("panel-live-preview-frame");
             expect(iFrame.src.endsWith("hyperlink.html")).toBeTrue();
 
-            for(let i=0;i<4;i++){
+            for (let i = 0; i < 4; i++) {
                 await forRemoteExec(`document.getElementById("externalLink").click()`);
             }
             await awaitsFor(function () { return openURLRequested; }, "https://google.com/ open", 2000);
@@ -1085,7 +1090,7 @@ define(function (require, exports, module) {
 
             // now click on the links a lotta time, no url should be opened
             openURLRequested = null;
-            for(let i=0;i<40;i++){
+            for (let i = 0; i < 40; i++) {
                 await forRemoteExec(`document.getElementById("externalLink").click()`);
             }
             await awaits(300);
@@ -1136,7 +1141,7 @@ define(function (require, exports, module) {
         }, 30000);
 
         it("should not be able to preview html file not in project - tauri only", async function () {
-            if(!Phoenix.isNativeApp) {
+            if (!Phoenix.isNativeApp) {
                 return;
             }
             await awaitsForDone(SpecRunnerUtils.openProjectFiles(["simple1.html"]),
@@ -1158,10 +1163,10 @@ define(function (require, exports, module) {
             await awaitsFor(
                 function () {
                     LiveDevProtocol.evaluate(script)
-                        .done((response)=>{
-                            result = JSON.parse(response.result||"");
+                        .done((response) => {
+                            result = JSON.parse(response.result || "");
                         });
-                    if(compareFn){
+                    if (compareFn) {
                         return compareFn(result);
                     }
                     // just exec and return if no compare function is specified
@@ -1182,17 +1187,17 @@ define(function (require, exports, module) {
             await waitsForLiveDevelopmentToOpen();
             let editor = EditorManager.getActiveEditor();
             editor.setCursorPos({ line: 0, ch: 0 });
-            await forRemoteExec(`document.getElementsByClassName("__brackets-ld-highlight").length`, (result)=>{
+            await forRemoteExec(`document.getElementsByClassName("__brackets-ld-highlight").length`, (result) => {
                 return result === 0;
             });
 
             editor.setCursorPos({ line: 11, ch: 10 });
 
-            await forRemoteExec(`document.getElementsByClassName("__brackets-ld-highlight").length`, (result)=>{
+            await forRemoteExec(`document.getElementsByClassName("__brackets-ld-highlight").length`, (result) => {
                 return result === 1;
             });
             await forRemoteExec(`document.getElementsByClassName("__brackets-ld-highlight")[0].trackingElement.id`,
-                (result)=>{
+                (result) => {
                     return result === 'testId';
                 });
 
@@ -1204,7 +1209,7 @@ define(function (require, exports, module) {
                 "SpecRunnerUtils.openProjectFiles simple2.html");
 
             await waitsForLiveDevelopmentToOpen();
-            await forRemoteExec(`document.getElementsByClassName("__brackets-ld-highlight").length`, (result)=>{
+            await forRemoteExec(`document.getElementsByClassName("__brackets-ld-highlight").length`, (result) => {
                 return result === 0;
             });
 
@@ -1214,12 +1219,12 @@ define(function (require, exports, module) {
             editor.setCursorPos({ line: 2, ch: 6 });
 
             await awaits(500);
-            await forRemoteExec(`document.getElementsByClassName("__brackets-ld-highlight").length`, (result)=>{
+            await forRemoteExec(`document.getElementsByClassName("__brackets-ld-highlight").length`, (result) => {
                 return result === 3;
             });
             await forRemoteExec(
                 `document.getElementsByClassName("__brackets-ld-highlight")[0].trackingElement.classList[0]`,
-                (result)=>{
+                (result) => {
                     return result === 'testClass';
                 });
 
@@ -1229,12 +1234,12 @@ define(function (require, exports, module) {
             editor.setCursorPos({ line: 0, ch: 1 });
 
             await awaits(500);
-            await forRemoteExec(`document.getElementsByClassName("__brackets-ld-highlight").length`, (result)=>{
+            await forRemoteExec(`document.getElementsByClassName("__brackets-ld-highlight").length`, (result) => {
                 return result === 2;
             });
             await forRemoteExec(
                 `document.getElementsByClassName("__brackets-ld-highlight")[0].trackingElement.classList[0]`,
-                (result)=>{
+                (result) => {
                     return result === 'testClass2';
                 });
 
@@ -1248,30 +1253,30 @@ define(function (require, exports, module) {
 
             await waitsForLiveDevelopmentToOpen();
             let editor = EditorManager.getActiveEditor();
-            await forRemoteExec(`document.getElementsByClassName("__brackets-ld-highlight").length`, (result)=>{
+            await forRemoteExec(`document.getElementsByClassName("__brackets-ld-highlight").length`, (result) => {
                 return result === 0;
             });
 
             editor.setCursorPos({ line: 11, ch: 10 });
 
             await awaits(500);
-            await forRemoteExec(`document.getElementsByClassName("__brackets-ld-highlight").length`, (result)=>{
+            await forRemoteExec(`document.getElementsByClassName("__brackets-ld-highlight").length`, (result) => {
                 return result === 1;
             });
             let originalWidth;
-            await forRemoteExec(`document.getElementsByClassName("__brackets-ld-highlight")[0].style.width`, (result)=>{
+            await forRemoteExec(`document.getElementsByClassName("__brackets-ld-highlight")[0].style.width`, (result) => {
                 originalWidth = result;
                 return true;
             });
 
             iFrame.style.width = "100px";
             await awaits(500);
-            await forRemoteExec(`document.getElementsByClassName("__brackets-ld-highlight")[0].style.width`, (result)=>{
+            await forRemoteExec(`document.getElementsByClassName("__brackets-ld-highlight")[0].style.width`, (result) => {
                 return originalWidth !== result;
             });
             iFrame.style.width = "100%";
             await awaits(500);
-            await forRemoteExec(`document.getElementsByClassName("__brackets-ld-highlight")[0].style.width`, (result)=>{
+            await forRemoteExec(`document.getElementsByClassName("__brackets-ld-highlight")[0].style.width`, (result) => {
                 return originalWidth === result;
             });
 
@@ -1286,17 +1291,17 @@ define(function (require, exports, module) {
             let editor = EditorManager.getActiveEditor();
 
             await awaits(500);
-            await forRemoteExec(`document.getElementsByClassName("__brackets-ld-highlight").length`, (result)=>{
+            await forRemoteExec(`document.getElementsByClassName("__brackets-ld-highlight").length`, (result) => {
                 return result === 0;
             });
             await forRemoteExec(`document.getElementById("testId2").click()`);
 
             await awaits(500);
-            await forRemoteExec(`document.getElementsByClassName("__brackets-ld-highlight").length`, (result)=>{
+            await forRemoteExec(`document.getElementsByClassName("__brackets-ld-highlight").length`, (result) => {
                 return result === 1;
             });
             await forRemoteExec(`document.getElementsByClassName("__brackets-ld-highlight")[0].trackingElement.id`,
-                (result)=>{
+                (result) => {
                     return result === 'testId2';
                 });
             expect(editor.getCursorPos()).toEql({ line: 12, ch: 0, sticky: null });
@@ -1305,10 +1310,10 @@ define(function (require, exports, module) {
         }, 30000);
 
         async function _forSelection(id, editor, cursor) {
-            await awaitsFor(()=>{
+            await awaitsFor(() => {
                 const cursorPos = editor.getCursorPos();
                 return cursorPos && cursorPos.line === cursor.line && cursorPos.ch === cursor.ch;
-            }, "waiting for editor reverse selection on "+ id);
+            }, "waiting for editor reverse selection on " + id);
         }
 
         async function _verifyCssReverseHighlight(fileName) {
@@ -1374,7 +1379,7 @@ define(function (require, exports, module) {
                 "closing all file");
 
             await forRemoteExec(`document.getElementById("testId").click()`);
-            await awaitsFor(()=>{
+            await awaitsFor(() => {
                 return !!EditorManager.getActiveEditor();
             }, "Editor to be opened");
             let editor = EditorManager.getActiveEditor();
@@ -1438,7 +1443,7 @@ define(function (require, exports, module) {
             await waitsForLiveDevelopmentToOpen();
 
             await awaits(1000);
-            await forRemoteExec(`document.getElementsByClassName("__brackets-ld-highlight").length`, (result)=>{
+            await forRemoteExec(`document.getElementsByClassName("__brackets-ld-highlight").length`, (result) => {
                 return result === 0;
             });
 
@@ -1456,11 +1461,11 @@ define(function (require, exports, module) {
             await forRemoteExec(`document.getElementById("testId").click()`);
             await awaits(1000);
 
-            await forRemoteExec(`document.getElementsByClassName("__brackets-ld-highlight").length`, (result)=>{
+            await forRemoteExec(`document.getElementsByClassName("__brackets-ld-highlight").length`, (result) => {
                 return result === 1;
             });
             await forRemoteExec(`document.getElementsByClassName("__brackets-ld-highlight")[0].trackingElement.id`,
-                (result)=>{
+                (result) => {
                     return result === 'testId';
                 });
             expect(editor.getCursorPos()).toEql({ line: 11, ch: 0, sticky: null });
@@ -1478,7 +1483,7 @@ define(function (require, exports, module) {
             editor && editor.setCursorPos({ line: 0, ch: 0 });
 
             await awaits(500);
-            await forRemoteExec(`document.getElementsByClassName("__brackets-ld-highlight").length`, (result)=>{
+            await forRemoteExec(`document.getElementsByClassName("__brackets-ld-highlight").length`, (result) => {
                 return result === 0;
             });
             await forRemoteExec(`document.getElementById("testId2").click()`);
@@ -1495,9 +1500,9 @@ define(function (require, exports, module) {
                 "SpecRunnerUtils.openProjectFiles simple1.html");
 
             await waitsForLiveDevelopmentToOpen();
-            await _editFileAndVerifyLivePreview("simple1.html", {line: 11, ch: 45}, 'hello world ',
+            await _editFileAndVerifyLivePreview("simple1.html", { line: 11, ch: 45 }, 'hello world ',
                 "testId", "Brackets is hello world awesome!");
-            await forRemoteExec(`document.savePageCtrlSDisabledByPhoenix`, (result)=>{
+            await forRemoteExec(`document.savePageCtrlSDisabledByPhoenix`, (result) => {
                 return result === true;
             });
 
@@ -1524,19 +1529,19 @@ define(function (require, exports, module) {
                 "SpecRunnerUtils.openProjectFiles simple1.html");
 
             await waitsForLiveDevelopmentToOpen();
-            await _editFileAndVerifyLivePreview("simple1.html", {line: 11, ch: 45}, 'hello world ',
+            await _editFileAndVerifyLivePreview("simple1.html", { line: 11, ch: 45 }, 'hello world ',
                 "testId", "Brackets is hello world awesome!");
 
             let editor = EditorManager.getActiveEditor();
             await BeautificationManager.beautifyEditor(editor);
-            await _editFileAndVerifyLivePreview("simple1.html", {line: 11, ch: 73}, 'yo',
+            await _editFileAndVerifyLivePreview("simple1.html", { line: 11, ch: 73 }, 'yo',
                 "testId", "Brackets is hello world awesome!yo");
 
             await awaitsForDone(CommandManager.execute(Commands.EDIT_UNDO), "undo");
             await awaitsForDone(CommandManager.execute(Commands.EDIT_UNDO), "undo");
             await awaitsForDone(CommandManager.execute(Commands.EDIT_UNDO), "undo");
 
-            await _editFileAndVerifyLivePreview("simple1.html", {line: 11, ch: 45}, 'hello world ',
+            await _editFileAndVerifyLivePreview("simple1.html", { line: 11, ch: 45 }, 'hello world ',
                 "testId", "Brackets is hello world awesome!");
 
             await endPreviewSession();
@@ -1547,7 +1552,7 @@ define(function (require, exports, module) {
                 "SpecRunnerUtils.openProjectFiles exploit1.html");
 
             await waitsForLiveDevelopmentToOpen();
-            await forRemoteExec(`document.responseStatus`, (result)=>{
+            await forRemoteExec(`document.responseStatus`, (result) => {
                 return result === 404;
             });
 
@@ -1562,11 +1567,11 @@ define(function (require, exports, module) {
             // scroll to middile of page element so that the scroll position is saved
             await forRemoteExec(`document.getElementById("midLine").scrollIntoView();`);
             let sessionStorageSavedScrollPos, savedWindowScrollY;
-            await forRemoteExec(`window.scrollY`, (result)=>{
+            await forRemoteExec(`window.scrollY`, (result) => {
                 savedWindowScrollY = result;
                 return result && result !== 0;
             });
-            await forRemoteExec(`sessionStorage.getItem("saved-scroll-" + location.href)`, (result)=>{
+            await forRemoteExec(`sessionStorage.getItem("saved-scroll-" + location.href)`, (result) => {
                 sessionStorageSavedScrollPos = result;
                 return !!result;
             });
@@ -1577,14 +1582,14 @@ define(function (require, exports, module) {
             await awaitsForDone(SpecRunnerUtils.openProjectFiles(["simple1.html"]),
                 "SpecRunnerUtils.openProjectFiles simple1.html");
             await waitsForLiveDevelopmentToOpen();
-            await forRemoteExec(`window.scrollY`, (result)=>{
+            await forRemoteExec(`window.scrollY`, (result) => {
                 return result !== savedWindowScrollY;
             });
 
             // now switch back to old page and verify if the scroll position was restored
             await awaitsForDone(SpecRunnerUtils.openProjectFiles(["longPage.html"]),
                 "SpecRunnerUtils.openProjectFiles longPage.html");
-            await forRemoteExec(`window.scrollY`, (result)=>{
+            await forRemoteExec(`window.scrollY`, (result) => {
                 return result === savedWindowScrollY;
             });
 
@@ -1651,7 +1656,7 @@ define(function (require, exports, module) {
 
             await waitsForLiveDevelopmentToOpen();
             await awaitsForDone(SpecRunnerUtils.openProjectFiles([SVG_IMAGE_PATH]),
-                "SpecRunnerUtils.openProjectFiles "+ SVG_IMAGE_PATH);
+                "SpecRunnerUtils.openProjectFiles " + SVG_IMAGE_PATH);
 
             await _waitForIframeSrc(SVG_IMAGE_PATH);
             let pinURLBtn = testWindow.$(testWindow.document.getElementById("pinURLButton"));
@@ -1713,7 +1718,7 @@ define(function (require, exports, module) {
             await waitsForLiveDevelopmentToOpen();
             await window.Phoenix.VFS.ensureExistsDirAsync("/test/parked");
             await awaitsForDone(SpecRunnerUtils.openProjectFiles([SVG_IMAGE_PATH]),
-                "SpecRunnerUtils.openProjectFiles"+SVG_IMAGE_PATH);
+                "SpecRunnerUtils.openProjectFiles" + SVG_IMAGE_PATH);
 
             await _waitForIframeSrc(SVG_IMAGE_PATH);
             let pinURLBtn = testWindow.$(testWindow.document.getElementById("pinURLButton"));
@@ -1738,7 +1743,7 @@ define(function (require, exports, module) {
 
         async function _storeInRemotePreview(value) {
             await forRemoteExec(`window.remoteSetterTest = "${value}"`);
-            await forRemoteExec(`window.remoteSetterTest`, (result)=>{
+            await forRemoteExec(`window.remoteSetterTest`, (result) => {
                 return result === value;
             });
         }
@@ -1761,7 +1766,7 @@ define(function (require, exports, module) {
                 document.getElementById('testId').textContent = '${jsChangedText}';});`;
             EditorManager.getActiveEditor().document.setText(code);
             await awaitsForDone(CommandManager.execute(Commands.FILE_SAVE_ALL), "FILE_SAVE_ALL");
-            await forRemoteExec(`document.getElementById("testId").textContent`, (result)=>{
+            await forRemoteExec(`document.getElementById("testId").textContent`, (result) => {
                 return result === jsChangedText;
             });
             await endPreviewSession();
@@ -1780,7 +1785,7 @@ define(function (require, exports, module) {
 
             testWindow.$("#reloadLivePreviewButton").click();
 
-            await forRemoteExec(`window.remoteSetterTest`, (result)=>{
+            await forRemoteExec(`window.remoteSetterTest`, (result) => {
                 return result !== storedValue;
             });
             await endPreviewSession();
@@ -1800,7 +1805,7 @@ define(function (require, exports, module) {
             testWindow.$("#pinURLButton").click();
             testWindow.$("#reloadLivePreviewButton").click();
 
-            await forRemoteExec(`window.remoteSetterTest`, (result)=>{
+            await forRemoteExec(`window.remoteSetterTest`, (result) => {
                 return result !== storedValue;
             });
             let iFrame = testWindow.document.getElementById("panel-live-preview-frame");
@@ -1826,7 +1831,7 @@ define(function (require, exports, module) {
 
             testWindow.$("#reloadLivePreviewButton").click();
 
-            await forRemoteExec(`window.remoteSetterTest`, (result)=>{
+            await forRemoteExec(`window.remoteSetterTest`, (result) => {
                 return result !== storedValue;
             });
             let iFrame = testWindow.document.getElementById("panel-live-preview-frame");
@@ -1852,7 +1857,7 @@ define(function (require, exports, module) {
 
             testWindow.$("#reloadLivePreviewButton").click();
 
-            await forRemoteExec(`window.remoteSetterTest`, (result)=>{
+            await forRemoteExec(`window.remoteSetterTest`, (result) => {
                 return result !== storedValue;
             });
             let iFrame = testWindow.document.getElementById("panel-live-preview-frame");


### PR DESCRIPTION
Previously used colors within a file will be prioritized in the color hint suggestions. These colors will be sorted in descending order based on their frequency of occurrence, ensuring that the most frequently used color appears at the top. This prioritization happens before displaying any other color hints.

Works for all color types. (hex, rgb, named colors)

![Screenshot 2025-01-30 122837](https://github.com/user-attachments/assets/529e2dd4-273f-42ed-9b91-970096f4acd3)
