### PR TITLE
feat: add support for closing tabs to right & left in context menu

### DIFF
--- a/src/extensionsIntegrated/TabBar/overflow.js
+++ b/src/extensionsIntegrated/TabBar/overflow.js
@@ -254,13 +254,23 @@ define(function (require, exports, module) {
             return;
         }
 
-        // make sure there is an active editor
+        let activePath;
+
+        // get the active file
         const activeEditor = EditorManager.getActiveEditor();
-        if (!activeEditor || !activeEditor.document || !activeEditor.document.file) {
-            return;
+        if (activeEditor && activeEditor.document && activeEditor.document.file) {
+            activePath = activeEditor.document.file.fullPath;
+        } else {
+            // If there is no active editor, we need to check if its an image file
+            const currentFile = MainViewManager.getCurrentlyViewedFile();
+            if (currentFile) {
+                activePath = currentFile.fullPath;
+            } else {
+                // if not an image file, not a text file, we don't need to scroll
+                return;
+            }
         }
 
-        const activePath = activeEditor.document.file.fullPath;
         // get the active tab. the active tab is the tab that is currently open
         const $activeTab = $tabBarElement.find(`.tab[data-path="${activePath}"]`);
 

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -429,6 +429,8 @@ define({
     // Tab bar Strings
     "CLOSE_TAB": "Close Tab",
     "CLOSE_ACTIVE_TAB": "Close Active Tab",
+    "CLOSE_TABS_TO_THE_RIGHT": "Close Tabs to the Right",
+    "CLOSE_TABS_TO_THE_LEFT": "Close Tabs to the Left",
     "CLOSE_ALL_TABS": "Close All Tabs",
     "CLOSE_UNMODIFIED_TABS": "Close Unmodified Tabs",
     "REOPEN_CLOSED_FILE": "Reopen Closed File",


### PR DESCRIPTION
Now when a tab is right clicked, along with other options we show two options i.e. close tabs to the right of the _right-clicked_ tab and the left of the _right-clicked_ tab.

![Screenshot 2025-04-02 191014](https://github.com/user-attachments/assets/2e553ebc-94d6-4096-8142-080fc1c66c5b)
