### PR TITLE
Add placeholder tab when a file is opened from file tree but not yet added to working set

### DIFF
--- a/src/extensionsIntegrated/TabBar/main.js
+++ b/src/extensionsIntegrated/TabBar/main.js
@@ -177,6 +177,13 @@ define(function (require, exports, module) {
             $tab.addClass('active-in-inactive-pane');
         }
 
+        // if this is a placeholder tab in inactive pane, we need to use the brown styling
+        // instead of the blue one for active tabs
+        if (isPlaceholder && isActive && !isPaneActive) {
+            $tab.removeClass('active');
+            $tab.addClass('active-in-inactive-pane');
+        }
+
         return $tab;
     }
 

--- a/src/extensionsIntegrated/TabBar/main.js
+++ b/src/extensionsIntegrated/TabBar/main.js
@@ -221,16 +221,6 @@ define(function (require, exports, module) {
         // Get all files from the working set. refer to `global.js`
         getAllFilesFromWorkingSet();
 
-        // When there is only one file, we enforce the creation of the tab bar
-        // this is done because, given the situation:
-        // In a vertical split, when no files are present in 'second-pane' so the tab bar is hidden.
-        // Now, when the user adds a file in 'second-pane', the tab bar should be shown but since updateTabs() only,
-        // updates the tabs, so the tab bar never gets created.
-        if (Global.firstPaneWorkingSet.length === 1 &&
-            (!$('#phoenix-tab-bar').length || $('#phoenix-tab-bar').is(':hidden'))) {
-            createTabBar();
-        }
-
         // Check for active files not in working set in any pane
         const activePane = MainViewManager.getActivePaneId();
         const firstPaneFile = MainViewManager.getCurrentlyViewedFile("first-pane");
@@ -260,7 +250,13 @@ define(function (require, exports, module) {
             };
         }
 
-        if (Global.secondPaneWorkingSet.length === 1 &&
+        // create the tab bar if there's a placeholder or a file in the working set
+        if ((Global.firstPaneWorkingSet.length > 0 || firstPanePlaceholder) &&
+            (!$('#phoenix-tab-bar').length || $('#phoenix-tab-bar').is(':hidden'))) {
+            createTabBar();
+        }
+
+        if ((Global.secondPaneWorkingSet.length > 0 || secondPanePlaceholder) &&
             (!$('#phoenix-tab-bar-2').length || $('#phoenix-tab-bar-2').is(':hidden'))) {
             createTabBar();
         }

--- a/src/extensionsIntegrated/TabBar/overflow.js
+++ b/src/extensionsIntegrated/TabBar/overflow.js
@@ -75,6 +75,7 @@ define(function (require, exports, module) {
                     name: $tab.find('.tab-name').text(),
                     isActive: $tab.hasClass('active'),
                     isDirty: $tab.hasClass('dirty'),
+                    isPlaceholder: $tab.hasClass('placeholder'),
                     $icon: $tab.find('.tab-icon').clone()
                 };
 
@@ -148,17 +149,22 @@ define(function (require, exports, module) {
                 <i class="fa-solid fa-times"></i>
             </span>`;
 
+            // add placeholder class to style it differently
+            const placeholderClass = item.isPlaceholder ? ' placeholder-name' : '';
+
             // return html for this item
             return {
                 html:
-                    `<div class="dropdown-tab-item" data-tab-path="${item.path}">
-                        <div class="tab-info-container">
-                            ${dirtyHtml}
-                            <span class="tab-icon-container">${iconHtml}</span>
-                            <span class="tab-name-container">${item.name}</span>
-                        </div>
-                        ${closeIconHtml}
-                    </div>`,
+                    `<div class="dropdown-tab-item${item.isPlaceholder
+                        ? ' placeholder-item' : ''
+                    }" data-tab-path="${item.path}">
+                <div class="tab-info-container">
+                    ${dirtyHtml}
+                    <span class="tab-icon-container">${iconHtml}</span>
+                    <span class="tab-name-container${placeholderClass}">${item.name}</span>
+                </div>
+                ${closeIconHtml}
+            </div>`,
                 enabled: true
             };
         });
@@ -223,6 +229,14 @@ define(function (require, exports, module) {
                 // Set the active pane and open the file
                 MainViewManager.setActivePaneId(paneId);
                 CommandManager.execute(Commands.FILE_OPEN, { fullPath: filePath });
+
+                // get the tab bar element based on paneId and scroll to the active tab
+                // we use setTimeout to ensure that the DOM has updated after the file open command
+                setTimeout(function () {
+                    const $tabBarElement = paneId === "first-pane" ?
+                        $("#phoenix-tab-bar") : $("#phoenix-tab-bar-2");
+                    scrollToActiveTab($tabBarElement);
+                }, 100);
             }
         });
 

--- a/src/styles/Extn-TabBar.less
+++ b/src/styles/Extn-TabBar.less
@@ -404,3 +404,8 @@
 .empty-pane-drop-target {
     border: 2px dashed #6db6ff !important;
 }
+
+.dropdown-tab-item.placeholder-item .tab-name-container,
+.tab-name-container.placeholder-name {
+    font-style: italic;
+}

--- a/src/styles/Extn-TabBar.less
+++ b/src/styles/Extn-TabBar.less
@@ -240,6 +240,45 @@
     background-color: rgba(255, 255, 255, 0.1);
 }
 
+.tab.placeholder .tab-name {
+    font-style: italic;
+    color: #888;
+}
+
+.dark .tab.placeholder .tab-name {
+    color: #888;
+}
+
+.tab.placeholder.active .tab-name {
+    color: #666;
+}
+
+.dark .tab.placeholder.active .tab-name {
+    color: #aaa;
+}
+
+.tab.placeholder::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 0.12rem;
+    background-color: #b4b2b2;
+}
+
+.dark .tab.placeholder::after {
+    background-color: #666;
+}
+
+.tab.placeholder.active::after {
+    background-color: #0078D7;
+}
+
+.dark .tab.placeholder.active::after {
+    background-color: #75BEFF;
+}
+
 .tab.dragging {
     opacity: 0.7;
     transform: scale(0.95);


### PR DESCRIPTION
When a file is opened from the file tree but is not added to the working set, a temporary placeholder tab is created in the tab bar. This tab is styled differently from regular tabs to make it visually distinct. 

Clicking on the placeholder tab adds it to the working set.

Visual Reference :-

https://github.com/user-attachments/assets/a4360f5c-ac4c-45a5-88ea-4a1e142931e1


