### PR TITLE
fix: tab bar bug fixes and improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "phoenix",
-    "version": "4.1.0-0",
+    "version": "4.1.1-0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "phoenix",
-            "version": "4.1.0-0",
+            "version": "4.1.1-0",
             "dependencies": {
                 "@bugsnag/js": "^7.18.0",
                 "@floating-ui/dom": "^0.5.4",

--- a/src-node/package-lock.json
+++ b/src-node/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@phcode/node-core",
-    "version": "4.1.0-0",
+    "version": "4.1.1-0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@phcode/node-core",
-            "version": "4.1.0-0",
+            "version": "4.1.1-0",
             "license": "GNU-AGPL3.0",
             "dependencies": {
                 "@phcode/fs": "^3.0.1",

--- a/src/extensions/default/Git/main.js
+++ b/src/extensions/default/Git/main.js
@@ -27,7 +27,8 @@ define(function (require, exports, module) {
         "src/History",
         "src/NoRepo",
         "src/ProjectTreeMarks",
-        "src/Remotes"
+        "src/Remotes",
+        "src/TabBarIntegration"
     ];
     require(modules);
 
@@ -48,10 +49,12 @@ define(function (require, exports, module) {
 
     // export API's for other extensions
     if (typeof window === "object") {
+        const TabBarIntegration = require("src/TabBarIntegration");
         window.phoenixGitEvents = {
             EventEmitter: EventEmitter,
             Events: Events,
-            Git
+            Git,
+            TabBarIntegration
         };
     }
 });

--- a/src/extensions/default/Git/src/TabBarIntegration.js
+++ b/src/extensions/default/Git/src/TabBarIntegration.js
@@ -28,13 +28,11 @@ define(function (require) {
         if (!status) {
             return false;
         }
-        return (
-            status.some(
-                (statusType) =>
-                    statusType === Git.FILE_STATUS.MODIFIED ||
-                    statusType === Git.FILE_STATUS.RENAMED ||
-                    statusType === Git.FILE_STATUS.COPIED
-            ) && !status.includes(Git.FILE_STATUS.STAGED)
+        return status.some(
+            (statusType) =>
+                statusType === Git.FILE_STATUS.MODIFIED ||
+                statusType === Git.FILE_STATUS.RENAMED ||
+                statusType === Git.FILE_STATUS.COPIED
         );
     }
 
@@ -50,7 +48,11 @@ define(function (require) {
             return false;
         }
 
-        return status.includes(Git.FILE_STATUS.UNTRACKED);
+        // return true if it's untracked or if it's newly added (which means it was untracked before staging)
+        return (
+            status.includes(Git.FILE_STATUS.UNTRACKED) ||
+            (status.includes(Git.FILE_STATUS.ADDED) && status.includes(Git.FILE_STATUS.STAGED))
+        );
     }
 
 

--- a/src/extensions/default/Git/src/TabBarIntegration.js
+++ b/src/extensions/default/Git/src/TabBarIntegration.js
@@ -1,0 +1,88 @@
+define(function (require) {
+    const EventEmitter = require("src/EventEmitter");
+    const Events = require("src/Events");
+    const Git = require("src/git/Git");
+    const Preferences = require("src/Preferences");
+
+    // the cache of file statuses by path
+    let fileStatusCache = {};
+
+    /**
+     * this function is responsible to get the Git status for a file path
+     *
+     * @param {string} fullPath - the file path
+     * @returns {Array|null} - Array of status strings or null if no status
+     */
+    function getFileStatus(fullPath) {
+        return fileStatusCache[fullPath] || null;
+    }
+
+    /**
+     * whether the file is modified or not
+     *
+     * @param {string} fullPath - the file path
+     * @returns {boolean} - True if the file is modified otherwise false
+     */
+    function isModified(fullPath) {
+        const status = getFileStatus(fullPath);
+        if (!status) {
+            return false;
+        }
+        return (
+            status.some(
+                (statusType) =>
+                    statusType === Git.FILE_STATUS.MODIFIED ||
+                    statusType === Git.FILE_STATUS.RENAMED ||
+                    statusType === Git.FILE_STATUS.COPIED
+            ) && !status.includes(Git.FILE_STATUS.STAGED)
+        );
+    }
+
+    /**
+     * whether the file is untracked or not
+     *
+     * @param {string} fullPath - the file path
+     * @returns {boolean} - True if the file is untracked otherwise false
+     */
+    function isUntracked(fullPath) {
+        const status = getFileStatus(fullPath);
+        if (!status) {
+            return false;
+        }
+
+        return status.includes(Git.FILE_STATUS.UNTRACKED);
+    }
+
+
+    // Update file status cache when Git status results are received
+    EventEmitter.on(Events.GIT_STATUS_RESULTS, function (files) {
+        // reset the cache
+        fileStatusCache = {};
+
+        const gitRoot = Preferences.get("currentGitRoot");
+        if (!gitRoot) {
+            return;
+        }
+
+        // we need to update cache with new status results
+        files.forEach(function (entry) {
+            const fullPath = gitRoot + entry.file;
+            fileStatusCache[fullPath] = entry.status;
+        });
+
+        // notify that file statuses have been updated
+        EventEmitter.emit("GIT_FILE_STATUS_CHANGED", fileStatusCache);
+    });
+
+    // clear cache when Git is disabled
+    EventEmitter.on(Events.GIT_DISABLED, function () {
+        fileStatusCache = {};
+        EventEmitter.emit("GIT_FILE_STATUS_CHANGED", fileStatusCache);
+    });
+
+    return {
+        getFileStatus: getFileStatus,
+        isModified: isModified,
+        isUntracked: isUntracked
+    };
+});

--- a/src/extensionsIntegrated/TabBar/main.js
+++ b/src/extensionsIntegrated/TabBar/main.js
@@ -42,8 +42,6 @@ define(function (require, exports, module) {
     const TabBarHTML = require("text!./html/tabbar-pane.html");
     const TabBarHTML2 = require("text!./html/tabbar-second-pane.html");
 
-
-
     /**
      * This holds the tab bar element
      * For tab bar structure, refer to `./html/tabbar-pane.html` and `./html/tabbar-second-pane.html`
@@ -53,7 +51,6 @@ define(function (require, exports, module) {
      */
     let $tabBar = null;
     let $tabBar2 = null;
-
 
     /**
      * This function is responsible to take all the files from the working set and gets the working sets ready
@@ -68,7 +65,6 @@ define(function (require, exports, module) {
 
         // to make sure atleast one pane is open
         if (paneList && paneList.length > 0) {
-
             // this gives the working set of the first pane
             const currFirstPaneWorkingSet = MainViewManager.getWorkingSet(paneList[0]);
 
@@ -108,8 +104,6 @@ define(function (require, exports, module) {
         }
     }
 
-
-
     /**
      * Responsible for creating the tab element
      * Note: this creates a tab (for a single file) not the tab bar
@@ -128,11 +122,11 @@ define(function (require, exports, module) {
         const activePathInPane = activeFileInPane ? activeFileInPane.fullPath : null;
 
         // Check if this file is active in its pane
-        const isActive = (entry.path === activePathInPane);
+        const isActive = entry.path === activePathInPane;
 
         // Current active pane (used to determine whether to add the blue underline)
         const currentActivePane = MainViewManager.getActivePaneId();
-        const isPaneActive = (paneId === currentActivePane);
+        const isPaneActive = paneId === currentActivePane;
 
         const isDirty = Helper._isFileModified(FileSystem.getFileForPath(entry.path));
         const isPlaceholder = entry.isPlaceholder === true;
@@ -140,9 +134,9 @@ define(function (require, exports, module) {
         // create tab with all the appropriate classes
         const $tab = $(
             `<div class="tab 
-            ${isActive ? 'active' : ''} 
-            ${isDirty ? 'dirty' : ''}
-            ${isPlaceholder ? 'placeholder' : ''}" 
+            ${isActive ? "active" : ""}
+            ${isDirty ? "dirty" : ""}
+            ${isPlaceholder ? "placeholder" : ""}"
             data-path="${entry.path}" 
             title="${entry.path}">
             <div class="tab-icon"></div>
@@ -153,13 +147,13 @@ define(function (require, exports, module) {
 
         // Add the file icon
         const $icon = Helper._getFileIcon(entry);
-        $tab.find('.tab-icon').append($icon);
+        $tab.find(".tab-icon").append($icon);
 
         // Check if we have a directory part in the displayName
-        const $tabName = $tab.find('.tab-name');
+        const $tabName = $tab.find(".tab-name");
         if (entry.displayName && entry.displayName !== entry.name) {
             // Split the displayName into directory and filename parts
-            const parts = entry.displayName.split('/');
+            const parts = entry.displayName.split("/");
             const dirName = parts[0];
             const fileName = parts[1];
 
@@ -174,39 +168,38 @@ define(function (require, exports, module) {
         if (isActive && !isPaneActive) {
             // if it's active but in a non-active pane, we add a special class
             // to style differently in CSS to indicate that it's active but not in the active pane
-            $tab.addClass('active-in-inactive-pane');
+            $tab.addClass("active-in-inactive-pane");
         }
 
         // if this is a placeholder tab in inactive pane, we need to use the brown styling
         // instead of the blue one for active tabs
         if (isPlaceholder && isActive && !isPaneActive) {
-            $tab.removeClass('active');
-            $tab.addClass('active-in-inactive-pane');
+            $tab.removeClass("active");
+            $tab.addClass("active-in-inactive-pane");
         }
 
         return $tab;
     }
 
-
     /**
      * Creates the tab bar and adds it to the DOM
      */
     function createTabBar() {
-        if (!Preference.tabBarEnabled || Preference.numberOfTabs === 0) {
+        if (!Preference.tabBarEnabled || Preference.tabBarNumberOfTabs === 0) {
+            cleanupTabBar();
             return;
         }
 
         // clean up any existing tab bars first and start fresh
         cleanupTabBar();
 
-        const $paneHeader = $('.pane-header');
+        const $paneHeader = $(".pane-header");
         if ($paneHeader.length === 1) {
             $tabBar = $(TabBarHTML);
             // since we need to add the tab bar before the editor which has .not-editor class
             $(".pane-header").after($tabBar);
             WorkspaceManager.recomputeLayout(true);
             updateTabs();
-
         } else if ($paneHeader.length === 2) {
             $tabBar = $(TabBarHTML);
             $tabBar2 = $(TabBarHTML2);
@@ -220,7 +213,6 @@ define(function (require, exports, module) {
         }
     }
 
-
     /**
      * This function updates the tabs in the tab bar
      * It is called when the working set changes. So instead of creating a new tab bar, we just update the existing one
@@ -228,6 +220,12 @@ define(function (require, exports, module) {
     function updateTabs() {
         // Get all files from the working set. refer to `global.js`
         getAllFilesFromWorkingSet();
+
+        // just to make sure that the number of tabs is not set to 0
+        if (Preference.tabBarNumberOfTabs === 0) {
+            cleanupTabBar();
+            return;
+        }
 
         // Check for active files not in working set in any pane
         const activePane = MainViewManager.getActivePaneId();
@@ -239,8 +237,7 @@ define(function (require, exports, module) {
         let secondPanePlaceholder = null;
 
         // Check if active file in first pane is not in the working set
-        if (firstPaneFile &&
-            !Global.firstPaneWorkingSet.some(entry => entry.path === firstPaneFile.fullPath)) {
+        if (firstPaneFile && !Global.firstPaneWorkingSet.some((entry) => entry.path === firstPaneFile.fullPath)) {
             firstPanePlaceholder = {
                 path: firstPaneFile.fullPath,
                 name: firstPaneFile.name,
@@ -250,8 +247,7 @@ define(function (require, exports, module) {
         }
 
         // Check if active file in second pane is not in the working set
-        if (secondPaneFile &&
-            !Global.secondPaneWorkingSet.some(entry => entry.path === secondPaneFile.fullPath)) {
+        if (secondPaneFile && !Global.secondPaneWorkingSet.some((entry) => entry.path === secondPaneFile.fullPath)) {
             secondPanePlaceholder = {
                 path: secondPaneFile.fullPath,
                 name: secondPaneFile.name,
@@ -263,9 +259,7 @@ define(function (require, exports, module) {
         // check for duplicate file names between placeholder tabs and working set entries
         if (firstPanePlaceholder) {
             // if any working set file has the same name as the placeholder
-            const hasDuplicate = Global.firstPaneWorkingSet.some(entry =>
-                entry.name === firstPanePlaceholder.name
-            );
+            const hasDuplicate = Global.firstPaneWorkingSet.some((entry) => entry.name === firstPanePlaceholder.name);
 
             if (hasDuplicate) {
                 // extract directory name from path
@@ -280,9 +274,7 @@ define(function (require, exports, module) {
         }
 
         if (secondPanePlaceholder) {
-            const hasDuplicate = Global.secondPaneWorkingSet.some(entry =>
-                entry.name === secondPanePlaceholder.name
-            );
+            const hasDuplicate = Global.secondPaneWorkingSet.some((entry) => entry.name === secondPanePlaceholder.name);
 
             if (hasDuplicate) {
                 const path = secondPanePlaceholder.path;
@@ -295,22 +287,25 @@ define(function (require, exports, module) {
         }
 
         // Create tab bar if there's a placeholder or a file in the working set
-        if ((Global.firstPaneWorkingSet.length > 0 || firstPanePlaceholder) &&
-            (!$('#phoenix-tab-bar').length || $('#phoenix-tab-bar').is(':hidden'))) {
+        if (
+            (Global.firstPaneWorkingSet.length > 0 || firstPanePlaceholder) &&
+            (!$("#phoenix-tab-bar").length || $("#phoenix-tab-bar").is(":hidden"))
+        ) {
             createTabBar();
         }
 
-        if ((Global.secondPaneWorkingSet.length > 0 || secondPanePlaceholder) &&
-            (!$('#phoenix-tab-bar-2').length || $('#phoenix-tab-bar-2').is(':hidden'))) {
+        if (
+            (Global.secondPaneWorkingSet.length > 0 || secondPanePlaceholder) &&
+            (!$("#phoenix-tab-bar-2").length || $("#phoenix-tab-bar-2").is(":hidden"))
+        ) {
             createTabBar();
         }
 
-        const $firstTabBar = $('#phoenix-tab-bar');
+        const $firstTabBar = $("#phoenix-tab-bar");
         // Update first pane's tabs
         if ($firstTabBar.length) {
             $firstTabBar.empty();
             if (Global.firstPaneWorkingSet.length > 0 || firstPanePlaceholder) {
-
                 // get the count of tabs that we want to display in the tab bar (from preference settings)
                 // from preference settings or working set whichever smaller
                 let tabsCountP1 = Math.min(Global.firstPaneWorkingSet.length, Preference.tabBarNumberOfTabs);
@@ -321,7 +316,28 @@ define(function (require, exports, module) {
                     tabsCountP1 = Global.firstPaneWorkingSet.length;
                 }
 
-                let displayedEntries = Global.firstPaneWorkingSet.slice(0, tabsCountP1);
+                let displayedEntries = [];
+
+                // check if active file is in the working set but would be excluded by tab count
+                if (firstPaneFile && Preference.tabBarNumberOfTabs > 0) {
+                    const activeFileIndex = Global.firstPaneWorkingSet.findIndex(
+                        (entry) => entry.path === firstPaneFile.fullPath
+                    );
+
+                    if (activeFileIndex >= 0 && activeFileIndex >= Preference.tabBarNumberOfTabs) {
+                        // active file is in working set but would be excluded by tab count
+                        // Show active file and one less from the top N files
+                        displayedEntries = [
+                            ...Global.firstPaneWorkingSet.slice(0, Preference.tabBarNumberOfTabs - 1),
+                            Global.firstPaneWorkingSet[activeFileIndex]
+                        ];
+                    } else {
+                        // Active file is either not in working set or already included in top N files
+                        displayedEntries = Global.firstPaneWorkingSet.slice(0, tabsCountP1);
+                    }
+                } else {
+                    displayedEntries = Global.firstPaneWorkingSet.slice(0, tabsCountP1);
+                }
 
                 // Add working set tabs
                 displayedEntries.forEach(function (entry) {
@@ -335,18 +351,34 @@ define(function (require, exports, module) {
             }
         }
 
-        const $secondTabBar = $('#phoenix-tab-bar-2');
+        const $secondTabBar = $("#phoenix-tab-bar-2");
         // Update second pane's tabs
         if ($secondTabBar.length) {
             $secondTabBar.empty();
             if (Global.secondPaneWorkingSet.length > 0 || secondPanePlaceholder) {
-
                 let tabsCountP2 = Math.min(Global.secondPaneWorkingSet.length, Preference.tabBarNumberOfTabs);
                 if (Preference.tabBarNumberOfTabs < 0) {
                     tabsCountP2 = Global.secondPaneWorkingSet.length;
                 }
 
-                let displayedEntries2 = Global.secondPaneWorkingSet.slice(0, tabsCountP2);
+                let displayedEntries2 = [];
+
+                if (secondPaneFile && Preference.tabBarNumberOfTabs > 0) {
+                    const activeFileIndex = Global.secondPaneWorkingSet.findIndex(
+                        (entry) => entry.path === secondPaneFile.fullPath
+                    );
+
+                    if (activeFileIndex >= 0 && activeFileIndex >= Preference.tabBarNumberOfTabs) {
+                        displayedEntries2 = [
+                            ...Global.secondPaneWorkingSet.slice(0, Preference.tabBarNumberOfTabs - 1),
+                            Global.secondPaneWorkingSet[activeFileIndex]
+                        ];
+                    } else {
+                        displayedEntries2 = Global.secondPaneWorkingSet.slice(0, tabsCountP2);
+                    }
+                } else {
+                    displayedEntries2 = Global.secondPaneWorkingSet.slice(0, tabsCountP2);
+                }
 
                 // Add working set tabs
                 displayedEntries2.forEach(function (entry) {
@@ -361,12 +393,12 @@ define(function (require, exports, module) {
         }
 
         // if no files are present in a pane and no placeholder, we want to hide the tab bar for that pane
-        if (Global.firstPaneWorkingSet.length === 0 && !firstPanePlaceholder && ($('#phoenix-tab-bar'))) {
-            Helper._hideTabBar($('#phoenix-tab-bar'), $('#overflow-button'));
+        if (Global.firstPaneWorkingSet.length === 0 && !firstPanePlaceholder && $("#phoenix-tab-bar")) {
+            Helper._hideTabBar($("#phoenix-tab-bar"), $("#overflow-button"));
         }
 
-        if (Global.secondPaneWorkingSet.length === 0 && !secondPanePlaceholder && ($('#phoenix-tab-bar-2'))) {
-            Helper._hideTabBar($('#phoenix-tab-bar-2'), $('#overflow-button-2'));
+        if (Global.secondPaneWorkingSet.length === 0 && !secondPanePlaceholder && $("#phoenix-tab-bar-2")) {
+            Helper._hideTabBar($("#phoenix-tab-bar-2"), $("#overflow-button-2"));
         }
 
         // Now that tabs are updated, scroll to the active tab if necessary.
@@ -394,9 +426,8 @@ define(function (require, exports, module) {
         }
 
         // handle drag and drop
-        DragDrop.init($('#phoenix-tab-bar'), $('#phoenix-tab-bar-2'));
+        DragDrop.init($("#phoenix-tab-bar"), $("#phoenix-tab-bar-2"));
     }
-
 
     /**
      * Removes existing tab bar and cleans up
@@ -415,16 +446,14 @@ define(function (require, exports, module) {
         WorkspaceManager.recomputeLayout(true);
     }
 
-
     /**
      * handle click events on the tabs to open the file
      */
     function handleTabClick() {
-
         // delegate event handling for both tab bars
         $(document).on("click", ".phoenix-tab-bar .tab", function (event) {
             // check if the clicked element is the close button
-            if ($(event.target).hasClass('fa-times') || $(event.target).closest('.tab-close').length) {
+            if ($(event.target).hasClass("fa-times") || $(event.target).closest(".tab-close").length) {
                 // Get the file path from the data-path attribute of the parent tab
                 const filePath = $(this).attr("data-path");
 
@@ -436,10 +465,7 @@ define(function (require, exports, module) {
                     // get the file object
                     const fileObj = FileSystem.getFileForPath(filePath);
                     // close the file
-                    CommandManager.execute(
-                        Commands.FILE_CLOSE,
-                        { file: fileObj, paneId: paneId }
-                    );
+                    CommandManager.execute(Commands.FILE_CLOSE, { file: fileObj, paneId: paneId });
 
                     // Prevent default behavior
                     event.preventDefault();
@@ -450,7 +476,7 @@ define(function (require, exports, module) {
 
         // delegate event handling for both tab bars
         $(document).on("mousedown", ".phoenix-tab-bar .tab", function (event) {
-            if ($(event.target).hasClass('fa-times') || $(event.target).closest('.tab-close').length) {
+            if ($(event.target).hasClass("fa-times") || $(event.target).closest(".tab-close").length) {
                 return;
             }
             // Get the file path from the data-path attribute
@@ -461,11 +487,11 @@ define(function (require, exports, module) {
                 const isSecondPane = $(this).closest("#phoenix-tab-bar-2").length > 0;
                 const paneId = isSecondPane ? "second-pane" : "first-pane";
                 const currentActivePane = MainViewManager.getActivePaneId();
-                const isPaneActive = (paneId === currentActivePane);
+                const isPaneActive = paneId === currentActivePane;
                 const currentFile = MainViewManager.getCurrentlyViewedFile(currentActivePane);
 
                 // Check if this is a placeholder tab
-                if ($(this).hasClass('placeholder')) {
+                if ($(this).hasClass("placeholder")) {
                     // Add the file to the working set when placeholder tab is clicked
                     const fileObj = FileSystem.getFileForPath(filePath);
                     MainViewManager.addToWorkingSet(paneId, fileObj);
@@ -496,7 +522,6 @@ define(function (require, exports, module) {
             MoreOptions.showMoreOptionsContextMenu(paneId, event.pageX, event.pageY, filePath);
         });
     }
-
 
     // debounce is used to prevent rapid consecutive calls to updateTabs,
     // which was causing integration tests to fail in Firefox. Without it,
@@ -545,8 +570,7 @@ define(function (require, exports, module) {
             // Update UI
             if ($tabBar) {
                 const $tab = $tabBar.find(`.tab[data-path="${filePath}"]`);
-                $tab.toggleClass('dirty', doc.isDirty);
-
+                $tab.toggleClass("dirty", doc.isDirty);
 
                 // Update the working set data
                 // First pane
@@ -558,11 +582,10 @@ define(function (require, exports, module) {
                 }
             }
 
-
             // Also update the $tab2 if it exists
             if ($tabBar2) {
                 const $tab2 = $tabBar2.find(`.tab[data-path="${filePath}"]`);
-                $tab2.toggleClass('dirty', doc.isDirty);
+                $tab2.toggleClass("dirty", doc.isDirty);
 
                 // Second pane
                 for (let i = 0; i < Global.secondPaneWorkingSet.length; i++) {
@@ -574,7 +597,6 @@ define(function (require, exports, module) {
             }
         });
     }
-
 
     /**
      * This is called when the tab bar preference is changed either,
@@ -601,17 +623,13 @@ define(function (require, exports, module) {
      * for toggling the tab bar from the menu bar
      */
     function _registerCommands() {
-        CommandManager.register(
-            Strings.CMD_TOGGLE_TABBAR,
-            Commands.TOGGLE_TABBAR,
-            () => {
-                const currentPref = PreferencesManager.get(Preference.PREFERENCES_TAB_BAR);
-                PreferencesManager.set(Preference.PREFERENCES_TAB_BAR, {
-                    ...currentPref,
-                    showTabBar: !currentPref.showTabBar
-                });
-            }
-        );
+        CommandManager.register(Strings.CMD_TOGGLE_TABBAR, Commands.TOGGLE_TABBAR, () => {
+            const currentPref = PreferencesManager.get(Preference.PREFERENCES_TAB_BAR);
+            PreferencesManager.set(Preference.PREFERENCES_TAB_BAR, {
+                ...currentPref,
+                showTabBar: !currentPref.showTabBar
+            });
+        });
     }
 
     /**
@@ -620,7 +638,6 @@ define(function (require, exports, module) {
      * when its scrolled down, the tab bar will scroll to the right
      */
     function setupTabBarScrolling() {
-
         // common  handler for both the tab bars
         function handleMouseWheel(e) {
             // get the tab bar element that is being scrolled
@@ -640,7 +657,7 @@ define(function (require, exports, module) {
         }
 
         // attach the wheel event handler to both tab bars
-        $(document).on('wheel', '#phoenix-tab-bar, #phoenix-tab-bar-2', handleMouseWheel);
+        $(document).on("wheel", "#phoenix-tab-bar, #phoenix-tab-bar-2", handleMouseWheel);
     }
 
     AppInit.appReady(function () {
@@ -662,7 +679,7 @@ define(function (require, exports, module) {
         handleTabClick();
 
         Overflow.init();
-        DragDrop.init($('#phoenix-tab-bar'), $('#phoenix-tab-bar-2'));
+        DragDrop.init($("#phoenix-tab-bar"), $("#phoenix-tab-bar-2"));
 
         // setup the mouse wheel scrolling
         setupTabBarScrolling();

--- a/src/extensionsIntegrated/TabBar/main.js
+++ b/src/extensionsIntegrated/TabBar/main.js
@@ -133,7 +133,6 @@ define(function (require, exports, module) {
 
         let gitStatus = ""; // this will be shown in the tooltip when a tab is hovered
         let gitStatusClass = ""; // for styling
-        let gitStatusLetter = ""; // shown in the tab, either U or M
 
         if (window.phoenixGitEvents && window.phoenixGitEvents.TabBarIntegration) {
             const TabBarIntegration = window.phoenixGitEvents.TabBarIntegration;
@@ -144,11 +143,9 @@ define(function (require, exports, module) {
             if (TabBarIntegration.isUntracked(entry.path)) {
                 gitStatus = "Untracked";
                 gitStatusClass = "git-new";
-                gitStatusLetter = "U";
             } else if (TabBarIntegration.isModified(entry.path)) {
                 gitStatus = "Modified";
                 gitStatusClass = "git-modified";
-                gitStatusLetter = "M";
             }
         }
 

--- a/src/extensionsIntegrated/TabBar/main.js
+++ b/src/extensionsIntegrated/TabBar/main.js
@@ -163,7 +163,6 @@ define(function (require, exports, module) {
             title="${Phoenix.app.getDisplayPath(entry.path)}${gitStatus ? " (" + gitStatus + ")" : ""}">
             <div class="tab-icon"></div>
             <div class="tab-name"></div>
-            ${gitStatusLetter ? `<div class="tab-git-status">${gitStatusLetter}</div>` : ""}
             <div class="tab-close"><i class="fa-solid fa-times"></i></div>
         </div>`
         );

--- a/src/extensionsIntegrated/TabBar/main.js
+++ b/src/extensionsIntegrated/TabBar/main.js
@@ -138,7 +138,7 @@ define(function (require, exports, module) {
             ${isDirty ? "dirty" : ""}
             ${isPlaceholder ? "placeholder" : ""}"
             data-path="${entry.path}" 
-            title="${entry.path}">
+            title="${Phoenix.app.getDisplayPath(entry.path)}">
             <div class="tab-icon"></div>
             <div class="tab-name"></div>
             <div class="tab-close"><i class="fa-solid fa-times"></i></div>

--- a/src/extensionsIntegrated/TabBar/more-options.js
+++ b/src/extensionsIntegrated/TabBar/more-options.js
@@ -42,10 +42,10 @@ define(function (require, exports, module) {
         "---",
         Strings.RENAME_TAB_FILE,
         Strings.DELETE_TAB_FILE,
+        Strings.SHOW_IN_FILE_TREE,
         "---",
         Strings.REOPEN_CLOSED_FILE
     ];
-
 
     /**
      * "CLOSE TAB"
@@ -60,13 +60,9 @@ define(function (require, exports, module) {
             const fileObj = FileSystem.getFileForPath(filePath);
 
             // Execute close command with file object and pane ID
-            CommandManager.execute(
-                Commands.FILE_CLOSE,
-                { file: fileObj, paneId: paneId }
-            );
+            CommandManager.execute(Commands.FILE_CLOSE, { file: fileObj, paneId: paneId });
         }
     }
-
 
     /**
      * "CLOSE ALL TABS"
@@ -88,13 +84,9 @@ define(function (require, exports, module) {
         // close each file in the pane, start from the rightmost [to avoid index shifts]
         for (let i = workingSet.length - 1; i >= 0; i--) {
             const fileObj = FileSystem.getFileForPath(workingSet[i].path);
-            CommandManager.execute(
-                Commands.FILE_CLOSE,
-                { file: fileObj, paneId: paneId }
-            );
+            CommandManager.execute(Commands.FILE_CLOSE, { file: fileObj, paneId: paneId });
         }
     }
-
 
     /**
      * "CLOSE UNMODIFIED TABS"
@@ -114,18 +106,14 @@ define(function (require, exports, module) {
         }
 
         // get all those entries that are not dirty
-        const unmodifiedEntries = workingSet.filter(entry => !entry.isDirty);
+        const unmodifiedEntries = workingSet.filter((entry) => !entry.isDirty);
 
         // close each unmodified file in the pane
         for (let i = unmodifiedEntries.length - 1; i >= 0; i--) {
             const fileObj = FileSystem.getFileForPath(unmodifiedEntries[i].path);
-            CommandManager.execute(
-                Commands.FILE_CLOSE,
-                { file: fileObj, paneId: paneId }
-            );
+            CommandManager.execute(Commands.FILE_CLOSE, { file: fileObj, paneId: paneId });
         }
     }
-
 
     /**
      * "CLOSE TABS TO THE LEFT"
@@ -146,23 +134,20 @@ define(function (require, exports, module) {
         }
 
         // find the index of the current file in the working set
-        const currentIndex = workingSet.findIndex(entry => entry.path === filePath);
+        const currentIndex = workingSet.findIndex((entry) => entry.path === filePath);
 
-        if (currentIndex > 0) { // we only proceed if there are tabs to the left
+        if (currentIndex > 0) {
+            // we only proceed if there are tabs to the left
             // get all files to the left of the current file
             const filesToClose = workingSet.slice(0, currentIndex);
 
             // Close each file, starting from the rightmost [to avoid index shifts]
             for (let i = filesToClose.length - 1; i >= 0; i--) {
                 const fileObj = FileSystem.getFileForPath(filesToClose[i].path);
-                CommandManager.execute(
-                    Commands.FILE_CLOSE,
-                    { file: fileObj, paneId: paneId }
-                );
+                CommandManager.execute(Commands.FILE_CLOSE, { file: fileObj, paneId: paneId });
             }
         }
     }
-
 
     /**
      * "CLOSE TABS TO THE RIGHT"
@@ -183,7 +168,7 @@ define(function (require, exports, module) {
         }
 
         // get the index of the current file in the working set
-        const currentIndex = workingSet.findIndex(entry => entry.path === filePath);
+        const currentIndex = workingSet.findIndex((entry) => entry.path === filePath);
         // only proceed if there are tabs to the right
         if (currentIndex !== -1 && currentIndex < workingSet.length - 1) {
             // get all files to the right of the current file
@@ -191,14 +176,10 @@ define(function (require, exports, module) {
 
             for (let i = filesToClose.length - 1; i >= 0; i--) {
                 const fileObj = FileSystem.getFileForPath(filesToClose[i].path);
-                CommandManager.execute(
-                    Commands.FILE_CLOSE,
-                    { file: fileObj, paneId: paneId }
-                );
+                CommandManager.execute(Commands.FILE_CLOSE, { file: fileObj, paneId: paneId });
             }
         }
     }
-
 
     /**
      * "REOPEN CLOSED FILE"
@@ -208,7 +189,6 @@ define(function (require, exports, module) {
     function reopenClosedFile() {
         CommandManager.execute(Commands.FILE_REOPEN_CLOSED);
     }
-
 
     /**
      * "RENAME FILE"
@@ -225,10 +205,9 @@ define(function (require, exports, module) {
             const fileObj = FileSystem.getFileForPath(filePath);
 
             // Execute the rename command with the file object
-            CommandManager.execute(Commands.FILE_RENAME, {file: fileObj});
+            CommandManager.execute(Commands.FILE_RENAME, { file: fileObj });
         }
     }
-
 
     /**
      * "DELETE FILE"
@@ -242,10 +221,28 @@ define(function (require, exports, module) {
             const fileObj = FileSystem.getFileForPath(filePath);
 
             // Execute the delete command with the file object
-            CommandManager.execute(Commands.FILE_DELETE, {file: fileObj});
+            CommandManager.execute(Commands.FILE_DELETE, { file: fileObj });
         }
     }
 
+    /**
+     * "SHOW IN FILE TREE"
+     * This function handles showing the file in the file tree
+     *
+     * @param {String} filePath - path of the file to show in file tree
+     */
+    function handleShowInFileTree(filePath) {
+        if (filePath) {
+            // First ensure the sidebar is visible so users can see the file in the tree
+            CommandManager.execute(Commands.SHOW_SIDEBAR);
+
+            // Get the file object using FileSystem
+            const fileObj = FileSystem.getFileForPath(filePath);
+
+            // Execute the show in tree command with the file object
+            CommandManager.execute(Commands.NAVIGATE_SHOW_IN_FILE_TREE, { file: fileObj });
+        }
+    }
 
     /**
      * This function is called when a tab is right-clicked
@@ -317,6 +314,9 @@ define(function (require, exports, module) {
             break;
         case Strings.DELETE_TAB_FILE:
             handleFileDelete(filePath);
+            break;
+        case Strings.SHOW_IN_FILE_TREE:
+            handleShowInFileTree(filePath);
             break;
         case Strings.REOPEN_CLOSED_FILE:
             reopenClosedFile();

--- a/src/extensionsIntegrated/TabBar/more-options.js
+++ b/src/extensionsIntegrated/TabBar/more-options.js
@@ -272,7 +272,7 @@ define(function (require, exports, module) {
 
         dropdown.showDropdown();
 
-        $(".tabbar-context-menu").css("max-height", "200px");
+        $(".tabbar-context-menu").css("max-height", "300px");
 
         // handle the option selection
         dropdown.on("select", function (e, item) {

--- a/src/extensionsIntegrated/TabBar/more-options.js
+++ b/src/extensionsIntegrated/TabBar/more-options.js
@@ -69,18 +69,6 @@ define(function (require, exports, module) {
 
 
     /**
-     * "CLOSE ACTIVE TAB"
-     * this closes the currently active tab
-     * doesn't matter if the context menu is opened from this tab or some other tab
-     */
-    function handleCloseActiveTab() {
-        // This simply executes the FILE_CLOSE command without parameters
-        // which will close the currently active file
-        CommandManager.execute(Commands.FILE_CLOSE);
-    }
-
-
-    /**
      * "CLOSE ALL TABS"
      * This will close all tabs in the specified pane
      *

--- a/src/extensionsIntegrated/TabBar/more-options.js
+++ b/src/extensionsIntegrated/TabBar/more-options.js
@@ -40,6 +40,9 @@ define(function (require, exports, module) {
         Strings.CLOSE_ALL_TABS,
         Strings.CLOSE_UNMODIFIED_TABS,
         "---",
+        Strings.RENAME_TAB_FILE,
+        Strings.DELETE_TAB_FILE,
+        "---",
         Strings.REOPEN_CLOSED_FILE
     ];
 
@@ -220,6 +223,43 @@ define(function (require, exports, module) {
 
 
     /**
+     * "RENAME FILE"
+     * This function handles the renaming of the file that was right-clicked
+     *
+     * @param {String} filePath - path of the file to rename
+     */
+    function handleFileRename(filePath) {
+        if (filePath) {
+            // First ensure the sidebar is visible so users can see the rename action
+            CommandManager.execute(Commands.SHOW_SIDEBAR);
+
+            // Get the file object using FileSystem
+            const fileObj = FileSystem.getFileForPath(filePath);
+
+            // Execute the rename command with the file object
+            CommandManager.execute(Commands.FILE_RENAME, {file: fileObj});
+        }
+    }
+
+
+    /**
+     * "DELETE FILE"
+     * This function handles the deletion of the file that was right-clicked
+     *
+     * @param {String} filePath - path of the file to delete
+     */
+    function handleFileDelete(filePath) {
+        if (filePath) {
+            // Get the file object using FileSystem
+            const fileObj = FileSystem.getFileForPath(filePath);
+
+            // Execute the delete command with the file object
+            CommandManager.execute(Commands.FILE_DELETE, {file: fileObj});
+        }
+    }
+
+
+    /**
      * This function is called when a tab is right-clicked
      * This will show the more options context menu
      *
@@ -278,6 +318,12 @@ define(function (require, exports, module) {
             break;
         case Strings.CLOSE_UNMODIFIED_TABS:
             handleCloseUnmodifiedTabs(paneId);
+            break;
+        case Strings.RENAME_TAB_FILE:
+            handleFileRename(filePath);
+            break;
+        case Strings.DELETE_TAB_FILE:
+            handleFileDelete(filePath);
             break;
         case Strings.REOPEN_CLOSED_FILE:
             reopenClosedFile();

--- a/src/extensionsIntegrated/TabBar/more-options.js
+++ b/src/extensionsIntegrated/TabBar/more-options.js
@@ -282,7 +282,12 @@ define(function (require, exports, module) {
             zIndex: 1000
         });
 
+        // Add a custom class to override the max-height, not sure why a scroll bar was coming but this did the trick
+        dropdown.dropdownExtraClasses = "tabbar-context-menu";
+
         dropdown.showDropdown();
+
+        $(".tabbar-context-menu").css("max-height", "200px");
 
         // handle the option selection
         dropdown.on("select", function (e, item) {

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -435,6 +435,7 @@ define({
     "REOPEN_CLOSED_FILE": "Reopen Closed File",
     "RENAME_TAB_FILE": "Rename File",
     "DELETE_TAB_FILE": "Delete File",
+    "SHOW_IN_FILE_TREE": "Show in File Tree",
 
     // CodeInspection: errors/warnings
     "ERRORS_NO_FILE": "No File Open",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -433,6 +433,8 @@ define({
     "CLOSE_ALL_TABS": "Close All Tabs",
     "CLOSE_UNMODIFIED_TABS": "Close Unmodified Tabs",
     "REOPEN_CLOSED_FILE": "Reopen Closed File",
+    "RENAME_TAB_FILE": "Rename File",
+    "DELETE_TAB_FILE": "Delete File",
 
     // CodeInspection: errors/warnings
     "ERRORS_NO_FILE": "No File Open",

--- a/src/styles/Extn-TabBar.less
+++ b/src/styles/Extn-TabBar.less
@@ -424,27 +424,26 @@
 }
 
 /* ------ for the git status markers -------------- */
-.tab-git-status {
-    font-size: 0.9rem;
-    font-weight: bold;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-left: 0.33rem;
+.tab.git-modified > .tab-icon:before {
+    content: "|";
+    color: #E3B551;
+    position: absolute;
+    margin-left: -4px;
+    margin-bottom: 5px;
 }
 
-.git-modified .tab-git-status {
+.dark .tab.git-modified > .tab-icon:before {
     color: #E3B551;
 }
 
-.dark .git-modified .tab-git-status {
-    color: #E3B551;
-}
-
-.git-new .tab-git-status {
+.tab.git-new > .tab-icon:before {
+    content: "|";
     color: #91CC41;
+    position: absolute;
+    margin-left: -4px;
+    margin-bottom: 5px;
 }
 
-.dark .git-new .tab-git-status {
+.dark .tab.git-new > .tab-icon:before {
     color: #91CC41;
 }

--- a/src/styles/Extn-TabBar.less
+++ b/src/styles/Extn-TabBar.less
@@ -307,30 +307,30 @@
 .tab-drag-indicator {
     position: fixed;
     width: 2px;
-    background-color: #0078D7;
+    background-color: rgba(0, 120, 215, 0.7);
     pointer-events: none;
     z-index: 10001;
-    box-shadow: 0 0 3px rgba(0, 120, 215, 0.5);
+    box-shadow: 0 0 3px rgba(0, 120, 215, 0.4);
     display: none;
-    animation: pulse 1.5s infinite;
+    animation: pulse 2s infinite;
 }
 
 .dark .tab-drag-indicator {
-    background-color: #75BEFF;
-    box-shadow: 0 0 3px rgba(117, 190, 255, 0.5);
+    background-color: rgba(117, 190, 255, 0.7);
+    box-shadow: 0 0 3px rgba(117, 190, 255, 0.4);
 }
 
 @keyframes pulse {
     0% {
-        opacity: 0.7;
+        opacity: 0.5;
     }
 
     50% {
-        opacity: 1;
+        opacity: 0.7;
     }
 
     100% {
-        opacity: 0.7;
+        opacity: 0.5;
     }
 }
 
@@ -413,4 +413,10 @@
 .dropdown-tab-item.placeholder-item .tab-name-container,
 .tab-name-container.placeholder-name {
     font-style: italic;
+}
+
+/* this is for invisible extended drag zone for tabs */
+#tab-drag-extended-zone {
+    background-color: transparent;
+    pointer-events: all;
 }

--- a/src/styles/Extn-TabBar.less
+++ b/src/styles/Extn-TabBar.less
@@ -137,6 +137,8 @@
     font-size: 0.7rem;
     opacity: 0.7;
     font-weight: normal;
+    position: relative;
+    top: 0.1rem;
 }
 
 .tab.active {
@@ -195,10 +197,10 @@
 .tab::before {
     content: "•";
     color: transparent;
-    font-size: 1.6rem;
+    font-size: 1.5rem;
     position: absolute;
     left: 0.4rem;
-    top: 0.25rem;
+    top: 0.33rem;
 }
 
 .tab.dirty::before {
@@ -215,7 +217,7 @@
 
 .tab-close {
     font-size: 0.75rem;
-    padding: 0.08rem 0.4rem;
+    padding: 0.1rem 0.4rem;
     margin-left: 0.25rem;
     color: #666;
     transition: all 0.2s ease;
@@ -419,4 +421,30 @@
 #tab-drag-extended-zone {
     background-color: transparent;
     pointer-events: all;
+}
+
+/* ------ for the git status markers -------------- */
+.tab-git-status {
+    font-size: 0.9rem;
+    font-weight: bold;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-left: 0.33rem;
+}
+
+.git-modified .tab-git-status {
+    color: #E3B551;
+}
+
+.dark .git-modified .tab-git-status {
+    color: #E3B551;
+}
+
+.git-new .tab-git-status {
+    color: #91CC41;
+}
+
+.dark .git-new .tab-git-status {
+    color: #91CC41;
 }

--- a/src/styles/Extn-TabBar.less
+++ b/src/styles/Extn-TabBar.less
@@ -80,7 +80,7 @@
 .tab {
     display: inline-flex;
     align-items: center;
-    padding: 0 0.5rem 0 0.85rem;
+    padding: 0 0.5rem 0 0.6rem;
     height: 100%;
     background-color: #f1f1f1;
     border-right: 1px solid rgba(0, 0, 0, 0.05);
@@ -108,6 +108,7 @@
     display: flex;
     align-items: center;
     margin-bottom: -2px;
+    margin-left: 0.7rem;
 }
 
 .tab-name {
@@ -191,13 +192,17 @@
     background-color: #666;
 }
 
-.tab.dirty::before {
+.tab::before {
     content: "•";
-    color: #888;
+    color: transparent;
     font-size: 1.6rem;
     position: absolute;
-    left: 0.75rem;
+    left: 0.4rem;
     top: 0.25rem;
+}
+
+.tab.dirty::before {
+    color: #888;
 }
 
 .dark .tab.dirty::before {
@@ -205,7 +210,7 @@
 }
 
 .tab.dirty .tab-icon {
-    margin-left: 0.8rem;
+    margin-left: 0.7rem;
 }
 
 .tab-close {

--- a/src/styles/Extn-TabBar.less
+++ b/src/styles/Extn-TabBar.less
@@ -426,7 +426,7 @@
 /* ------ for the git status markers -------------- */
 .tab.git-modified > .tab-icon:before {
     content: "|";
-    color: #E3B551;
+    color: #f1ae1c;
     position: absolute;
     margin-left: -4px;
     margin-bottom: 5px;
@@ -438,7 +438,7 @@
 
 .tab.git-new > .tab-icon:before {
     content: "|";
-    color: #91CC41;
+    color: #69a01f;
     position: absolute;
     margin-left: -4px;
     margin-bottom: 5px;


### PR DESCRIPTION
1. Reserve space for dirty icon always to prevent tabs shift when a file is modified/saved.

**Before**
https://github.com/user-attachments/assets/50ff6184-081f-4bfe-82b1-facbb1c83ade

**After**
https://github.com/user-attachments/assets/5ed7b0c4-bd4a-4eae-b53c-7c15ec2d9e74



2. Add option to rename, delete file and show in file tree in the tab context menu
![Screenshot 2025-05-15 021424](https://github.com/user-attachments/assets/e0aab882-044a-4abb-97a2-881b96f14112)

3. Made drag-drop scroll smoother
4. Currently active tab is always shown on the tab bar even if user manually sets a number in the numberOfTabs preference option
5. Fix: Now, we show the display path when a tab is hovered instead of the tauri path
6. We also show the git change markers in the tab to visually identify the tab that is added/modified

![Screenshot 2025-05-18 203412](https://github.com/user-attachments/assets/d7f6f15e-41ea-4334-8edb-529aa514e151)
![Screenshot 2025-05-18 203417](https://github.com/user-attachments/assets/dcc310cb-f162-431e-9016-9f78ba3cc1c2)

