### PR TITLE
Refactor styling for profile page

### DIFF
--- a/docs/API-Reference/command/Commands.md
+++ b/docs/API-Reference/command/Commands.md
@@ -825,6 +825,18 @@ Sorts working set by file type
 Toggles automatic working set sorting
 
 **Kind**: global variable  
+<a name="CMD_TOGGLE_SHOW_WORKING_SET"></a>
+
+## CMD\_TOGGLE\_SHOW\_WORKING\_SET
+Toggles working set visibility
+
+**Kind**: global variable  
+<a name="CMD_TOGGLE_SHOW_FILE_TABS"></a>
+
+## CMD\_TOGGLE\_SHOW\_FILE\_TABS
+Toggles file tabs visibility
+
+**Kind**: global variable  
 <a name="CMD_KEYBOARD_NAV_UI_OVERLAY"></a>
 
 ## CMD\_KEYBOARD\_NAV\_UI\_OVERLAY

--- a/src/extensionsIntegrated/Phoenix/html/login-dialog.html
+++ b/src/extensionsIntegrated/Phoenix/html/login-dialog.html
@@ -8,7 +8,7 @@
             {{signInBtnText}}
         </button>
         <div class="support-link">
-            <button id="phoenix-support-btn" class="btn dialog-button">
+            <button id="phoenix-support-btn" class="text-link">
                 <i class="fa fa-question-circle"></i>
                 {{supportBtnText}}
             </button>

--- a/src/extensionsIntegrated/Phoenix/html/profile-panel.html
+++ b/src/extensionsIntegrated/Phoenix/html/profile-panel.html
@@ -26,14 +26,16 @@
             {{accountBtnText}}
         </button>
 
-        <button id="phoenix-support-btn" class="btn dialog-button menu-button">
-            <i class="fa fa-question-circle"></i>
-            {{supportBtnText}}
-        </button>
-
         <button id="phoenix-signout-btn" class="btn dialog-button menu-button signout">
             <i class="fa fa-sign-out-alt"></i>
             {{signOutBtnText}}
         </button>
+
+        <div class="support-link">
+            <button id="phoenix-support-btn" class="text-link">
+                <i class="fa fa-question-circle"></i>
+                {{supportBtnText}}
+            </button>
+        </div>
     </div>
 </div>

--- a/src/styles/Extn-UserProfile.less
+++ b/src/styles/Extn-UserProfile.less
@@ -1,7 +1,7 @@
 @import "brackets_variables.less";
 
 .profile-popup {
-    background-color: @bc-menu-bg;
+    background-color: @bc-panel-bg;
     color: @bc-menu-text;
     border-radius: @bc-border-radius;
     box-shadow: 0 3px 9px @bc-shadow;
@@ -59,6 +59,7 @@
 
     .user-plan {
         color: #3c3;
+        //color: #2b7d2b;
         font-size: 16px;
     }
 
@@ -76,7 +77,7 @@
     .progress-bar {
         width: 100%;
         height: 8px;
-        background-color: @bc-input-bg;
+        background-color: #fff;
         border-radius: 4px;
         overflow: hidden;
         border: 1px solid @bc-btn-border;
@@ -90,8 +91,9 @@
     }
 
     .support-link {
-        margin-top: 20px;
+        margin-top: 6px;
         text-align: center;
+        width: 100%;
     }
 
     .menu-button {
@@ -107,7 +109,34 @@
         }
 
         &.signout {
-            color: #f55;
+            color: #d44;
+        }
+    }
+
+    .text-link {
+        background: none;
+        border: none;
+        box-shadow: none;
+        cursor: pointer;
+        color: @bc-text-medium;
+        font-size: (@baseFontSize + 1);
+        padding: 8px 12px;
+        margin: 3px 0;
+        width: 100%;
+        text-align: center;
+        transition: color 0.2s ease;
+
+        i {
+            margin-right: 5px;
+        }
+
+        &:hover, &:focus {
+            color: @bc-text-emphasized;
+            outline: none;
+        }
+
+        &.menu-button {
+            text-align: left;
         }
     }
 
@@ -158,7 +187,7 @@
 }
 
 .dark .profile-popup {
-    background-color: @dark-bc-menu-bg;
+    background-color: @dark-bc-panel-bg;
     color: @dark-bc-menu-text;
     box-shadow: 0 3px 9px @dark-bc-shadow;
 
@@ -185,6 +214,14 @@
 
         .progress-fill {
             background-color: @dark-bc-primary-btn-bg;
+        }
+    }
+
+    .text-link {
+        color: @dark-bc-text-thin-quiet;
+
+        &:hover, &:focus {
+            color: lighten(@dark-bc-text-thin-quiet, 30%);
         }
     }
 

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -671,7 +671,7 @@ a, img {
 
 .user {
     background: url("images/circle-user-solid.svg") center no-repeat;
-    background-size: 20px 20px;
+    background-size: 18px 18px;
 }
 
 #editor-holder {


### PR DESCRIPTION
This PR does the following 2 changes:
1. Reduced the size of the profile icon on the toolbar to make it consistent with other buttons.
2. Made the contact support button similar in both the sign in and the profile popup.


**Visual reference**
![Screenshot 2025-05-22 152015](https://github.com/user-attachments/assets/c3f69a69-fe47-4f07-8427-4b8cb8178a59)
![Screenshot 2025-05-22 152026](https://github.com/user-attachments/assets/da9162f6-ed74-4db9-9d44-4d87a04a0ed2)
![Screenshot 2025-05-22 152036](https://github.com/user-attachments/assets/9843f03d-b0c7-43af-8aca-4027fdb1759b)
