### PR TITLE
Fix tab bar drag-drop issues in between panes

### DIFF
--- a/docs/API-Reference/command/Commands.md
+++ b/docs/API-Reference/command/Commands.md
@@ -824,6 +824,18 @@ Sorts working set by file type
 ## CMD\_WORKING\_SORT\_TOGGLE\_AUTO
 Toggles automatic working set sorting
 
+**Kind**: global variable
+<a name="CMD_TOGGLE_SHOW_WORKING_SET"></a>
+
+## CMD\_TOGGLE\_SHOW\_WORKING\_SET
+Toggles working set visibility
+
+**Kind**: global variable
+<a name="CMD_TOGGLE_SHOW_FILE_TABS"></a>
+
+## CMD\_TOGGLE\_SHOW\_FILE\_TABS
+Toggles file tabs visibility
+
 **Kind**: global variable  
 <a name="CMD_TOGGLE_SHOW_WORKING_SET"></a>
 

--- a/src/extensionsIntegrated/TabBar/drag-drop.js
+++ b/src/extensionsIntegrated/TabBar/drag-drop.js
@@ -40,6 +40,27 @@ define(function (require, exports, module) {
     let dragSourcePane = null;
 
     /**
+     * this function is responsible to make sure that all the drag state is properly cleaned up
+     * it is needed to make sure that the tab bar doesn't get unresponsive
+     * because of handlers not being attached properly
+     */
+    function cleanupDragState() {
+        $(".tab").removeClass("dragging drag-target");
+        $(".empty-pane-drop-target").removeClass("empty-pane-drop-target");
+        updateDragIndicator(null);
+        draggedTab = null;
+        dragOverTab = null;
+        dragSourcePane = null;
+
+        if (scrollInterval) {
+            clearInterval(scrollInterval);
+            scrollInterval = null;
+        }
+
+        $("#tab-drag-extended-zone").remove();
+    }
+
+    /**
      * Initialize drag and drop functionality for tab bars
      * This is called from `main.js`
      * This function sets up event listeners for both panes' tab bars
@@ -202,9 +223,6 @@ define(function (require, exports, module) {
             if (e.preventDefault) {
                 e.preventDefault();
             }
-            // hide the drag indicator
-            updateDragIndicator(null);
-            removeOuterDropZone();
 
             // get container dimensions to determine drop position
             const containerRect = this.getBoundingClientRect();
@@ -235,6 +253,9 @@ define(function (require, exports, module) {
                     }
                 }
             }
+
+            // ensure all drag state is cleaned up
+            cleanupDragState();
         });
 
         /**
@@ -311,9 +332,7 @@ define(function (require, exports, module) {
                 }
             }
 
-            // Clean up
-            updateDragIndicator(null);
-            removeOuterDropZone();
+            cleanupDragState();
         }
     }
 
@@ -449,7 +468,6 @@ define(function (require, exports, module) {
         if (e.stopPropagation) {
             e.stopPropagation(); // Stops browser from redirecting
         }
-        updateDragIndicator(null);
 
         // Only process the drop if the dragged tab is different from the drop target
         if (draggedTab !== this) {
@@ -474,6 +492,8 @@ define(function (require, exports, module) {
                 moveWorkingSetItem(targetPaneId, draggedPath, targetPath, onLeftSide);
             }
         }
+
+        cleanupDragState();
         return false;
     }
 
@@ -484,20 +504,7 @@ define(function (require, exports, module) {
      * @param {Event} e - The event object
      */
     function handleDragEnd(e) {
-        $(".tab").removeClass("dragging drag-target");
-        updateDragIndicator(null);
-        draggedTab = null;
-        dragOverTab = null;
-        dragSourcePane = null;
-
-        // Clear scroll interval if it exists
-        if (scrollInterval) {
-            clearInterval(scrollInterval);
-            scrollInterval = null;
-        }
-
-        // Remove the extended drop zone if it exists
-        $("#tab-drag-extended-zone").remove();
+        cleanupDragState();
     }
 
     /**
@@ -762,11 +769,7 @@ define(function (require, exports, module) {
                     }
                 }
 
-                // reset all drag state stuff
-                updateDragIndicator(null);
-                draggedTab = null;
-                dragOverTab = null;
-                dragSourcePane = null;
+                cleanupDragState();
             }
         });
     }

--- a/src/extensionsIntegrated/TabBar/drag-drop.js
+++ b/src/extensionsIntegrated/TabBar/drag-drop.js
@@ -635,13 +635,8 @@ define(function (require, exports, module) {
             // Add to the target pane at the calculated position
             MainViewManager.addToWorkingSet(targetPaneId, draggedFile, targetInsertIndex);
 
-            // If the tab was the active one in the source pane,
-            // make it active in the target pane too
-            const activeFile = MainViewManager.getCurrentlyViewedFile(sourcePaneId);
-            if (activeFile && activeFile.fullPath === draggedPath) {
-                // Open the file in the target pane and make it active
-                CommandManager.execute(Commands.FILE_OPEN, { fullPath: draggedPath, paneId: targetPaneId });
-            }
+            // we always need to make the dragged tab active in the target pane when moving between panes
+            CommandManager.execute(Commands.FILE_OPEN, { fullPath: draggedPath, paneId: targetPaneId });
         }
     }
 

--- a/src/styles/Extn-TabBar.less
+++ b/src/styles/Extn-TabBar.less
@@ -409,7 +409,7 @@
 }
 
 .empty-pane-drop-target {
-    border: 2px dashed #6db6ff !important;
+    border: 1px solid #6db6ff !important;
 }
 
 .dropdown-tab-item.placeholder-item .tab-name-container,

--- a/src/styles/Extn-TabBar.less
+++ b/src/styles/Extn-TabBar.less
@@ -138,7 +138,7 @@
     opacity: 0.7;
     font-weight: normal;
     position: relative;
-    top: 0.1rem;
+    top: 0.05rem;
 }
 
 .tab.active {
@@ -200,7 +200,7 @@
     font-size: 1.5rem;
     position: absolute;
     left: 0.4rem;
-    top: 0.33rem;
+    top: 0.28rem;
 }
 
 .tab.dirty::before {


### PR DESCRIPTION
This PR does the following changes:
1st Commit:- Earlier it was not possible to drop a dragged tab over the editor area. This commit fixes that issue. Now users can drag a tab from one pane and drop it in the editor area of the other pane and the tab successfully gets placed.

2nd Commit:- When a tab was dragged from one pane to the other pane, the dragged tab now becomes active. Earlier it was not possible.

3rd Commit:- Earlier, after dragging dropping tabs, sometimes tab bar becomes unresponsive. this was because _registerHandlers was not attaching all the events properly. fixed that.

4th commit:- Just updated the pane border styling.

5th commit:- Sometimes when a tab was dragged from one pane to other pane, then a placeholder(temporary tab) used to appear on the first pane from where tab was dragged. Fixed that. This issue mainly appeared because when dragging a click event also gets fired because of which a placeholder tab was added.

6th commit:- just some styling changes and made the dirty icon, file directory name, and close icon all aligned