### PR TITLE
Fixed UI issues with emmet code hints in HTML files

### DIFF
--- a/src/extensions/default/HTMLCodeHints/main.js
+++ b/src/extensions/default/HTMLCodeHints/main.js
@@ -143,15 +143,20 @@ define(function (require, exports, module) {
      * @returns {jQuery} - A jQuery element representing the formatted hint.
      */
     function formatEmmetHint(abbr) {
-        // Create the main container for the hint text.
+        // Create the main container for the hint
         var $hint = $("<span>")
-            .addClass("emmet-hint")
+            .addClass("emmet-hint");
+
+        // Create a wrapper for the text content
+        var $textContent = $("<span>")
+            .addClass("emmet-text-content")
             .text(abbr);
 
         // style in brackets_patterns_override.less file
         let $icon = $(`<span class="emmet-code-hint">Emmet</span>`);
 
-        // Append the icon to the hint element
+        // Append both text content and icon to the main container
+        $hint.append($textContent);
         $hint.append($icon);
 
         return $hint;

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -602,7 +602,9 @@ a:focus {
     .dropdown-menu {
         box-shadow: 0 3px 9px @bc-shadow;
         max-height: 160px;
+        max-width: 400px;
         overflow-y: auto;
+        overflow-x: hidden;
         padding: 0;
 
         .dark & {
@@ -746,6 +748,16 @@ a:focus {
 
 .emmet-hint {
     margin-right: 48px !important;
+}
+
+.emmet-text-content {
+    display: inline-block;
+    max-width: 320px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    vertical-align: top;
+    line-height: inherit;
 }
 
 #codehint-desc {

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -727,20 +727,25 @@ a:focus {
   }
 }
 
-.emmet-hint {
-    margin-right: 48px !important;
+.emmet-code-hint {
+    visibility: hidden;
 }
 
-.emmet-code-hint {
+.codehint-menu .dropdown-menu li a.highlight .emmet-code-hint {
+    visibility: visible;
     position: absolute;
-    font-size: 0.85em;
+    right: 1rem;
+    font-size: 0.85em !important;
     font-weight: @font-weight-semibold;
-    right: 4px;
-    bottom: 0px;
+    letter-spacing: 0.3px;
     color: @css-codehint-icon !important;
     .dark& {
         color: @dark-css-codehint-icon !important;
     }
+}
+
+.emmet-hint {
+    margin-right: 48px !important;
 }
 
 #codehint-desc {

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -602,9 +602,7 @@ a:focus {
     .dropdown-menu {
         box-shadow: 0 3px 9px @bc-shadow;
         max-height: 160px;
-        max-width: 400px;
         overflow-y: auto;
-        overflow-x: hidden;
         padding: 0;
 
         .dark & {


### PR DESCRIPTION
This PR does the following 2 fixes. Refer to https://github.com/phcode-dev/phoenix/issues/2269

1st commit: The Emmet icon in HTML and Stylesheet files are a bit different. Updated the Emmet icon to look same in both the files for consistency.
2nd commit: In very large emmet abbreviations the code hints can get extremely large covering the whole screen space. Gave it a max-width so that it doesn't cover up the whole screen space.
**Before**
![Screenshot 2025-05-30 032358](https://github.com/user-attachments/assets/f0189ef1-6a5c-4e0b-bfae-50e2ed9f0377)

**After**
![Screenshot 2025-05-30 044510](https://github.com/user-attachments/assets/bdb8daff-252b-45ed-a33d-7d1de3502884)

