### PR TITLE
Truncate long directory names in working set

### DIFF
--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -1003,7 +1003,7 @@ define(function (require, exports, module) {
 
     /**
      * adds the directory name to external project files
-     * when the directory length is more than 3, we just show `...`
+     * when the directory length is more than 3, we show it in this format: `<root directory>/.../<parent directory>`
      * otherwise the full path
      * @private
      * @param {Array.<string>} externalProjectFiles - the list of the external project files
@@ -1028,7 +1028,9 @@ define(function (require, exports, module) {
 
                 let truncatedPath = displayPath; // truncatedPath value will be shown in the UI
                 if (dirSplit.length > 3) {
-                    truncatedPath = dirSplit[0] + separator + "\u2026" + separator + dirSplit[dirSplit.length - 1];
+                    // because sometimes dirSplit[0] is empty
+                    let rootDirName = dirSplit[0] ? dirSplit[0] : dirSplit[1];
+                    truncatedPath = rootDirName + separator + "\u2026" + separator + dirSplit[dirSplit.length - 1];
                 }
 
                 const $dir = $(`<span title='${displayPath}' class='directory'/>`)

--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -1028,7 +1028,9 @@ define(function (require, exports, module) {
 
                 let truncatedPath = displayPath; // truncatedPath value will be shown in the UI
                 if (dirSplit.length > 3) {
-                    // because sometimes dirSplit[0] is empty
+                    // dirSplit[0] maybe empty sometimes:
+                    // - In browsers, for paths starting with "/" (e.g., "/fs/path/to/file")
+                    // - In desktop app, for absolute paths on Linux/Mac (e.g., "/root/fs/path/to/file")
                     let rootDirName = dirSplit[0] ? dirSplit[0] : dirSplit[1];
                     truncatedPath = rootDirName + separator + "\u2026" + separator + dirSplit[dirSplit.length - 1];
                 }


### PR DESCRIPTION
In the working set, when files from external folders were opened, we used to show the full directory path. This often made the path unnecessarily long.

Fixed it — now, if a file is nested more than 3 levels deep, we display the path in a shortened format: `root folder/.../parent folder`.

Issue reference: https://github.com/phcode-dev/phoenix/issues/2187

Visual reference
**Before**
![Screenshot 2025-06-28 181642](https://github.com/user-attachments/assets/89b8b715-b389-4c5d-bf92-cb1aafc7914f)

**After**
![Screenshot 2025-06-28 181721](https://github.com/user-attachments/assets/153ed82a-63c7-4578-a6de-91b12ff5c1db)

