### PR TITLE
[FEAT] A collapse button in the sidebar which when clicked closes all the open folders

### DIFF
--- a/src/extensions/default/Git/styles/git-styles.less
+++ b/src/extensions/default/Git/styles/git-styles.less
@@ -907,6 +907,7 @@
     white-space: nowrap;
     padding: 2px 5px;
     margin-left: -5px;
+    margin-right: 2em;
     .dropdown-arrow {
         display: inline-block;
         width: 7px;

--- a/src/extensionsIntegrated/CollapseFolders/main.js
+++ b/src/extensionsIntegrated/CollapseFolders/main.js
@@ -87,6 +87,12 @@ define(function (require, exports, module) {
             return;
         }
 
+        // we need this check to see if on site load the mouse is already over the sidebar area or not
+        // because if it is, then we need to show the button
+        if ($sidebar.is(":hover")) {
+            $collapseBtn.addClass("show");
+        }
+
         $sidebar.on("mouseenter", function () {
             $collapseBtn.addClass("show");
         });

--- a/src/extensionsIntegrated/CollapseFolders/main.js
+++ b/src/extensionsIntegrated/CollapseFolders/main.js
@@ -1,0 +1,79 @@
+define(function (require, exports, module) {
+    const AppInit = require("utils/AppInit");
+    const ProjectManager = require("project/ProjectManager");
+
+    /**
+     * This is the main function that handles the closing of all the directories
+     */
+    function handleCollapseBtnClick() {
+        // this will give us an array of array's
+        // the root level directories will be at index 0, its next level will be at index 1 and so on
+        const openNodes = ProjectManager._actionCreator.model.getOpenNodes();
+        if (!openNodes || openNodes.length === 0) {
+            return;
+        }
+
+        // traversing from the back because the deepest nested directories should be closed first
+        // Note: this is an array of all the directories at the deepest level
+        for (let i = openNodes.length - 1; i >= 0; i--) {
+            // close all the directories
+            openNodes[i].forEach(function (folderPath) {
+                try {
+                    // to close each dir
+                    ProjectManager._actionCreator.setDirectoryOpen(folderPath, false);
+                } catch (error) {
+                    console.error("Failed to close folder:", folderPath, error);
+                }
+            });
+        }
+    }
+
+    /**
+     * This function is responsible to create the 'Collapse All' button
+     * and append it to the sidebar area on the project-files-header
+     */
+    function createCollapseButton() {
+        const $projectFilesHeader = $("#project-files-header");
+        // make sure that we were able to get the project-files-header DOM element
+        if ($projectFilesHeader.length === 0) {
+            return;
+        }
+
+        // create the collapse btn
+        const $collapseBtn = $(`
+            <div id="collapse-folders" class="btn-alt-quiet" title="Collapse All">
+                <i class="fa-solid fa-chevron-down collapse-icon" aria-hidden="true"></i>
+                <i class="fa-solid fa-chevron-up collapse-icon" aria-hidden="true"></i>
+            </div>
+        `);
+
+        $collapseBtn.on("click", handleCollapseBtnClick);
+
+        $projectFilesHeader.append($collapseBtn); // append the btn to the project-files-header
+
+        _setupHoverBehavior($collapseBtn); // hover functionality to show/hide the button
+    }
+
+    /**
+     * This function is responsible for the hover behavior to show/hide the collapse button
+     * we only show the button when the cursor is over the sidebar area
+     */
+    function _setupHoverBehavior($collapseBtn) {
+        const $sidebar = $("#sidebar");
+        if ($sidebar.length === 0) {
+            return;
+        }
+
+        $sidebar.on("mouseenter", function () {
+            $collapseBtn.addClass("show");
+        });
+
+        $sidebar.on("mouseleave", function () {
+            $collapseBtn.removeClass("show");
+        });
+    }
+
+    AppInit.appReady(function () {
+        createCollapseButton();
+    });
+});

--- a/src/extensionsIntegrated/CollapseFolders/main.js
+++ b/src/extensionsIntegrated/CollapseFolders/main.js
@@ -1,3 +1,26 @@
+/*
+ * GNU AGPL-3.0 License
+ *
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
+ *
+ */
+
+/* Displays a Collapse button in the sidebar area */
+/* when the button gets clicked, it closes all the directories recursively that are opened */
+/* Styling for the button is done in `../../styles/Extn-CollapseFolders.less` */
 define(function (require, exports, module) {
     const AppInit = require("utils/AppInit");
     const ProjectManager = require("project/ProjectManager");

--- a/src/extensionsIntegrated/CollapseFolders/main.js
+++ b/src/extensionsIntegrated/CollapseFolders/main.js
@@ -71,35 +71,7 @@ define(function (require, exports, module) {
         `);
 
         $collapseBtn.on("click", handleCollapseBtnClick);
-
         $projectFilesHeader.append($collapseBtn); // append the btn to the project-files-header
-
-        _setupHoverBehavior($collapseBtn); // hover functionality to show/hide the button
-    }
-
-    /**
-     * This function is responsible for the hover behavior to show/hide the collapse button
-     * we only show the button when the cursor is over the sidebar area
-     */
-    function _setupHoverBehavior($collapseBtn) {
-        const $sidebar = $("#sidebar");
-        if ($sidebar.length === 0) {
-            return;
-        }
-
-        // we need this check to see if on site load the mouse is already over the sidebar area or not
-        // because if it is, then we need to show the button
-        if ($sidebar.is(":hover")) {
-            $collapseBtn.addClass("show");
-        }
-
-        $sidebar.on("mouseenter", function () {
-            $collapseBtn.addClass("show");
-        });
-
-        $sidebar.on("mouseleave", function () {
-            $collapseBtn.removeClass("show");
-        });
     }
 
     AppInit.appReady(function () {

--- a/src/extensionsIntegrated/loader.js
+++ b/src/extensionsIntegrated/loader.js
@@ -45,4 +45,5 @@ define(function (require, exports, module) {
     require("./CSSColorPreview/main");
     require("./TabBar/main");
     require("./CustomSnippets/main");
+    require("./CollapseFolders/main");
 });

--- a/src/styles/Extn-CollapseFolders.less
+++ b/src/styles/Extn-CollapseFolders.less
@@ -3,9 +3,10 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    padding: 0.2em 0.4em;
+    padding: 0.2em 0.65em;
+    margin-top: 0.1em;
     position: absolute !important;
-    right: 0.5em;
+    right: 0;
     opacity: 0;
     visibility: hidden;
     transition:

--- a/src/styles/Extn-CollapseFolders.less
+++ b/src/styles/Extn-CollapseFolders.less
@@ -17,9 +17,9 @@
         font-size: 0.5em;
         line-height: 1;
     }
+}
 
-    &.show {
-        opacity: 1;
-        visibility: visible;
-    }
+#sidebar:hover #collapse-folders {
+    opacity: 1;
+    visibility: visible;
 }

--- a/src/styles/Extn-CollapseFolders.less
+++ b/src/styles/Extn-CollapseFolders.less
@@ -1,0 +1,24 @@
+#collapse-folders {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 0.2em 0.4em;
+    position: absolute !important;
+    right: 0.5em;
+    opacity: 0;
+    visibility: hidden;
+    transition:
+        opacity 0.2s ease-in-out,
+        visibility 0.2s ease-in-out;
+
+    .collapse-icon {
+        font-size: 0.5em;
+        line-height: 1;
+    }
+
+    &.show {
+        opacity: 1;
+        visibility: visible;
+    }
+}

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -45,6 +45,7 @@
 @import "Extn-DisplayShortcuts.less";
 @import "Extn-CSSColorPreview.less";
 @import "Extn-CustomSnippets.less";
+@import "Extn-CollapseFolders.less";
 @import "UserProfile.less";
 
 /* Overall layout */

--- a/test/UnitTestSuite.js
+++ b/test/UnitTestSuite.js
@@ -128,6 +128,7 @@ define(function (require, exports, module) {
     require("spec/Extn-JSHint-integ-test");
     require("spec/Extn-ESLint-integ-test");
     require("spec/Extn-CSSColorPreview-integ-test");
+    require("spec/Extn-CollapseFolders-integ-test");
     // extension integration tests
     require("spec/Extn-CSSCodeHints-integ-test");
     require("spec/Extn-HTMLCodeHints-Lint-integ-test");

--- a/test/spec/Extn-CollapseFolders-integ-test.js
+++ b/test/spec/Extn-CollapseFolders-integ-test.js
@@ -1,0 +1,334 @@
+/*
+ * GNU AGPL-3.0 License
+ *
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
+ *
+ */
+
+/*global describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, awaitsFor, awaitsForDone */
+
+define(function (require, exports, module) {
+    const SpecRunnerUtils = require("spec/SpecRunnerUtils");
+
+    const testPath = SpecRunnerUtils.getTestPath("/spec/ProjectManager-test-files");
+
+    let ProjectManager, // loaded from brackets.test
+        CommandManager, // loaded from brackets.test
+        testWindow,
+        brackets,
+        $;
+
+    describe("integration:CollapseFolders", function () {
+        beforeAll(async function () {
+            testWindow = await SpecRunnerUtils.createTestWindowAndRun();
+            brackets = testWindow.brackets;
+            ProjectManager = brackets.test.ProjectManager;
+            CommandManager = brackets.test.CommandManager;
+            $ = testWindow.$;
+
+            await SpecRunnerUtils.loadProjectInTestWindow(testPath);
+        }, 30000);
+
+        afterAll(async function () {
+            ProjectManager = null;
+            CommandManager = null;
+            testWindow = null;
+            brackets = null;
+            $ = null;
+            await SpecRunnerUtils.closeTestWindow();
+        }, 30000);
+
+        afterEach(async function () {
+            await testWindow.closeAllFiles();
+        });
+
+        it("Should create collapse button in project files header", function () {
+            const $projectFilesHeader = $("#project-files-header");
+            const $collapseBtn = $("#collapse-folders");
+
+            expect($projectFilesHeader.length).toBe(1);
+            expect($collapseBtn.length).toBe(1);
+            expect($collapseBtn.parent()[0]).toBe($projectFilesHeader[0]);
+        });
+
+        it("Should have correct button structure and classes", function () {
+            const $collapseBtn = $("#collapse-folders");
+            const $icons = $collapseBtn.find("i.collapse-icon");
+
+            expect($collapseBtn.hasClass("btn-alt-quiet")).toBe(true);
+            expect($collapseBtn.attr("title")).toBe("Collapse All");
+            expect($icons.length).toBe(2);
+            expect($icons.eq(0).hasClass("fa-solid")).toBe(true);
+            expect($icons.eq(0).hasClass("fa-chevron-down")).toBe(true);
+            expect($icons.eq(1).hasClass("fa-solid")).toBe(true);
+            expect($icons.eq(1).hasClass("fa-chevron-up")).toBe(true);
+        });
+
+        it("Should show button on sidebar hover", async function () {
+            const $sidebar = $("#sidebar");
+            const $collapseBtn = $("#collapse-folders");
+
+            // Initially button should not have show class
+            expect($collapseBtn.hasClass("show")).toBe(false);
+
+            // Trigger mouseenter on sidebar
+            $sidebar.trigger("mouseenter");
+
+            await awaitsFor(
+                function () {
+                    return $collapseBtn.hasClass("show");
+                },
+                "Button should show on sidebar hover",
+                1000
+            );
+
+            expect($collapseBtn.hasClass("show")).toBe(true);
+        });
+
+        it("Should hide button on sidebar mouse leave", async function () {
+            const $sidebar = $("#sidebar");
+            const $collapseBtn = $("#collapse-folders");
+
+            // First show the button
+            $sidebar.trigger("mouseenter");
+            await awaitsFor(
+                function () {
+                    return $collapseBtn.hasClass("show");
+                },
+                "Button should show first",
+                1000
+            );
+
+            // Then trigger mouseleave
+            $sidebar.trigger("mouseleave");
+
+            await awaitsFor(
+                function () {
+                    return !$collapseBtn.hasClass("show");
+                },
+                "Button should hide on sidebar mouse leave",
+                1000
+            );
+
+            expect($collapseBtn.hasClass("show")).toBe(false);
+        });
+
+        it("Should have click handler attached", function () {
+            const $collapseBtn = $("#collapse-folders");
+            const events = $._data($collapseBtn[0], "events");
+
+            expect(events).toBeTruthy();
+            expect(events.click).toBeTruthy();
+            expect(events.click.length).toBe(1);
+        });
+
+        function findTreeNode(fullPath) {
+            const $treeItems = testWindow.$("#project-files-container li");
+            let $result;
+
+            const name = fullPath.split("/").pop();
+
+            $treeItems.each(function () {
+                const $treeNode = testWindow.$(this);
+                if ($treeNode.children("a").text().trim() === name) {
+                    $result = $treeNode;
+                    return false; // break the loop
+                }
+            });
+            return $result;
+        }
+
+        async function openFolder(folderPath) {
+            const $treeNode = findTreeNode(folderPath);
+            expect($treeNode).toBeTruthy();
+
+            if (!$treeNode.hasClass("jstree-open")) {
+                $treeNode.children("a").children("span").click();
+
+                await awaitsFor(
+                    function () {
+                        return $treeNode.hasClass("jstree-open");
+                    },
+                    `Open folder ${folderPath}`,
+                    2000
+                );
+            }
+        }
+
+        function isFolderOpen(folderPath) {
+            const $treeNode = findTreeNode(folderPath);
+            return $treeNode && $treeNode.hasClass("jstree-open");
+        }
+
+        function getOpenFolders() {
+            const openFolders = [];
+            testWindow.$("#project-files-container li.jstree-open").each(function () {
+                const $node = testWindow.$(this);
+                const folderName = $node.children("a").text().trim();
+                if (folderName) {
+                    openFolders.push(folderName);
+                }
+            });
+            return openFolders;
+        }
+
+        it("Should collapse all open directories when clicked", async function () {
+            // First, open some directories
+            const directoryPath = testPath + "/directory";
+
+            await openFolder("directory");
+
+            // Verify the directory is open
+            expect(isFolderOpen("directory")).toBe(true);
+
+            // Show the collapse button by hovering over sidebar
+            const $sidebar = $("#sidebar");
+            const $collapseBtn = $("#collapse-folders");
+            $sidebar.trigger("mouseenter");
+
+            await awaitsFor(
+                function () {
+                    return $collapseBtn.hasClass("show");
+                },
+                "Button should show",
+                1000
+            );
+
+            // Click the collapse button
+            $collapseBtn.trigger("click");
+
+            // Wait for directories to close
+            await awaitsFor(
+                function () {
+                    return !isFolderOpen("directory");
+                },
+                "Directory should be closed after clicking collapse button",
+                2000
+            );
+
+            // Verify the directory is now closed
+            expect(isFolderOpen("directory")).toBe(false);
+        });
+
+        it("Should collapse multiple open directories when clicked", async function () {
+            // Open multiple directories if they exist
+            await openFolder("directory");
+
+            // Verify directories are open
+            expect(isFolderOpen("directory")).toBe(true);
+
+            const initialOpenFolders = getOpenFolders();
+            expect(initialOpenFolders.length).toBeGreaterThan(0);
+
+            // Show the collapse button and click it
+            const $sidebar = $("#sidebar");
+            const $collapseBtn = $("#collapse-folders");
+            $sidebar.trigger("mouseenter");
+
+            await awaitsFor(
+                function () {
+                    return $collapseBtn.hasClass("show");
+                },
+                "Button should show",
+                1000
+            );
+
+            $collapseBtn.trigger("click");
+
+            // Wait for all directories to close
+            await awaitsFor(
+                function () {
+                    return getOpenFolders().length === 0;
+                },
+                "All directories should be closed",
+                2000
+            );
+
+            // Verify no directories are open
+            expect(getOpenFolders().length).toBe(0);
+        });
+
+        it("Should handle click when no directories are open", function () {
+            // Ensure no directories are open initially
+            const openFolders = getOpenFolders();
+            expect(openFolders.length).toBe(0);
+
+            // Show the collapse button and click it
+            const $sidebar = $("#sidebar");
+            const $collapseBtn = $("#collapse-folders");
+            $sidebar.trigger("mouseenter");
+
+            // This should not throw an error
+            expect(function () {
+                $collapseBtn.trigger("click");
+            }).not.toThrow();
+
+            // Should still have no open folders
+            expect(getOpenFolders().length).toBe(0);
+        });
+
+        it("Should work with nested directories", async function () {
+            // Open a parent directory first
+            await openFolder("directory");
+            expect(isFolderOpen("directory")).toBe(true);
+
+            // If there are subdirectories, try to open one
+            // Note: This test assumes the test project has nested directories
+            const $subdirs = testWindow.$("#project-files-container li.jstree-open li.jstree-closed");
+            if ($subdirs.length > 0) {
+                // Open a subdirectory if one exists
+                $subdirs.first().children("a").children("span").click();
+
+                await awaitsFor(
+                    function () {
+                        return $subdirs.first().hasClass("jstree-open");
+                    },
+                    "Open subdirectory",
+                    2000
+                );
+            }
+
+            const initialOpenCount = getOpenFolders().length;
+            expect(initialOpenCount).toBeGreaterThan(0);
+
+            // Show the collapse button and click it
+            const $sidebar = $("#sidebar");
+            const $collapseBtn = $("#collapse-folders");
+            $sidebar.trigger("mouseenter");
+
+            await awaitsFor(
+                function () {
+                    return $collapseBtn.hasClass("show");
+                },
+                "Button should show",
+                1000
+            );
+
+            $collapseBtn.trigger("click");
+
+            // Wait for all directories to close (including nested ones)
+            await awaitsFor(
+                function () {
+                    return getOpenFolders().length === 0;
+                },
+                "All nested directories should be closed",
+                2000
+            );
+
+            expect(getOpenFolders().length).toBe(0);
+        });
+    });
+});


### PR DESCRIPTION
This PR adds a 'Collapse' button in the sidebar area, specifically 'project-files-header' section.
this button when clicked closes all the opened folders recursively. it is really useful to keep things organized.
Now, to keep the UI simpler, we hide the button by default and only show it when the sidebar area is hovered. 

Issue reference: https://github.com/phcode-dev/phoenix/issues/2126

**Visual Reference**
https://github.com/user-attachments/assets/968a871d-9a17-4d85-838f-81b850b775b4

