### PR TITLE
fix: tab icon colors in light theme

### DIFF
--- a/src/styles/Extn-TabBar.less
+++ b/src/styles/Extn-TabBar.less
@@ -23,6 +23,13 @@
     transition: height 0.3s ease;
     scroll-behavior: auto;
     background-color: #f5f5f5;
+
+    .bd-icon {
+        color: #666;
+        .dark & {
+            color: unset;
+        }
+    }
 }
 
 .dark .phoenix-tab-bar {
@@ -341,6 +348,12 @@
     align-items: center;
     cursor: pointer;
     justify-content: space-between;
+    .bd-icon {
+        color: #666;
+        .dark &, .selected & {
+            color: unset;
+        }
+    }
 }
 
 .dropdown-tab-item:hover {


### PR DESCRIPTION
## With this change in light theme:
<img width="956" height="227" alt="image" src="https://github.com/user-attachments/assets/cbaa1907-cd3a-4918-81f6-c320e3912ecc" />

## Before this change in light theme:
<img width="956" height="227" alt="image" src="https://github.com/user-attachments/assets/80bd8c83-e87e-46f2-b7cc-12a6b7d7b7f9" />


## With this change in dark theme:
<img width="956" height="227" alt="image" src="https://github.com/user-attachments/assets/4e2e70b4-1ee0-43b1-9f72-c3be251ce4df" />

## Before this change in dark theme:
<img width="956" height="227" alt="image" src="https://github.com/user-attachments/assets/9e2b9c81-294f-4b7f-a764-d2be22daa12f" />
