### PR TITLE
Git panel not getting updated when phoenix gains focus

### DIFF
--- a/src/extensions/default/Git/src/git/GitCli.js
+++ b/src/extensions/default/Git/src/git/GitCli.js
@@ -797,6 +797,8 @@ define(function (require, exports) {
         });
     }
 
+    // this function right now is not being used anywhere,
+    // but leaving it here (we might need it in the future)
     function hasStatusChanged() {
         const prevStatus = lastGitStatusResults;
         return status().then(function (currentStatus) {


### PR DESCRIPTION
This PR fixes the issue of git panel not getting updated properly when changes were made from external sources.

**Before**
Earlier, we had a 5seconds of focus switch dedupe time. The problem with this was that if user switch from the external source to Phoenix very quickly (maybe right after executing the command) then we were not refreshing the Git as it had a timer. Secondly, the hasStatusChanged only tracked for commit changes, and not the push/pull and other changes, that also prevented the panel to update when needed.

**After**
Now, when Phoenix gains focus, we check if the git panel is open. If its open it likely means that user performed some git changes externally, so we refresh the git panel. But if the git panel is not open, we just refresh the branch. This approach makes sure that we don't call the expensive REFRESH_ALL all the time when unintended. We call it only when its very likely that it should be updated.