### PR TITLE
When save operation is performed on a placeholder tab, we add that tab to the working set

### DIFF
--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -737,12 +737,12 @@ define(function (require, exports, module) {
                 logger.leaveTrail("UI Menu Click: " + menuItem._command.getID());
                 MainViewManager.focusActivePane();
                 if (menuItem._command._options.eventSource) {
-                    menuItem._command.execute({
+                    CommandManager.execute(menuItem._command.getID(), {
                         eventSource: CommandManager.SOURCE_UI_MENU_CLICK,
                         sourceType: self.id
                     });
                 } else {
-                    menuItem._command.execute();
+                    CommandManager.execute(menuItem._command.getID());
                 }
             });
 


### PR DESCRIPTION
 This PR ensures that when the save operation is performed we add the placeholder tab to the working set. This is the most intuitive UX as most mainline editors has this UX.

  Note: When working on it, noticed that beforeExecuteCommand is not listening for any commands that is done through the UI. I mean that if the save/save all or any other similar operation is performed using the keyboard shortcut then it listened for those commands but when those operations are performed using the UI (File menu > Save) or anything similar, then beforeExecuteCommand was not listening to the commands.

  Root cause: Found that the issue was because menu clicks were calling Command.prototype.execute() directly instead of using CommandManager.execute(). This was bypassing the command event system.

  Fix: Changed the menu click handler in Menus.js to use CommandManager.execute() so that all commands (keyboard shortcuts AND menu clicks) go through the same path and trigger beforeExecuteCommand properly.

  This PR doesn't break any existing functionality - just makes the command execution consistent.