### PR TITLE
fix: git history viewer close button overlaps tab bar

### DIFF
--- a/src/extensions/default/Git/styles/git-styles.less
+++ b/src/extensions/default/Git/styles/git-styles.less
@@ -455,10 +455,8 @@
 
 #history-viewer {
     position: absolute;
-    top: 0px;
-    right: 0px;
-    bottom: 0px;
-    left: 0px;
+    inset: 0;
+    z-index: 2;
     overflow: hidden;
     background: @bc-panel-bg;
     .flex-box(column);


### PR DESCRIPTION
**BEFORE** - tab bar overlapping history viewer
<img width="1492" height="649" alt="Screenshot 2025-10-26 173357" src="https://github.com/user-attachments/assets/5d4ac3d2-6ebe-47cf-a505-3c8ad5e3360a" />

**AFTER** - history viewer has a higher z-index that tab bar
<img width="1496" height="866" alt="Screenshot 2025-10-26 173613" src="https://github.com/user-attachments/assets/2bfa8223-ac6a-4637-ad77-d58fb1801a37" />


