### PR TITLE
fix: sometimes the html live doc goes into an inconsistant state

### DIFF
--- a/src/LiveDevelopment/Servers/BaseServer.js
+++ b/src/LiveDevelopment/Servers/BaseServer.js
@@ -146,9 +146,9 @@ define(function (require, exports, module) {
             return;
         }
 
-        var key = this._liveDocuments[this._documentKey(liveDocument.doc.file.fullPath)];
+        const key = this._documentKey(liveDocument.doc.file.fullPath);
 
-        if (key) {
+        if (this._liveDocuments[key]) {
             delete this._liveDocuments[key];
         }
     };


### PR DESCRIPTION
1. Fixed BaseServer.remove() Bug (BaseServer.js:149)

Before: Used lookup result as key for deletion
After: Correctly uses the key string returned by _documentKey()

This fix ensures LiveHTMLDocuments are actually removed from the cache when
 closed, preventing memory leaks and stale references.

2. Fixed _markText() Function (HTMLInstrumentation.js:823-847) ✩ PRIMARY FIX

Key change: Now detects when an editor has no marks and allows marking even when fullBuild = false

The logic now:
- Checks if the editor has any existing tagID marks
- Allows marking if: DOM is a full build OR editor has no marks
- Still refuses to re-mark if editor already has marks and DOM is stale (preserves safety)

This solves the core issue where switching editor panes or reopening documents would
 leave the new editor without marks.

3. Added Defensive Fallback (HTMLInstrumentation.js:758-769)

Added a safety net that:
- Detects when markCache is empty but DOM has nodes
- Automatically forces re-marking if this happens
- Logs a warning so we know it triggered

How This Fixes the Issue

The error "couldn't find existing mark for tagID" occurred because:
1. Document edited -> cache has fullBuild = false
2. User switches panes -> new editor has NO marks
3. Old _markText() refused to mark the new editor
4. generateInstrumentedHTML() tried to use non-existent marks -> ERROR

Now:
- _markText() detects the editor has no marks and marks it anyway (even with fullBuild = false)
- If marks are somehow still missing, the defensive fallback catches it
- BaseServer properly cleans up old documents
