### PR TITLE
fix: 2 popped out live previews not syncing click selection

### DIFF
--- a/src/LiveDevelopment/MultiBrowserImpl/protocol/LiveDevProtocol.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/protocol/LiveDevProtocol.js
@@ -357,6 +357,7 @@ define(function (require, exports, module) {
                 console.error("error in tag selection", e);
             }
             editMode && liveDoc && liveDoc.disableHighlightOnCursorActivity(false);
+            liveDoc && liveDoc.updateHighlight();
         } else {
             // enrich received message with clientId
             msg.clientId = clientId;


### PR DESCRIPTION
## 2 live previews not syncing selection
Have two live previews, click on an element and see that the element doesn't update in the other.
This happened as we blocked sending highlight messages back to live preview on cursor position change if the selection was initiated from live preview in https://github.com/phcode-dev/phoenix/pull/2566