### PR TITLE
Git getting refreshed everytime when live preview is clicked

### DIFF
--- a/src/extensions/default/Git/src/Main.js
+++ b/src/extensions/default/Git/src/Main.js
@@ -411,7 +411,30 @@ define(function (require, exports) {
     let scheduledRefresh = null;
     const REFRESH_DEDUPE_TIME = 3000;
 
+    // this variable tracks if user clicked on the live preview iframe
+    // this is done cause when live preview iframe is clicked in highlight/edit mode,
+    // we set cursor back to the editor because of which editor regains focus and refreshes git
+    let focusWentToLivePreview = false;
+
+    // when editor window loses focus we check if focus went to live preview,
+    // if it did, then we just set the flag to true
+    $(window).on("blur", function () {
+        // delay to let activeElement update
+        setTimeout(function () {
+            const activeEl = document.activeElement;
+            if (activeEl && activeEl.id === "panel-live-preview-frame") {
+                focusWentToLivePreview = true;
+            }
+        }, 0);
+    });
+
     function refreshOnFocusChange() {
+        // ignore git refresh if focus went to live preview
+        if (focusWentToLivePreview) {
+            focusWentToLivePreview = false;
+            return;
+        }
+
         // to sync external git changes after switching to app.
         if (gitEnabled) {
             const isGitPanelVisible = Panel.getPanel().is(":visible");


### PR DESCRIPTION
When user clicks on the live preview iframe in highlight/edit mode, the window loses focus to the iframe. Later when user clicks back on the editor, window.focus fires and this does a git refresh (a full git refresh when git panel is visible)
this was a huge performance drawback....

now, we maintain a focusWentToLivePreview variable using which before refreshing git we check if the focus was taken by live preview, if its true then we ignore the git refresh....