### PR TITLE
fix: live preview related document handling and editor event leak threshold

### DIFF
--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -775,7 +775,7 @@ define(function (require, exports, module) {
 
     // Set up event dispatching
     EventDispatcher.makeEventDispatcher(exports);
-    EventDispatcher.setLeakThresholdForEvent(EVENT_ACTIVE_EDITOR_CHANGED, 30);
+    EventDispatcher.setLeakThresholdForEvent(EVENT_ACTIVE_EDITOR_CHANGED, 50);
 
     // File-based preferences handling
     exports.on(EVENT_ACTIVE_EDITOR_CHANGED, function (e, current) {


### PR DESCRIPTION
Fix null liveDoc access when a related document is not found, guard against duplicate StylesheetAdded race, use consistent url key, and raise active-editor-changed leak threshold to 50.

