### PR TITLE
refactor: purify AISnapshotStore as data-only layer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,3 +12,15 @@
 - Always use curly braces for `if`/`else`/`for`/`while`.
 - No trailing whitespace.
 - Use `const` and `let` instead of `var`.
+
+## Phoenix MCP (Desktop App Testing)
+
+Use `exec_js` to run JS in the Phoenix browser runtime. jQuery `$()` is global. `brackets.test.*` exposes internal modules (DocumentManager, CommandManager, ProjectManager, FileSystem, EditorManager). Always `return` a value from `exec_js` to see results. Prefer reusing an already-running Phoenix instance (`get_phoenix_status`) over launching a new one.
+
+**Open AI sidebar tab:** `document.querySelectorAll('span').forEach(s => { if (s.textContent.trim() === 'AI' && s.childNodes.length === 1) s.parentElement.click(); });`
+
+**Send AI chat message:** `$('.ai-chat-textarea').val('prompt'); $('.ai-chat-textarea').trigger('input'); $('.ai-send-btn').click();`
+
+**Click AI chat buttons:** `$('.ai-edit-restore-btn:contains("Undo")').click();`
+
+**Check logs:** `get_browser_console_logs` with `filter` regex (e.g. `"AI UI"`, `"error"`) and `tail` — includes both browser console and Node.js (PhNode) logs. Use `get_terminal_logs` for Electron process output (only available if Phoenix was launched via `start_phoenix`).


### PR DESCRIPTION
Move _undoApplied (UI button state) to AIChatPanel. Eliminate _initialSnapshotCreated (redundant with getSnapshotCount() > 0) and _lastSnapshotAfter (redundant with _snapshots[last]). Reorder createInitialSnapshot before recordFileBeforeEdit so back-fill populates _snapshots[0] directly. Add Phoenix MCP usage hints to CLAUDE.md.
