### PR TITLE
fix: blank gap below status bar when plugin side panel opens in browser

### DIFF
--- a/src/view/WorkspaceManager.js
+++ b/src/view/WorkspaceManager.js
@@ -457,6 +457,24 @@ define(function (require, exports, module) {
         // listen for resize here.
         listenToResize($("#sidebar"));
         listenToResize($("#main-toolbar"));
+
+        // In the browser, the #titlebar contains the menubar and filename which can wrap to
+        // multiple lines when the .content area narrows (e.g. when a plugin side panel opens).
+        // The wrapping causes a transient height change that settles asynchronously after JS
+        // recalculates the title-wrapper width. A ResizeObserver catches the settled height
+        // and triggers a layout recomputation so the editor fills the correct space.
+        let _titlebarHeight = $("#titlebar").outerHeight();
+        const titlebarEl = document.getElementById("titlebar");
+        if (titlebarEl) {
+            const titlebarObserver = new ResizeObserver(function () {
+                let newHeight = $("#titlebar").outerHeight();
+                if (newHeight !== _titlebarHeight) {
+                    _titlebarHeight = newHeight;
+                    triggerUpdateLayout();
+                }
+            });
+            titlebarObserver.observe(titlebarEl);
+        }
     });
 
     /**


### PR DESCRIPTION
When a plugin side panel (e.g. live preview) opens, the content area narrows, causing the titlebar menubar items to wrap to multiple lines. This transiently inflates the titlebar height (~35px → ~92px), and multiple synchronous layout calculations run during this state, sizing the editor too small. After the titlebar settles (~58px), a ~34px blank gap remains below the status bar.

Add a ResizeObserver on the titlebar that detects height changes and triggers a layout recomputation, correcting the editor size after the titlebar wrapping settles.
