### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/src-node/www/phoenix-splash/error.html
+++ b/src-node/www/phoenix-splash/error.html
@@ -8,10 +8,10 @@
                 const urlSearchParams = new URLSearchParams(window.location.search);
                 const params = Object.fromEntries(urlSearchParams.entries());
                 if(params.mainHeading){
-                    document.getElementById("mainHeading").innerHTML = decodeURIComponent(params.mainHeading);
+                    document.getElementById("mainHeading").textContent = decodeURIComponent(params.mainHeading);
                 }
                 if(params.mainSpan){
-                    document.getElementById("mainSpan").innerHTML = decodeURIComponent(params.mainSpan);
+                    document.getElementById("mainSpan").textContent = decodeURIComponent(params.mainSpan);
                 }
             }
         </script>

--- a/src/assets/phoenix-splash/live-preview-error.html
+++ b/src/assets/phoenix-splash/live-preview-error.html
@@ -9,10 +9,10 @@
                 const urlSearchParams = new URLSearchParams(window.location.search);
                 const params = Object.fromEntries(urlSearchParams.entries());
                 if(params.mainHeading){
-                    document.getElementById("mainHeading").innerHTML = decodeURIComponent(params.mainHeading);
+                    document.getElementById("mainHeading").textContent = decodeURIComponent(params.mainHeading);
                 }
                 if(params.mainSpan){
-                    document.getElementById("mainSpan").innerHTML = decodeURIComponent(params.mainSpan);
+                    document.getElementById("mainSpan").textContent = decodeURIComponent(params.mainSpan);
                 }
             }
         </script>


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `src-node/www/phoenix-splash/error.html:L11`

The page reads `mainHeading` and `mainSpan` from URL query parameters, decodes them, and assigns them directly to `innerHTML`. An attacker can craft a URL containing HTML/JS payloads that execute in the page context.

## Solution

Avoid `innerHTML` for untrusted data. Use `textContent`/`innerText` instead, or sanitize with a robust HTML sanitizer (e.g., DOMPurify) if HTML rendering is required.

## Changes

- `src-node/www/phoenix-splash/error.html` (modified)
- `src/assets/phoenix-splash/live-preview-error.html` (modified)