### PR TITLE
fix(live-preview): In design mode, we cant do some keyboard shortcuts in html edit mode

### DIFF
--- a/src/LiveDevelopment/BrowserScripts/RemoteFunctions.js
+++ b/src/LiveDevelopment/BrowserScripts/RemoteFunctions.js
@@ -1578,6 +1578,18 @@ function RemoteFunctions(config = {}) {
     // working normally.
     const _KEYS_NOT_FORWARDED = { c:1, v:1, x:1, a:1, z:1, y:1, C:1, V:1, X:1, A:1, Z:1, Y:1 };
 
+    // Forwarding only makes sense when the page runs as an embedded LP iframe
+    // inside Phoenix; if the user popped the preview out into a real browser
+    // tab, the synthetic events would go to a window with no Phoenix UI.
+    // Default false, flip to true via __PHOENIX_EMBED_INFO (per its contract:
+    // guaranteed to fire in embedded iframes, not guaranteed otherwise).
+    let _isPhoenixEmbeddedIframe = false;
+    if (window.__PHOENIX_EMBED_INFO && window.__PHOENIX_EMBED_INFO.onPhoenixEmbeddedInfoAvailable) {
+        window.__PHOENIX_EMBED_INFO.onPhoenixEmbeddedInfoAvailable(function (isEmbedded) {
+            _isPhoenixEmbeddedIframe = !!isEmbedded;
+        });
+    }
+
     function _isFunctionKey(event) {
         return event.key.length >= 2 && event.key[0] === 'F' && !isNaN(event.key.slice(1));
     }
@@ -1600,9 +1612,19 @@ function RemoteFunctions(config = {}) {
         if (config.mode === 'edit' && (event.key === 'Escape' || event.key === 'Esc')) {
             event.preventDefault();
             _handleEscapeKeyPress();
+        }
+    });
+
+    // Forwarder for design mode: runs as late as we can manage in the standard
+    // event flow — bubble phase on `window` (latest target after document),
+    // and the listener itself is registered on `load` so it goes last among
+    // same-target listeners. This gives the previewed page's own handlers the
+    // best chance to call preventDefault (which we then honor) before we
+    // forward to Phoenix.
+    function _designModeKeyForwarder(event) {
+        if (!_isPhoenixEmbeddedIframe || !config.designMode) {
             return;
         }
-        // Polite: if the previewed page handled the key, don't double-fire.
         if (event.defaultPrevented) {
             return;
         }
@@ -1614,11 +1636,12 @@ function RemoteFunctions(config = {}) {
         if (isMod && event.key && event.key.length === 1 && !_KEYS_NOT_FORWARDED[event.key]) {
             _forwardKeyEventToPhoenix(event);
         }
-    });
+    }
 
     // we need to refresh the config once the load is completed
     // this is important because messageBroker gets ready for use only when load fires
     window.addEventListener('load', function() {
+        window.addEventListener('keydown', _designModeKeyForwarder);
         MessageBroker.send({
             requestConfigRefresh: true
         });

--- a/src/LiveDevelopment/BrowserScripts/RemoteFunctions.js
+++ b/src/LiveDevelopment/BrowserScripts/RemoteFunctions.js
@@ -1573,10 +1573,46 @@ function RemoteFunctions(config = {}) {
         });
     }
 
+    // Modifier shortcuts forwarded to the Phoenix KeyBindingManager. Clipboard
+    // and undo/redo are excluded so form inputs in the previewed page keep
+    // working normally.
+    const _KEYS_NOT_FORWARDED = { c:1, v:1, x:1, a:1, z:1, y:1, C:1, V:1, X:1, A:1, Z:1, Y:1 };
+
+    function _isFunctionKey(event) {
+        return event.key.length >= 2 && event.key[0] === 'F' && !isNaN(event.key.slice(1));
+    }
+
+    function _forwardKeyEventToPhoenix(event) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        MessageBroker.send({
+            keyForward: true,
+            key: event.key,
+            code: event.code,
+            ctrlKey: event.ctrlKey,
+            metaKey: event.metaKey,
+            shiftKey: event.shiftKey,
+            altKey: event.altKey
+        });
+    }
+
     document.addEventListener('keydown', function(event) {
         if (config.mode === 'edit' && (event.key === 'Escape' || event.key === 'Esc')) {
             event.preventDefault();
             _handleEscapeKeyPress();
+            return;
+        }
+        // Polite: if the previewed page handled the key, don't double-fire.
+        if (event.defaultPrevented) {
+            return;
+        }
+        if (_isFunctionKey(event)) {
+            _forwardKeyEventToPhoenix(event);
+            return;
+        }
+        const isMod = event.metaKey || event.ctrlKey;
+        if (isMod && event.key && event.key.length === 1 && !_KEYS_NOT_FORWARDED[event.key]) {
+            _forwardKeyEventToPhoenix(event);
         }
     });
 

--- a/src/LiveDevelopment/MultiBrowserImpl/protocol/LiveDevProtocol.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/protocol/LiveDevProtocol.js
@@ -53,7 +53,8 @@ define(function (require, exports, module) {
         HTMLInstrumentation   = require("LiveDevelopment/MultiBrowserImpl/language/HTMLInstrumentation"),
         StringUtils = require("utils/StringUtils"),
         FileViewController    = require("project/FileViewController"),
-        MainViewManager     = require("view/MainViewManager");
+        MainViewManager     = require("view/MainViewManager"),
+        WorkspaceManager    = require("view/WorkspaceManager");
 
     const LIVE_DEV_REMOTE_SCRIPTS_FILE_NAME = `phoenix_live_preview_scripts_instrumented_${StringUtils.randomString(8)}.js`;
     const LIVE_DEV_REMOTE_WORKER_SCRIPTS_FILE_NAME = `pageLoaderWorker_${StringUtils.randomString(8)}.js`;
@@ -189,6 +190,9 @@ define(function (require, exports, module) {
      * @private
      */
     function _focusEditorIfNeeded(editor, tagName, contentEditable) {
+        if (WorkspaceManager.isInDesignMode()) {
+            return;
+        }
         const focusShouldBeInLivePreview = ['INPUT', 'TEXTAREA'].includes(tagName) || contentEditable;
         if(focusShouldBeInLivePreview){
             return;
@@ -247,7 +251,9 @@ define(function (require, exports, module) {
             activeEditorPath = activeEditor ? activeEditor.document.file.fullPath : null,
             activeFullEditorPath = activeFullEditor ? activeFullEditor.document.file.fullPath : null;
         if(!liveDocPath){
-            activeEditor && activeEditor.focus(); // restore focus from live preview
+            if (activeEditor && !WorkspaceManager.isInDesignMode()) {
+                activeEditor.focus(); // restore focus from live preview
+            }
             return;
         }
         const allOpenFileCount = MainViewManager.getWorkingSetSize(MainViewManager.ALL_PANES);

--- a/src/LiveDevelopment/MultiBrowserImpl/protocol/LiveDevProtocol.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/protocol/LiveDevProtocol.js
@@ -189,6 +189,26 @@ define(function (require, exports, module) {
      * set focus to editor
      * @private
      */
+    /**
+     * Re-dispatches a keyboard shortcut originating from the live preview iframe
+     * onto document.body so KeyBindingManager picks it up. Needed because key
+     * events fired inside an iframe don't bubble to the parent's document.
+     * @private
+     */
+    function _forwardKeyboardShortcutFromIframe(data) {
+        const event = new KeyboardEvent("keydown", {
+            key: data.key,
+            code: data.code,
+            ctrlKey: !!data.ctrlKey,
+            metaKey: !!data.metaKey,
+            shiftKey: !!data.shiftKey,
+            altKey: !!data.altKey,
+            bubbles: true,
+            cancelable: true
+        });
+        document.body.dispatchEvent(event);
+    }
+
     function _focusEditorIfNeeded(editor, tagName, contentEditable) {
         if (WorkspaceManager.isInDesignMode()) {
             return;
@@ -347,6 +367,8 @@ define(function (require, exports, module) {
                     pendingHandler.deferred.resolve(msg);
                 }
             }
+        } else if (msg.keyForward) {
+            _forwardKeyboardShortcutFromIframe(msg);
         } else if (msg.clicked && msg.tagId) {
             // While previewing an html file, and if css related file is active in the editor, then clicking on the
             // live preview, here we set the cursor position in the css file. but this will also trigger a css

--- a/src/LiveDevelopment/main.js
+++ b/src/LiveDevelopment/main.js
@@ -43,6 +43,7 @@ define(function main(require, exports, module) {
         Strings             = require("strings"),
         ExtensionUtils      = require("utils/ExtensionUtils"),
         StringUtils         = require("utils/StringUtils"),
+        WorkspaceManager    = require("view/WorkspaceManager"),
         EventDispatcher      = require("utils/EventDispatcher");
 
     const LIVE_PREVIEW_MODE = CONSTANTS.LIVE_PREVIEW_MODE,
@@ -260,12 +261,21 @@ define(function main(require, exports, module) {
         return getCurrentMode() === LIVE_PREVIEW_MODE;
     }
 
+    function _designModeChanged() {
+        const config = MultiBrowserLiveDev.getConfig();
+        config.designMode = WorkspaceManager.isInDesignMode();
+        MultiBrowserLiveDev.updateConfig(config);
+    }
+
     /** Initialize LiveDevelopment */
     AppInit.appReady(function () {
         params.parse();
         const config = Object.assign({}, defaultConfig, MultiBrowserLiveDev.getConfig());
         config.mode = getCurrentMode();
+        config.designMode = WorkspaceManager.isInDesignMode();
         MultiBrowserLiveDev.init(config);
+
+        WorkspaceManager.on(WorkspaceManager.EVENT_WORKSPACE_DESIGN_MODE_CHANGE, _designModeChanged);
 
         _loadStyles();
 

--- a/src/command/CommandManager.js
+++ b/src/command/CommandManager.js
@@ -158,6 +158,18 @@ define(function (require, exports, module) {
     };
 
     /**
+     * Returns true if the command opted in to running while the workspace is in
+     * design mode (editor collapsed). KeyBindingManager uses this to decide
+     * whether a keyboard shortcut should fire; commands that don't opt in are
+     * swallowed in design mode.
+     *
+     * @return {boolean}
+     */
+    Command.prototype.isSupportedInDesignMode = function () {
+        return !!(this._options && this._options.supportsDesignMode);
+    };
+
+    /**
      * Sets enabled state of Command and dispatches "enabledStateChange"
      * when the enabled state changes.
      *
@@ -250,6 +262,10 @@ define(function (require, exports, module) {
      * event.sourceType(Eg. Ctrl-K) parameter.
      * @param {string} options.htmlName If set, this will be displayed in ui menus instead of the name given.
      *      Example: `"Phoenix menu<i class='fa fa-car' style='margin-left: 4px;'></i>"`
+     * @param {boolean} options.supportsDesignMode If true, this command's keyboard shortcut will still fire when
+     *      the workspace is in design mode. Commands that don't opt in are swallowed in design mode because the
+     *      editor area is collapsed and most shortcuts are nonsensical there. Reserve this flag for commands that
+     *      remain useful with no editor visible (file open/save/close, Quick Open, Find in Files, etc.).
      *
      * @return {?Command}
      */

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -947,6 +947,19 @@ define(function (require, exports, module) {
      */
     function _handleKey(key) {
         if (_enabled && _keyMap[key]) {
+            let command = CommandManager.get(_keyMap[key].commandID);
+            // In design mode, when focus is inside the live preview iframe (the
+            // user is interacting with their previewed page), swallow shortcuts
+            // that didn't opt in via Command.isSupportedInDesignMode(). When
+            // focus is elsewhere in the Phoenix UI (e.g. AI chat textarea), let
+            // shortcuts behave normally — design mode shouldn't break Phoenix's
+            // own UI interactions.
+            const focusInIframe = document.activeElement &&
+                    document.activeElement.tagName === 'IFRAME';
+            if (Phoenix.isInDesignMode() && focusInIframe &&
+                    command && !command.isSupportedInDesignMode()) {
+                return true;
+            }
             Metrics.countEvent(Metrics.EVENT_TYPE.KEYBOARD, "shortcut", key);
             Metrics.countEvent(Metrics.EVENT_TYPE.KEYBOARD, "command", _keyMap[key].commandID);
             logger.leaveTrail("Keyboard shortcut: " + key + " command: " + _keyMap[key].commandID);
@@ -954,7 +967,6 @@ define(function (require, exports, module) {
             // we always mark the event as processed and return true.
             // We don't want multiple behavior tied to the same key event. For Instance, in browser, if `ctrl-k`
             // is not handled by quick edit, it will open browser url bar if we return false here(which is bad ux).
-            let command = CommandManager.get(_keyMap[key].commandID);
             let eventDetails = undefined;
             if(command._options.eventSource){
                 eventDetails = {

--- a/src/command/KeyboardOverlayMode.js
+++ b/src/command/KeyboardOverlayMode.js
@@ -203,7 +203,7 @@ define(function (require, exports, module) {
 
     AppInit.appReady(function () {
         CommandManager.register(Strings.CMD_KEYBOARD_NAV_OVERLAY,
-            Commands.CMD_KEYBOARD_NAV_UI_OVERLAY, startOverlayMode);
+            Commands.CMD_KEYBOARD_NAV_UI_OVERLAY, startOverlayMode, { supportsDesignMode: true });
         const viewMenu = Menus.getMenu(Menus.AppMenuBar.VIEW_MENU);
         viewMenu.addMenuItem(Commands.CMD_KEYBOARD_NAV_UI_OVERLAY, 'Ctrl-P',
             Menus.AFTER, Commands.VIEW_TOGGLE_INSPECTION);

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -2414,7 +2414,7 @@ define(function (require, exports, module) {
     CommandManager.register(Strings.CMD_FILE_OPEN,                   Commands.FILE_OPEN,                      handleDocumentOpen, _designModeOpts);
 
     // New commands
-    CommandManager.register(Strings.CMD_ADD_TO_WORKING_SET,          Commands.CMD_ADD_TO_WORKINGSET_AND_OPEN, handleFileAddToWorkingSetAndOpen);
+    CommandManager.register(Strings.CMD_ADD_TO_WORKING_SET,          Commands.CMD_ADD_TO_WORKINGSET_AND_OPEN, handleFileAddToWorkingSetAndOpen, _designModeOpts);
     CommandManager.register(Strings.CMD_FILE_OPEN,                   Commands.CMD_OPEN,                       handleFileOpen, _designModeOpts);
 
     // File Commands
@@ -2423,33 +2423,33 @@ define(function (require, exports, module) {
     CommandManager.register(Strings.CMD_FILE_NEW_FOLDER,             Commands.FILE_NEW_FOLDER,                handleNewFolderInProject);
     CommandManager.register(Strings.CMD_FILE_SAVE,                   Commands.FILE_SAVE,                      handleFileSave, _designModeOpts);
     CommandManager.register(Strings.CMD_FILE_SAVE_ALL,               Commands.FILE_SAVE_ALL,                  handleFileSaveAll, _designModeOpts);
-    CommandManager.register(Strings.CMD_FILE_SAVE_AS,                Commands.FILE_SAVE_AS,                   handleFileSaveAs);
+    CommandManager.register(Strings.CMD_FILE_SAVE_AS,                Commands.FILE_SAVE_AS,                   handleFileSaveAs, _designModeOpts);
     CommandManager.register(Strings.CMD_FILE_RENAME,                 Commands.FILE_RENAME,                    handleFileRename);
     CommandManager.register(Strings.CMD_FILE_DELETE,                 Commands.FILE_DELETE,                    handleFileDelete);
 
     // Close Commands
     CommandManager.register(Strings.CMD_FILE_CLOSE,                  Commands.FILE_CLOSE,                     handleFileClose, _designModeOpts);
     CommandManager.register(Strings.CMD_FILE_CLOSE_ALL,              Commands.FILE_CLOSE_ALL,                 handleFileCloseAll, _designModeOpts);
-    CommandManager.register(Strings.CMD_FILE_CLOSE_LIST,             Commands.FILE_CLOSE_LIST,                handleFileCloseList);
+    CommandManager.register(Strings.CMD_FILE_CLOSE_LIST,             Commands.FILE_CLOSE_LIST,                handleFileCloseList, _designModeOpts);
     CommandManager.register(Strings.CMD_REOPEN_CLOSED,               Commands.FILE_REOPEN_CLOSED,             handleReopenClosed, _designModeOpts);
 
     // Traversal
-    CommandManager.register(Strings.CMD_NEXT_DOC,                    Commands.NAVIGATE_NEXT_DOC,              handleGoNextDoc);
-    CommandManager.register(Strings.CMD_PREV_DOC,                    Commands.NAVIGATE_PREV_DOC,              handleGoPrevDoc);
+    CommandManager.register(Strings.CMD_NEXT_DOC,                    Commands.NAVIGATE_NEXT_DOC,              handleGoNextDoc, _designModeOpts);
+    CommandManager.register(Strings.CMD_PREV_DOC,                    Commands.NAVIGATE_PREV_DOC,              handleGoPrevDoc, _designModeOpts);
 
-    CommandManager.register(Strings.CMD_NEXT_DOC_LIST_ORDER,         Commands.NAVIGATE_NEXT_DOC_LIST_ORDER,   handleGoNextDocListOrder);
-    CommandManager.register(Strings.CMD_PREV_DOC_LIST_ORDER,         Commands.NAVIGATE_PREV_DOC_LIST_ORDER,   handleGoPrevDocListOrder);
+    CommandManager.register(Strings.CMD_NEXT_DOC_LIST_ORDER,         Commands.NAVIGATE_NEXT_DOC_LIST_ORDER,   handleGoNextDocListOrder, _designModeOpts);
+    CommandManager.register(Strings.CMD_PREV_DOC_LIST_ORDER,         Commands.NAVIGATE_PREV_DOC_LIST_ORDER,   handleGoPrevDocListOrder, _designModeOpts);
 
     // Special Commands
-    CommandManager.register(showInOS,                                Commands.NAVIGATE_SHOW_IN_OS,            handleShowInOS);
-    CommandManager.register(defaultTerminal,                         Commands.NAVIGATE_OPEN_IN_TERMINAL,      openDefaultTerminal);
+    CommandManager.register(showInOS,                                Commands.NAVIGATE_SHOW_IN_OS,            handleShowInOS, _designModeOpts);
+    CommandManager.register(defaultTerminal,                         Commands.NAVIGATE_OPEN_IN_TERMINAL,      openDefaultTerminal, _designModeOpts);
     if (brackets.platform === "win") {
         CommandManager.register(Strings.CMD_OPEN_IN_POWER_SHELL,     Commands.NAVIGATE_OPEN_IN_POWERSHELL,    openPowerShell);
     }
-    CommandManager.register(Strings.CMD_OPEN_IN_DEFAULT_APP,         Commands.NAVIGATE_OPEN_IN_DEFAULT_APP,   openDefaultApp);
+    CommandManager.register(Strings.CMD_OPEN_IN_DEFAULT_APP,         Commands.NAVIGATE_OPEN_IN_DEFAULT_APP,   openDefaultApp, _designModeOpts);
     CommandManager.register(Strings.CMD_NEW_BRACKETS_WINDOW,         Commands.FILE_NEW_WINDOW,                handleFileNewWindow, _designModeOpts);
-    CommandManager.register(quitString,                              Commands.FILE_QUIT,                      handleFileCloseWindow);
-    CommandManager.register(Strings.CMD_SHOW_IN_TREE,                Commands.NAVIGATE_SHOW_IN_FILE_TREE,     handleShowInTree);
+    CommandManager.register(quitString,                              Commands.FILE_QUIT,                      handleFileCloseWindow, _designModeOpts);
+    CommandManager.register(Strings.CMD_SHOW_IN_TREE,                Commands.NAVIGATE_SHOW_IN_FILE_TREE,     handleShowInTree, _designModeOpts);
 
     // These commands have no UI representation and are only used internally
     CommandManager.registerInternal(Commands.APP_ABORT_QUIT,            handleAbortQuit);

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -2405,29 +2405,33 @@ define(function (require, exports, module) {
     exports.APP_QUIT_CANCELLED = APP_QUIT_CANCELLED;
 
 
+    // Commands allowlisted to fire while in design mode (editor collapsed) so the
+    // user can still open / save / close files without leaving design mode.
+    const _designModeOpts = { supportsDesignMode: true };
+
     // Deprecated commands
     CommandManager.register(Strings.CMD_ADD_TO_WORKING_SET,          Commands.FILE_ADD_TO_WORKING_SET,        handleFileAddToWorkingSet);
-    CommandManager.register(Strings.CMD_FILE_OPEN,                   Commands.FILE_OPEN,                      handleDocumentOpen);
+    CommandManager.register(Strings.CMD_FILE_OPEN,                   Commands.FILE_OPEN,                      handleDocumentOpen, _designModeOpts);
 
     // New commands
     CommandManager.register(Strings.CMD_ADD_TO_WORKING_SET,          Commands.CMD_ADD_TO_WORKINGSET_AND_OPEN, handleFileAddToWorkingSetAndOpen);
-    CommandManager.register(Strings.CMD_FILE_OPEN,                   Commands.CMD_OPEN,                       handleFileOpen);
+    CommandManager.register(Strings.CMD_FILE_OPEN,                   Commands.CMD_OPEN,                       handleFileOpen, _designModeOpts);
 
     // File Commands
     CommandManager.register(Strings.CMD_FILE_NEW_UNTITLED,           Commands.FILE_NEW_UNTITLED,              handleFileNew);
     CommandManager.register(Strings.CMD_FILE_NEW,                    Commands.FILE_NEW,                       handleFileNewInProject);
     CommandManager.register(Strings.CMD_FILE_NEW_FOLDER,             Commands.FILE_NEW_FOLDER,                handleNewFolderInProject);
-    CommandManager.register(Strings.CMD_FILE_SAVE,                   Commands.FILE_SAVE,                      handleFileSave);
-    CommandManager.register(Strings.CMD_FILE_SAVE_ALL,               Commands.FILE_SAVE_ALL,                  handleFileSaveAll);
+    CommandManager.register(Strings.CMD_FILE_SAVE,                   Commands.FILE_SAVE,                      handleFileSave, _designModeOpts);
+    CommandManager.register(Strings.CMD_FILE_SAVE_ALL,               Commands.FILE_SAVE_ALL,                  handleFileSaveAll, _designModeOpts);
     CommandManager.register(Strings.CMD_FILE_SAVE_AS,                Commands.FILE_SAVE_AS,                   handleFileSaveAs);
     CommandManager.register(Strings.CMD_FILE_RENAME,                 Commands.FILE_RENAME,                    handleFileRename);
     CommandManager.register(Strings.CMD_FILE_DELETE,                 Commands.FILE_DELETE,                    handleFileDelete);
 
     // Close Commands
-    CommandManager.register(Strings.CMD_FILE_CLOSE,                  Commands.FILE_CLOSE,                     handleFileClose);
-    CommandManager.register(Strings.CMD_FILE_CLOSE_ALL,              Commands.FILE_CLOSE_ALL,                 handleFileCloseAll);
+    CommandManager.register(Strings.CMD_FILE_CLOSE,                  Commands.FILE_CLOSE,                     handleFileClose, _designModeOpts);
+    CommandManager.register(Strings.CMD_FILE_CLOSE_ALL,              Commands.FILE_CLOSE_ALL,                 handleFileCloseAll, _designModeOpts);
     CommandManager.register(Strings.CMD_FILE_CLOSE_LIST,             Commands.FILE_CLOSE_LIST,                handleFileCloseList);
-    CommandManager.register(Strings.CMD_REOPEN_CLOSED,               Commands.FILE_REOPEN_CLOSED,             handleReopenClosed);
+    CommandManager.register(Strings.CMD_REOPEN_CLOSED,               Commands.FILE_REOPEN_CLOSED,             handleReopenClosed, _designModeOpts);
 
     // Traversal
     CommandManager.register(Strings.CMD_NEXT_DOC,                    Commands.NAVIGATE_NEXT_DOC,              handleGoNextDoc);
@@ -2443,7 +2447,7 @@ define(function (require, exports, module) {
         CommandManager.register(Strings.CMD_OPEN_IN_POWER_SHELL,     Commands.NAVIGATE_OPEN_IN_POWERSHELL,    openPowerShell);
     }
     CommandManager.register(Strings.CMD_OPEN_IN_DEFAULT_APP,         Commands.NAVIGATE_OPEN_IN_DEFAULT_APP,   openDefaultApp);
-    CommandManager.register(Strings.CMD_NEW_BRACKETS_WINDOW,         Commands.FILE_NEW_WINDOW,                handleFileNewWindow);
+    CommandManager.register(Strings.CMD_NEW_BRACKETS_WINDOW,         Commands.FILE_NEW_WINDOW,                handleFileNewWindow, _designModeOpts);
     CommandManager.register(quitString,                              Commands.FILE_QUIT,                      handleFileCloseWindow);
     CommandManager.register(Strings.CMD_SHOW_IN_TREE,                Commands.NAVIGATE_SHOW_IN_FILE_TREE,     handleShowInTree);
 

--- a/src/extensibility/ExtensionManagerDialog.js
+++ b/src/extensibility/ExtensionManagerDialog.js
@@ -429,7 +429,7 @@ define(function (require, exports, module) {
         return new $.Deferred().resolve(dialog).promise();
     }
 
-    CommandManager.register(Strings.CMD_EXTENSION_MANAGER, Commands.FILE_EXTENSION_MANAGER, _showDialog);
+    CommandManager.register(Strings.CMD_EXTENSION_MANAGER, Commands.FILE_EXTENSION_MANAGER, _showDialog, { supportsDesignMode: true });
 
     AppInit.appReady(function () {
         $("#toolbar-extension-manager").click(_showDialog);

--- a/src/extensions/default/CloseOthers/main.js
+++ b/src/extensions/default/CloseOthers/main.js
@@ -157,13 +157,13 @@ define(function (require, exports, module) {
 
         CommandManager.register(Strings.CMD_FILE_CLOSE_BELOW, closeBelow, function () {
             handleClose(closeBelow);
-        });
+        }, { supportsDesignMode: true });
         CommandManager.register(Strings.CMD_FILE_CLOSE_OTHERS, closeOthers, function () {
             handleClose(closeOthers);
-        });
+        }, { supportsDesignMode: true });
         CommandManager.register(Strings.CMD_FILE_CLOSE_ABOVE, closeAbove, function () {
             handleClose(closeAbove);
-        });
+        }, { supportsDesignMode: true });
 
         if (prefs.closeBelow) {
             workingSetListCmenu.addMenuItem(closeBelow, "", Menus.AFTER, Commands.FILE_CLOSE);

--- a/src/extensions/default/DebugCommands/main.js
+++ b/src/extensions/default/DebugCommands/main.js
@@ -776,30 +776,30 @@ define(function (require, exports, module) {
     let loadOrReloadString = extensionDevelopment.isProjectLoadedAsExtension() ?
         Strings.CMD_RELOAD_CURRENT_EXTENSION : Strings.CMD_LOAD_CURRENT_EXTENSION;
     CommandManager.register(loadOrReloadString,     DEBUG_LOAD_CURRENT_EXTENSION,
-        extensionDevelopment.loadCurrentExtension);
+        extensionDevelopment.loadCurrentExtension, { supportsDesignMode: true });
     CommandManager.register(Strings.CMD_UNLOAD_CURRENT_EXTENSION,     DEBUG_UNLOAD_CURRENT_EXTENSION,
-        extensionDevelopment.unloadCurrentExtension);
-    CommandManager.register(Strings.CMD_REFRESH_WINDOW,             DEBUG_REFRESH_WINDOW,           handleReload);
-    CommandManager.register(Strings.CMD_RELOAD_WITHOUT_USER_EXTS,   DEBUG_RELOAD_WITHOUT_USER_EXTS, handleReloadWithoutUserExts);
+        extensionDevelopment.unloadCurrentExtension, { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_REFRESH_WINDOW,             DEBUG_REFRESH_WINDOW,           handleReload, { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_RELOAD_WITHOUT_USER_EXTS,   DEBUG_RELOAD_WITHOUT_USER_EXTS, handleReloadWithoutUserExts, { supportsDesignMode: true });
 
     // Start with the "Run Tests" item disabled. It will be enabled later if the test file can be found.
-    CommandManager.register(Strings.CMD_RUN_UNIT_TESTS,       DEBUG_RUN_UNIT_TESTS,         _runUnitTests);
+    CommandManager.register(Strings.CMD_RUN_UNIT_TESTS,       DEBUG_RUN_UNIT_TESTS,         _runUnitTests, { supportsDesignMode: true });
 
-    CommandManager.register(Strings.CMD_SHOW_PERF_DATA,            DEBUG_SHOW_PERF_DATA,            handleShowPerfData);
+    CommandManager.register(Strings.CMD_SHOW_PERF_DATA,            DEBUG_SHOW_PERF_DATA,            handleShowPerfData, { supportsDesignMode: true });
 
     let switchLanguageStr = Strings.CMD_SWITCH_LANGUAGE === "Switch Language\u2026" ?
         Strings.CMD_SWITCH_LANGUAGE :
         `${Strings.CMD_SWITCH_LANGUAGE} (Switch Language)`;
-    CommandManager.register(switchLanguageStr,           DEBUG_SWITCH_LANGUAGE,           handleSwitchLanguage);
+    CommandManager.register(switchLanguageStr,           DEBUG_SWITCH_LANGUAGE,           handleSwitchLanguage, { supportsDesignMode: true });
 
-    CommandManager.register(Strings.CMD_ENABLE_LOGGING, DEBUG_ENABLE_LOGGING,   _handleLogging);
-    CommandManager.register(Strings.CMD_ENABLE_PHNODE_INSPECTOR, DEBUG_ENABLE_PHNODE_INSPECTOR, _handlePhNodeInspectEnable);
-    CommandManager.register(Strings.CMD_GET_PHNODE_INSPECTOR_URL, DEBUG_GET_PHNODE_INSPECTOR_URL, _handleGetPhNodeInspectURL);
-    CommandManager.register(Strings.CMD_ENABLE_LIVE_PREVIEW_LOGS, DEBUG_LIVE_PREVIEW_LOGGING, _handleLivePreviewLogging);
-    CommandManager.register(Strings.CMD_ENABLE_GIT_LOGS, DEBUG_GIT_EXTENSION_LOGGING, _handleGitLogging);
-    CommandManager.register(Strings.CMD_OPEN_VFS, DEBUG_OPEN_VFS,   _openVFS);
-    CommandManager.register(Strings.CMD_OPEN_EXTENSIONS_FOLDER, DEBUG_OPEN_EXTENSION_FOLDER,   _openExtensionsFolder);
-    CommandManager.register(Strings.CMD_OPEN_VIRTUAL_SERVER, DEBUG_OPEN_VIRTUAL_SERVER,   _openVirtualServer);
+    CommandManager.register(Strings.CMD_ENABLE_LOGGING, DEBUG_ENABLE_LOGGING,   _handleLogging, { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_ENABLE_PHNODE_INSPECTOR, DEBUG_ENABLE_PHNODE_INSPECTOR, _handlePhNodeInspectEnable, { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_GET_PHNODE_INSPECTOR_URL, DEBUG_GET_PHNODE_INSPECTOR_URL, _handleGetPhNodeInspectURL, { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_ENABLE_LIVE_PREVIEW_LOGS, DEBUG_LIVE_PREVIEW_LOGGING, _handleLivePreviewLogging, { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_ENABLE_GIT_LOGS, DEBUG_GIT_EXTENSION_LOGGING, _handleGitLogging, { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_OPEN_VFS, DEBUG_OPEN_VFS,   _openVFS, { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_OPEN_EXTENSIONS_FOLDER, DEBUG_OPEN_EXTENSION_FOLDER,   _openExtensionsFolder, { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_OPEN_VIRTUAL_SERVER, DEBUG_OPEN_VIRTUAL_SERVER,   _openVirtualServer, { supportsDesignMode: true });
 
     CommandManager.register(Strings.CMD_OPEN_PREFERENCES, DEBUG_OPEN_PREFERENCES_IN_SPLIT_VIEW, handleOpenPrefsInSplitView);
     const debugMenu = Menus.getMenu(Menus.AppMenuBar.DEBUG_MENU);
@@ -815,7 +815,7 @@ define(function (require, exports, module) {
     debugMenu.addMenuDivider();
     // Show Developer Tools (optionally enabled)
     if(Phoenix.isNativeApp){
-        CommandManager.register(Strings.CMD_SHOW_DEV_TOOLS, DEBUG_SHOW_DEVELOPER_TOOLS, _handleShowDeveloperTools);
+        CommandManager.register(Strings.CMD_SHOW_DEV_TOOLS, DEBUG_SHOW_DEVELOPER_TOOLS, _handleShowDeveloperTools, { supportsDesignMode: true });
         debugMenu.addMenuItem(DEBUG_SHOW_DEVELOPER_TOOLS, KeyboardPrefs.showDeveloperTools);
     }
     // this command is defined in core, but exposed only in Debug menu for now
@@ -826,7 +826,7 @@ define(function (require, exports, module) {
     }
     const diagnosticsSubmenu = debugMenu.addSubMenu(Strings.CMD_DIAGNOSTIC_TOOLS, DIAGNOSTICS_SUBMENU);
     diagnosticsSubmenu.addMenuItem(DEBUG_RUN_UNIT_TESTS);
-    CommandManager.register(Strings.CMD_BUILD_TESTS, DEBUG_BUILD_TESTS, TestBuilder.toggleTestBuilder);
+    CommandManager.register(Strings.CMD_BUILD_TESTS, DEBUG_BUILD_TESTS, TestBuilder.toggleTestBuilder, { supportsDesignMode: true });
     diagnosticsSubmenu.addMenuItem(DEBUG_BUILD_TESTS);
     if (AppConfig.config.environment === "dev") {
         diagnosticsSubmenu.addMenuItem("debug.phoenixBuilderConnect");

--- a/src/extensions/default/Git/src/CloseNotModified.js
+++ b/src/extensions/default/Git/src/CloseNotModified.js
@@ -48,7 +48,7 @@ define(function (require, exports) {
 
     function init() {
         closeUnmodifiedCmd       = CommandManager.register(Strings.CMD_CLOSE_UNMODIFIED,
-            Constants.CMD_GIT_CLOSE_UNMODIFIED, handleCloseNotModified);
+            Constants.CMD_GIT_CLOSE_UNMODIFIED, handleCloseNotModified, { supportsDesignMode: true });
         Utils.enableCommand(Constants.CMD_GIT_CLOSE_UNMODIFIED, false);
     }
 

--- a/src/extensions/default/HealthData/main.js
+++ b/src/extensions/default/HealthData/main.js
@@ -43,7 +43,7 @@ define(function (require, exports, module) {
 
     // Register the command and add the menu item for the Health Data Statistics
     function addCommand() {
-        CommandManager.register(Strings.CMD_HEALTH_DATA_STATISTICS, healthDataCmdId, handleHealthDataStatistics);
+        CommandManager.register(Strings.CMD_HEALTH_DATA_STATISTICS, healthDataCmdId, handleHealthDataStatistics, { supportsDesignMode: true });
 
         menu.addMenuItem(healthDataCmdId, "", Menus.AFTER, Commands.HELP_GET_INVOLVED);
         menu.addMenuDivider(Menus.AFTER, Commands.HELP_GET_INVOLVED);

--- a/src/extensions/default/Phoenix-extension-store/main.js
+++ b/src/extensions/default/Phoenix-extension-store/main.js
@@ -86,7 +86,7 @@ define(function (require, exports, module) {
 
     ExtensionUtils.loadStyleSheet(module, "extension-store.css");
     // todo: replace with extension manager dialogue command
-    toggleCmd = CommandManager.register("Extensions Panel", "toggleExtensionsPanel", _toggleVisibility);
+    toggleCmd = CommandManager.register("Extensions Panel", "toggleExtensionsPanel", _toggleVisibility, { supportsDesignMode: true });
 
     function _createExtensionPanel() {
         $icon = $("#toolbar-extension-manager");

--- a/src/extensionsIntegrated/DisplayShortcuts/main.js
+++ b/src/extensionsIntegrated/DisplayShortcuts/main.js
@@ -24,7 +24,7 @@
 /*global define, brackets, $, CodeMirror, _showShortcuts, window */
 
 define(function (require, exports, module) {
-    
+
     // Brackets modules
     const _                   = require("thirdparty/lodash"),
         CodeMirror          = require("thirdparty/CodeMirror/lib/codemirror"),
@@ -111,7 +111,7 @@ define(function (require, exports, module) {
     function _getOriginFromCommandId(cmdID, keyBinding) {
         // According to CommandManager.register() documentation:
         //  Core commands in Brackets use a simple command title as an id, for example "open.file".
-        //  Extensions should use the following format: "author.myextension.mycommandname". 
+        //  Extensions should use the following format: "author.myextension.mycommandname".
         //  For example, "lschmitt.csswizard.format.css".
         const customOrigin = KeyBindingManager._getCustomShortcutOrigin(keyBinding);
         if(customOrigin){
@@ -303,7 +303,7 @@ define(function (require, exports, module) {
             // New sort column
             sortColumn = newSortColumn;
         }
-        
+
         // Update page
         _showShortcuts();
     }
@@ -341,7 +341,7 @@ define(function (require, exports, module) {
     function _showShortcuts() {
         _updatePresets();
         let $shortcuts = $("#shortcuts-panel");
-        
+
         // Apply any active filter
         _filterShortcuts(true);
 
@@ -465,7 +465,7 @@ define(function (require, exports, module) {
         let s, file_menu;
 
         // Register commands
-        CommandManager.register(Strings.KEYBOARD_SHORTCUT_MENU_SHOW_SHORTCUTS, TOGGLE_SHORTCUTS_ID, _handleShowHideShortcuts);
+        CommandManager.register(Strings.KEYBOARD_SHORTCUT_MENU_SHOW_SHORTCUTS, TOGGLE_SHORTCUTS_ID, _handleShowHideShortcuts, { supportsDesignMode: true });
 
         // Add command to Help menu, if it exists
         file_menu = Menus.getMenu(Menus.AppMenuBar.FILE_MENU);

--- a/src/extensionsIntegrated/NavigationAndHistory/NavigationProvider.js
+++ b/src/extensionsIntegrated/NavigationAndHistory/NavigationProvider.js
@@ -538,8 +538,8 @@ define(function (require, exports, module) {
     * @private
     */
     function _initNavigationCommands() {
-        CommandManager.register(Strings.CMD_NAVIGATE_BACKWARD, NAVIGATION_JUMP_BACK, _navigateBack);
-        CommandManager.register(Strings.CMD_NAVIGATE_FORWARD, NAVIGATION_JUMP_FWD, _navigateForward);
+        CommandManager.register(Strings.CMD_NAVIGATE_BACKWARD, NAVIGATION_JUMP_BACK, _navigateBack, { supportsDesignMode: true });
+        CommandManager.register(Strings.CMD_NAVIGATE_FORWARD, NAVIGATION_JUMP_FWD, _navigateForward, { supportsDesignMode: true });
         if(Phoenix.isTestWindow){
             CommandManager.register("reset nav forward and back for tests", _NAVIGATION_RESET_FOR_TESTS, _clearStacks);
         }

--- a/src/extensionsIntegrated/NavigationAndHistory/main.js
+++ b/src/extensionsIntegrated/NavigationAndHistory/main.js
@@ -761,20 +761,20 @@ define(function (require, exports, module) {
         // Command to show recent files list
 
         if (!CommandManager.get(SHOW_RECENT_FILES)) {
-            CommandManager.register(Strings.CMD_RECENT_FILES_OPEN, SHOW_RECENT_FILES, _showRecentFileList);
+            CommandManager.register(Strings.CMD_RECENT_FILES_OPEN, SHOW_RECENT_FILES, _showRecentFileList, { supportsDesignMode: true });
             KeyBindingManager.addBinding(SHOW_RECENT_FILES,
                 Phoenix.isNativeApp ? "Ctrl-R" : "Ctrl-Alt-Shift-O");
         }
 
         // Keyboard only - Navigate to the next doc in MROF list
         if (!CommandManager.get(NEXT_IN_RECENT_FILES)) {
-            CommandManager.register(Strings.CMD_NEXT_DOC, NEXT_IN_RECENT_FILES, _cmdMoveNext);
+            CommandManager.register(Strings.CMD_NEXT_DOC, NEXT_IN_RECENT_FILES, _cmdMoveNext, { supportsDesignMode: true });
         }
         KeyBindingManager.addBinding(NEXT_IN_RECENT_FILES, KeyboardPrefs[NEXT_IN_RECENT_FILES]);
 
         // Keyboard only - Navigate to the prev doc in MROF list
         if (!CommandManager.get(PREV_IN_RECENT_FILES)) {
-            CommandManager.register(Strings.CMD_PREV_DOC, PREV_IN_RECENT_FILES, _cmdMovePrev);
+            CommandManager.register(Strings.CMD_PREV_DOC, PREV_IN_RECENT_FILES, _cmdMovePrev, { supportsDesignMode: true });
         }
         KeyBindingManager.addBinding(PREV_IN_RECENT_FILES, KeyboardPrefs[PREV_IN_RECENT_FILES]);
 

--- a/src/extensionsIntegrated/NoDistractions/main.js
+++ b/src/extensionsIntegrated/NoDistractions/main.js
@@ -154,9 +154,9 @@ define(function (require, exports, module) {
      * Register the Commands , add the Menu Items and key bindings
      */
     AppInit.appReady(function () {
-        CommandManager.register(Strings.CMD_TOGGLE_PURE_CODE, CMD_TOGGLE_PURE_CODE, _togglePureCode);
-        CommandManager.register(Strings.CMD_TOGGLE_FULLSCREEN, CMD_TOGGLE_FULLSCREEN, _toggleFullScreen);
-        CommandManager.register(Strings.CMD_TOGGLE_PANELS, CMD_TOGGLE_PANELS, _togglePanels);
+        CommandManager.register(Strings.CMD_TOGGLE_PURE_CODE, CMD_TOGGLE_PURE_CODE, _togglePureCode, { supportsDesignMode: true });
+        CommandManager.register(Strings.CMD_TOGGLE_FULLSCREEN, CMD_TOGGLE_FULLSCREEN, _toggleFullScreen, { supportsDesignMode: true });
+        CommandManager.register(Strings.CMD_TOGGLE_PANELS, CMD_TOGGLE_PANELS, _togglePanels, { supportsDesignMode: true });
 
         Menus.getMenu(Menus.AppMenuBar.VIEW_MENU).addMenuItem(CMD_TOGGLE_PANELS, "", Menus.AFTER, Commands.VIEW_HIDE_SIDEBAR);
         Menus.getMenu(Menus.AppMenuBar.VIEW_MENU).addMenuItem(CMD_TOGGLE_PURE_CODE, togglePureCodeKey, Menus.AFTER, CMD_TOGGLE_PANELS);

--- a/src/extensionsIntegrated/Phoenix-live-preview/main.js
+++ b/src/extensionsIntegrated/Phoenix-live-preview/main.js
@@ -675,12 +675,18 @@ define(function (require, exports, module) {
     function _popoutLivePreview(browserName) {
         // We cannot use $iframe.src here if panel is hidden
         const openURL = StaticServer.getTabPopoutURL(currentLivePreviewURL);
+        // In design mode the LP panel fills the editor area — hiding it would
+        // leave the user staring at a blank workspace. Keep the panel open and
+        // just open the popout alongside it.
+        const closePanelAfterPopout = !WorkspaceManager.isInDesignMode();
         if(browserName && ALLOWED_BROWSERS_NAMES.includes(browserName)){
             Metrics.countEvent(Metrics.EVENT_TYPE.LIVE_PREVIEW, "popout", browserName);
             NodeUtils.openUrlInBrowser(openURL, browserName)
                 .then(()=>{
                     _loadPreview(true);
-                    _setPanelVisibility(false);
+                    if (closePanelAfterPopout) {
+                        _setPanelVisibility(false);
+                    }
                 })
                 .catch(err=>{
                     console.error("Error opening url in browser: ", browserName, err);
@@ -695,7 +701,9 @@ define(function (require, exports, module) {
             NativeApp.openURLInDefaultBrowser(openURL, "livePreview");
             Metrics.countEvent(Metrics.EVENT_TYPE.LIVE_PREVIEW, "popoutBtn", "click");
             _loadPreview(true);
-            _setPanelVisibility(false);
+            if (closePanelAfterPopout) {
+                _setPanelVisibility(false);
+            }
         }
     }
 

--- a/src/extensionsIntegrated/Phoenix-live-preview/main.js
+++ b/src/extensionsIntegrated/Phoenix-live-preview/main.js
@@ -1476,12 +1476,12 @@ define(function (require, exports, module) {
         }, fileChangeListenerStartDelay);
         CommandManager.register(Strings.CMD_LIVE_FILE_PREVIEW,  Commands.FILE_LIVE_FILE_PREVIEW, function () {
             _toggleVisibilityOnClick();
-        });
+        }, { supportsDesignMode: true });
         CommandManager.register(Strings.CMD_LIVE_FILE_PREVIEW_SETTINGS,
-            Commands.FILE_LIVE_FILE_PREVIEW_SETTINGS, _showSettingsDialog);
+            Commands.FILE_LIVE_FILE_PREVIEW_SETTINGS, _showSettingsDialog, { supportsDesignMode: true });
         CommandManager.register(Strings.CMD_RELOAD_LIVE_PREVIEW, Commands.CMD_RELOAD_LIVE_PREVIEW, function () {
             _loadPreview(true, true);
-        });
+        }, { supportsDesignMode: true });
         let fileMenu = Menus.getMenu(Menus.AppMenuBar.FILE_MENU);
         fileMenu.addMenuItem(Commands.FILE_LIVE_FILE_PREVIEW, "", Menus.AFTER, Commands.FILE_EXTENSION_MANAGER);
         fileMenu.addMenuItem(Commands.CMD_RELOAD_LIVE_PREVIEW, "",

--- a/src/extensionsIntegrated/Phoenix-live-preview/main.js
+++ b/src/extensionsIntegrated/Phoenix-live-preview/main.js
@@ -1008,6 +1008,10 @@ define(function (require, exports, module) {
         // Use mdviewr for markdown files (unless custom server is configured)
         if(previewDetails.isMarkdownFile && !previewDetails.isCustomServer && !previewDetails.isNoPreview) {
             _loadMdviewrPreview(previewDetails, force);
+            // Embedded panel uses mdviewr above; popped-out tabs still render
+            // the legacy server-rendered markdown URL, so broadcast the URL
+            // change so they navigate too — same path as the HTML branch.
+            StaticServer.redirectAllTabs(currentLivePreviewURL, force);
             return;
         }
         // Switching away from mdviewr to non-markdown preview

--- a/src/extensionsIntegrated/Phoenix-live-preview/utils.js
+++ b/src/extensionsIntegrated/Phoenix-live-preview/utils.js
@@ -39,12 +39,16 @@ define(function (require, exports, module) {
     const LIVE_PREVIEW_IFRAME_ID = "panel-live-preview-frame";
     const MDVIEWR_IFRAME_ID = "panel-md-preview-frame";
     const EditorManager      = require("editor/EditorManager");
+    const WorkspaceManager   = require("view/WorkspaceManager");
     // File-type classification helpers live in a shared utility module so
     // non-live-preview code (e.g. Quick Open in design mode) can use them
     // without depending on this extension.
     const FileTypeUtils      = require("utils/FileTypeUtils");
 
     function focusActiveEditorIfFocusInLivePreview() {
+        if (WorkspaceManager.isInDesignMode()) {
+            return;
+        }
         const editor  = EditorManager.getActiveEditor();
         if(!editor){
             return;

--- a/src/extensionsIntegrated/Phoenix/new-project.js
+++ b/src/extensionsIntegrated/Phoenix/new-project.js
@@ -92,7 +92,7 @@ define(function (require, exports, module) {
     }
 
     function _addMenuEntries() {
-        CommandManager.register(Strings.CMD_PROJECT_NEW, Commands.FILE_NEW_PROJECT, _showNewProjectDialogue);
+        CommandManager.register(Strings.CMD_PROJECT_NEW, Commands.FILE_NEW_PROJECT, _showNewProjectDialogue, { supportsDesignMode: true });
         const fileMenu = Menus.getMenu(Menus.AppMenuBar.FILE_MENU);
         fileMenu.addMenuItem(Commands.FILE_NEW_PROJECT, "", Menus.AFTER, Commands.FILE_NEW_FOLDER);
     }

--- a/src/extensionsIntegrated/Terminal/main.js
+++ b/src/extensionsIntegrated/Terminal/main.js
@@ -773,8 +773,8 @@ define(function (require, exports, module) {
     }
 
     // Register commands
-    CommandManager.register("New Terminal", CMD_NEW_TERMINAL, _createNewTerminal);
-    CommandManager.register(Strings.CMD_VIEW_TERMINAL, CMD_VIEW_TERMINAL, _showTerminal);
+    CommandManager.register("New Terminal", CMD_NEW_TERMINAL, _createNewTerminal, { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_VIEW_TERMINAL, CMD_VIEW_TERMINAL, _showTerminal, { supportsDesignMode: true });
     CommandManager.register(Strings.CMD_OPEN_IN_INTEGRATED_TERMINAL,
         Commands.NAVIGATE_OPEN_IN_INTEGRATED_TERMINAL, function () {
             const entry = ProjectManager.getSelectedItem();
@@ -786,7 +786,7 @@ define(function (require, exports, module) {
                 cwdPath = projectRoot ? projectRoot.fullPath : undefined;
             }
             _createNewTerminal(cwdPath);
-        });
+        }, { supportsDesignMode: true });
 
     // Terminal context menu commands
     CommandManager.register(Strings.CMD_COPY, CMD_TERMINAL_COPY, function () {

--- a/src/extensionsIntegrated/appUpdater/main.js
+++ b/src/extensionsIntegrated/appUpdater/main.js
@@ -598,10 +598,10 @@ define(function (require, exports, module) {
         });
         CommandManager.register(Strings.CMD_CHECK_FOR_UPDATE, Commands.HELP_CHECK_UPDATES, ()=>{
             checkForUpdates();
-        });
+        }, { supportsDesignMode: true });
         CommandManager.register(Strings.CMD_AUTO_UPDATE, Commands.HELP_AUTO_UPDATE, ()=>{
             PreferencesManager.set(PREFS_AUTO_UPDATE, !PreferencesManager.get(PREFS_AUTO_UPDATE));
-        });
+        }, { supportsDesignMode: true });
         const helpMenu = Menus.getMenu(Menus.AppMenuBar.HELP_MENU);
         helpMenu.addMenuItem(Commands.HELP_CHECK_UPDATES, "", Menus.AFTER, Commands.HELP_GET_INVOLVED);
         // auto update is not added to help menu toggle as it will lead to install base version

--- a/src/extensionsIntegrated/appUpdater/update-electron.js
+++ b/src/extensionsIntegrated/appUpdater/update-electron.js
@@ -483,10 +483,10 @@ define(function (require, exports, module) {
         });
         CommandManager.register(Strings.CMD_CHECK_FOR_UPDATE, Commands.HELP_CHECK_UPDATES, ()=>{
             checkForUpdates();
-        });
+        }, { supportsDesignMode: true });
         CommandManager.register(Strings.CMD_AUTO_UPDATE, Commands.HELP_AUTO_UPDATE, ()=>{
             PreferencesManager.set(PREFS_AUTO_UPDATE, !PreferencesManager.get(PREFS_AUTO_UPDATE));
-        });
+        }, { supportsDesignMode: true });
         const helpMenu = Menus.getMenu(Menus.AppMenuBar.HELP_MENU);
         helpMenu.addMenuItem(Commands.HELP_CHECK_UPDATES, "", Menus.AFTER, Commands.HELP_GET_INVOLVED);
         PreferencesManager.definePreference(PREFS_AUTO_UPDATE, "boolean", true, {

--- a/src/help/HelpCommandHandlers.js
+++ b/src/help/HelpCommandHandlers.js
@@ -178,8 +178,9 @@ define(function (require, exports, module) {
     CommandManager.register(Strings.CMD_DOCS,                   Commands.HELP_DOCS,                 _handleLinkMenuItem(brackets.config.docs_url), { supportsDesignMode: true });
     CommandManager.register(Strings.CMD_SUPPORT,                Commands.HELP_SUPPORT,              _handleLinkMenuItem(brackets.config.support_url), { supportsDesignMode: true });
     CommandManager.register(Strings.CMD_GET_PRO,                Commands.HELP_GET_PRO,              _handleLinkMenuItem(brackets.config.purchase_url), {
-        htmlName: getProString
-    }, { supportsDesignMode: true });
+        htmlName: getProString,
+        supportsDesignMode: true
+    });
     CommandManager.register(Strings.CMD_VIEW_LICENSE,           Commands.HELP_VIEW_LICENSE,         _openLicenseLink, { supportsDesignMode: true });
     CommandManager.register(Strings.CMD_SUGGEST,                Commands.HELP_SUGGEST,              _handleLinkMenuItem(brackets.config.suggest_feature_url), { supportsDesignMode: true });
     CommandManager.register(Strings.CMD_REPORT_ISSUE,           Commands.HELP_REPORT_ISSUE,         _handleLinkMenuItem(brackets.config.report_issue_url), { supportsDesignMode: true });

--- a/src/help/HelpCommandHandlers.js
+++ b/src/help/HelpCommandHandlers.js
@@ -174,20 +174,20 @@ define(function (require, exports, module) {
 
     const getProString = `${Strings.CMD_GET_PRO}<i class='fa fa-feather' style='margin-left: 4px;'></i>`;
 
-    CommandManager.register(Strings.CMD_HOW_TO_USE_BRACKETS,    Commands.HELP_HOW_TO_USE_BRACKETS,  _handleLinkMenuItem(brackets.config.how_to_use_url));
-    CommandManager.register(Strings.CMD_DOCS,                   Commands.HELP_DOCS,                 _handleLinkMenuItem(brackets.config.docs_url));
-    CommandManager.register(Strings.CMD_SUPPORT,                Commands.HELP_SUPPORT,              _handleLinkMenuItem(brackets.config.support_url));
+    CommandManager.register(Strings.CMD_HOW_TO_USE_BRACKETS,    Commands.HELP_HOW_TO_USE_BRACKETS,  _handleLinkMenuItem(brackets.config.how_to_use_url), { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_DOCS,                   Commands.HELP_DOCS,                 _handleLinkMenuItem(brackets.config.docs_url), { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_SUPPORT,                Commands.HELP_SUPPORT,              _handleLinkMenuItem(brackets.config.support_url), { supportsDesignMode: true });
     CommandManager.register(Strings.CMD_GET_PRO,                Commands.HELP_GET_PRO,              _handleLinkMenuItem(brackets.config.purchase_url), {
         htmlName: getProString
-    });
-    CommandManager.register(Strings.CMD_VIEW_LICENSE,           Commands.HELP_VIEW_LICENSE,         _openLicenseLink);
-    CommandManager.register(Strings.CMD_SUGGEST,                Commands.HELP_SUGGEST,              _handleLinkMenuItem(brackets.config.suggest_feature_url));
-    CommandManager.register(Strings.CMD_REPORT_ISSUE,           Commands.HELP_REPORT_ISSUE,         _handleLinkMenuItem(brackets.config.report_issue_url));
-    CommandManager.register(Strings.CMD_RELEASE_NOTES,          Commands.HELP_RELEASE_NOTES,        _handleLinkMenuItem(brackets.config.release_notes_url));
-    CommandManager.register(Strings.CMD_GET_INVOLVED,           Commands.HELP_GET_INVOLVED,         _handleLinkMenuItem(brackets.config.get_involved_url));
-    CommandManager.register(Strings.CMD_SHOW_EXTENSIONS_FOLDER, Commands.HELP_SHOW_EXT_FOLDER,      _handleShowExtensionsFolder);
-    CommandManager.register(Strings.CMD_HOMEPAGE,               Commands.HELP_HOMEPAGE,             _handleLinkMenuItem(brackets.config.homepage_url));
-    CommandManager.register(Strings.CMD_TWITTER,                Commands.HELP_TWITTER,              _handleLinkMenuItem(brackets.config.twitter_url));
-    CommandManager.register(Strings.CMD_YOUTUBE,                Commands.HELP_YOUTUBE,              _handleLinkMenuItem(brackets.config.youtube_url));
-    CommandManager.register(Strings.CMD_ABOUT,                  Commands.HELP_ABOUT,                _handleAboutDialog);
+    }, { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_VIEW_LICENSE,           Commands.HELP_VIEW_LICENSE,         _openLicenseLink, { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_SUGGEST,                Commands.HELP_SUGGEST,              _handleLinkMenuItem(brackets.config.suggest_feature_url), { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_REPORT_ISSUE,           Commands.HELP_REPORT_ISSUE,         _handleLinkMenuItem(brackets.config.report_issue_url), { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_RELEASE_NOTES,          Commands.HELP_RELEASE_NOTES,        _handleLinkMenuItem(brackets.config.release_notes_url), { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_GET_INVOLVED,           Commands.HELP_GET_INVOLVED,         _handleLinkMenuItem(brackets.config.get_involved_url), { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_SHOW_EXTENSIONS_FOLDER, Commands.HELP_SHOW_EXT_FOLDER,      _handleShowExtensionsFolder, { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_HOMEPAGE,               Commands.HELP_HOMEPAGE,             _handleLinkMenuItem(brackets.config.homepage_url), { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_TWITTER,                Commands.HELP_TWITTER,              _handleLinkMenuItem(brackets.config.twitter_url), { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_YOUTUBE,                Commands.HELP_YOUTUBE,              _handleLinkMenuItem(brackets.config.youtube_url), { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_ABOUT,                  Commands.HELP_ABOUT,                _handleAboutDialog, { supportsDesignMode: true });
 });

--- a/src/index.html
+++ b/src/index.html
@@ -451,6 +451,10 @@
                 }
             };
             window.Phoenix.isNativeApp = window.__IS_NATIVE_SHELL__;
+            // Default stub — WorkspaceManager replaces this with its real accessor on load.
+            // Defining it here means leaf modules (e.g. KeyBindingManager) can call
+            // Phoenix.isInDesignMode() unconditionally without a presence check.
+            window.Phoenix.isInDesignMode = function () { return false; };
             window.Phoenix.TRUSTED_ORIGINS[location.origin] = true;
             Phoenix.isSupportedBrowser = Phoenix.isNativeApp ||
                 (Phoenix.browser.isDeskTop && ("serviceWorker" in navigator));

--- a/src/phoenix-builder/main.js
+++ b/src/phoenix-builder/main.js
@@ -140,7 +140,7 @@ define(function (require, exports, module) {
         });
     }
 
-    CommandManager.register(Strings.CMD_PHOENIX_BUILDER_CONNECT, COMMAND_ID, _handlePhoenixBuilderConnect);
+    CommandManager.register(Strings.CMD_PHOENIX_BUILDER_CONNECT, COMMAND_ID, _handlePhoenixBuilderConnect, { supportsDesignMode: true });
 
     // Boot script already connects if enabled — no appReady action needed.
 

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -2229,17 +2229,17 @@ define(function (require, exports, module) {
     EventDispatcher.on_duringInit(MainViewManager, "currentFileChange", _currentFileChange);
 
     // Commands
-    CommandManager.register(Strings.CMD_OPEN_FOLDER,      Commands.FILE_OPEN_FOLDER,      openProject);
-    CommandManager.register(Strings.CMD_PROJECT_SETTINGS, Commands.FILE_PROJECT_SETTINGS, _projectSettings);
-    CommandManager.register(Strings.CMD_FILE_REFRESH,     Commands.FILE_REFRESH,          refreshFileTree);
-    CommandManager.register(Strings.CMD_FILE_CUT, Commands.FILE_CUT, _cutFileCMD);
-    CommandManager.register(Strings.CMD_FILE_COPY, Commands.FILE_COPY, _copyFileCMD);
-    CommandManager.register(Strings.CMD_FILE_COPY_PATH, Commands.FILE_COPY_PATH, _copyProjectRelativePath);
-    CommandManager.register(Strings.CMD_FILE_PASTE, Commands.FILE_PASTE, _pasteFileCMD);
-    CommandManager.register(Strings.CMD_FILE_DUPLICATE, Commands.FILE_DUPLICATE, _duplicateFileCMD);
-    CommandManager.register(Strings.CMD_FILE_DUPLICATE_FILE, Commands.FILE_DUPLICATE_FILE, _duplicateFileCMD);
-    CommandManager.register(Strings.CMD_FILE_DOWNLOAD_PROJECT, Commands.FILE_DOWNLOAD_PROJECT, _downloadFolderCommand);
-    CommandManager.register(Strings.CMD_FILE_DOWNLOAD, Commands.FILE_DOWNLOAD, _downloadCommand);
+    CommandManager.register(Strings.CMD_OPEN_FOLDER,      Commands.FILE_OPEN_FOLDER,      openProject, { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_PROJECT_SETTINGS, Commands.FILE_PROJECT_SETTINGS, _projectSettings, { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_FILE_REFRESH,     Commands.FILE_REFRESH,          refreshFileTree, { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_FILE_CUT, Commands.FILE_CUT, _cutFileCMD, { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_FILE_COPY, Commands.FILE_COPY, _copyFileCMD, { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_FILE_COPY_PATH, Commands.FILE_COPY_PATH, _copyProjectRelativePath, { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_FILE_PASTE, Commands.FILE_PASTE, _pasteFileCMD, { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_FILE_DUPLICATE, Commands.FILE_DUPLICATE, _duplicateFileCMD, { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_FILE_DUPLICATE_FILE, Commands.FILE_DUPLICATE_FILE, _duplicateFileCMD, { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_FILE_DOWNLOAD_PROJECT, Commands.FILE_DOWNLOAD_PROJECT, _downloadFolderCommand, { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_FILE_DOWNLOAD, Commands.FILE_DOWNLOAD, _downloadCommand, { supportsDesignMode: true });
 
     // Define the preference to decide how to sort the Project Tree files
     PreferencesManager.definePreference(SORT_DIRECTORIES_FIRST, "boolean", true, {
@@ -2250,7 +2250,7 @@ define(function (require, exports, module) {
             actionCreator.setSortDirectoriesFirst(sortPref);
             CommandManager.get(Commands.FILE_SHOW_FOLDERS_FIRST).setChecked(sortPref);
         });
-    CommandManager.register(Strings.CMD_FILE_SHOW_FOLDERS_FIRST, Commands.FILE_SHOW_FOLDERS_FIRST, _showFolderFirst);
+    CommandManager.register(Strings.CMD_FILE_SHOW_FOLDERS_FIRST, Commands.FILE_SHOW_FOLDERS_FIRST, _showFolderFirst, { supportsDesignMode: true });
     CommandManager.get(Commands.FILE_SHOW_FOLDERS_FIRST).setChecked(PreferencesManager.get(SORT_DIRECTORIES_FIRST));
 
     actionCreator.setSortDirectoriesFirst(PreferencesManager.get(SORT_DIRECTORIES_FIRST));

--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -319,12 +319,12 @@ define(function (require, exports, module) {
     _cmdSplitNone       = CommandManager.register(Strings.CMD_SPLITVIEW_NONE,       Commands.CMD_SPLITVIEW_NONE,       _handleSplitViewNone);
     _cmdSplitVertical   = CommandManager.register(Strings.CMD_SPLITVIEW_VERTICAL,   Commands.CMD_SPLITVIEW_VERTICAL,   _handleSplitViewVertical);
     _cmdSplitHorizontal = CommandManager.register(Strings.CMD_SPLITVIEW_HORIZONTAL, Commands.CMD_SPLITVIEW_HORIZONTAL, _handleSplitViewHorizontal);
-    _cmdToggleWorkingSet = CommandManager.register(Strings.CMD_TOGGLE_SHOW_WORKING_SET, Commands.CMD_TOGGLE_SHOW_WORKING_SET, _handleToggleWorkingSet);
+    _cmdToggleWorkingSet = CommandManager.register(Strings.CMD_TOGGLE_SHOW_WORKING_SET, Commands.CMD_TOGGLE_SHOW_WORKING_SET, _handleToggleWorkingSet, { supportsDesignMode: true });
     _cmdToggleFileTabs = CommandManager.register(Strings.CMD_TOGGLE_SHOW_FILE_TABS, Commands.CMD_TOGGLE_SHOW_FILE_TABS, _handleToggleFileTabs);
 
-    CommandManager.register(Strings.CMD_TOGGLE_SIDEBAR, Commands.VIEW_HIDE_SIDEBAR, toggle);
-    CommandManager.register(Strings.CMD_SHOW_SIDEBAR, Commands.SHOW_SIDEBAR, show);
-    CommandManager.register(Strings.CMD_HIDE_SIDEBAR, Commands.HIDE_SIDEBAR, hide);
+    CommandManager.register(Strings.CMD_TOGGLE_SIDEBAR, Commands.VIEW_HIDE_SIDEBAR, toggle, { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_SHOW_SIDEBAR, Commands.SHOW_SIDEBAR, show, { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_HIDE_SIDEBAR, Commands.HIDE_SIDEBAR, hide, { supportsDesignMode: true });
 
     /**
      * Programmatically resize the sidebar to the given width. Persists

--- a/src/project/WorkingSetSort.js
+++ b/src/project/WorkingSetSort.js
@@ -389,10 +389,10 @@ define(function (require, exports, module) {
     /**
      * Register Command Handlers
      */
-    CommandManager.register(Strings.CMD_WORKINGSET_SORT_BY_ADDED, Commands.CMD_WORKINGSET_SORT_BY_ADDED, _.partial(_handleSort, Commands.CMD_WORKINGSET_SORT_BY_ADDED));
-    CommandManager.register(Strings.CMD_WORKINGSET_SORT_BY_NAME, Commands.CMD_WORKINGSET_SORT_BY_NAME, _.partial(_handleSort, Commands.CMD_WORKINGSET_SORT_BY_NAME));
-    CommandManager.register(Strings.CMD_WORKINGSET_SORT_BY_TYPE, Commands.CMD_WORKINGSET_SORT_BY_TYPE, _.partial(_handleSort, Commands.CMD_WORKINGSET_SORT_BY_TYPE));
-    CommandManager.register(Strings.CMD_WORKING_SORT_TOGGLE_AUTO, Commands.CMD_WORKING_SORT_TOGGLE_AUTO, _handleToggleAutoSort);
+    CommandManager.register(Strings.CMD_WORKINGSET_SORT_BY_ADDED, Commands.CMD_WORKINGSET_SORT_BY_ADDED, _.partial(_handleSort, Commands.CMD_WORKINGSET_SORT_BY_ADDED), { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_WORKINGSET_SORT_BY_NAME, Commands.CMD_WORKINGSET_SORT_BY_NAME, _.partial(_handleSort, Commands.CMD_WORKINGSET_SORT_BY_NAME), { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_WORKINGSET_SORT_BY_TYPE, Commands.CMD_WORKINGSET_SORT_BY_TYPE, _.partial(_handleSort, Commands.CMD_WORKINGSET_SORT_BY_TYPE), { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_WORKING_SORT_TOGGLE_AUTO, Commands.CMD_WORKING_SORT_TOGGLE_AUTO, _handleToggleAutoSort, { supportsDesignMode: true });
 
 
     /**

--- a/src/search/FindInFilesUI.js
+++ b/src/search/FindInFilesUI.js
@@ -577,11 +577,11 @@ define(function (require, exports, module) {
     });
 
     // Initialize: command handlers
-    CommandManager.register(Strings.CMD_FIND_IN_FILES,       Commands.CMD_FIND_IN_FILES,       _showFindBar);
-    CommandManager.register(Strings.CMD_FIND_IN_SUBTREE,     Commands.CMD_FIND_IN_SUBTREE,     _showFindBarForSubtree);
+    CommandManager.register(Strings.CMD_FIND_IN_FILES,       Commands.CMD_FIND_IN_FILES,       _showFindBar, { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_FIND_IN_SUBTREE,     Commands.CMD_FIND_IN_SUBTREE,     _showFindBarForSubtree, { supportsDesignMode: true });
 
-    CommandManager.register(Strings.CMD_REPLACE_IN_FILES,    Commands.CMD_REPLACE_IN_FILES,    _showReplaceBar);
-    CommandManager.register(Strings.CMD_REPLACE_IN_SUBTREE,  Commands.CMD_REPLACE_IN_SUBTREE,  _showReplaceBarForSubtree);
+    CommandManager.register(Strings.CMD_REPLACE_IN_FILES,    Commands.CMD_REPLACE_IN_FILES,    _showReplaceBar, { supportsDesignMode: true });
+    CommandManager.register(Strings.CMD_REPLACE_IN_SUBTREE,  Commands.CMD_REPLACE_IN_SUBTREE,  _showReplaceBarForSubtree, { supportsDesignMode: true });
 
     FindUtils.on(FindUtils.SEARCH_INDEXING_STARTED, _searchIndexingStarted);
     FindUtils.on(FindUtils.SEARCH_INDEXING_PROGRESS, _searchIndexingProgressing);

--- a/src/search/QuickOpen.js
+++ b/src/search/QuickOpen.js
@@ -1048,7 +1048,7 @@ define(function (require, exports, module) {
             });
     });
 
-    CommandManager.register(Strings.CMD_QUICK_OPEN, Commands.NAVIGATE_QUICK_OPEN, doFileSearch);
+    CommandManager.register(Strings.CMD_QUICK_OPEN, Commands.NAVIGATE_QUICK_OPEN, doFileSearch, { supportsDesignMode: true });
     CommandManager.register(Strings.CMD_GOTO_DEFINITION, Commands.NAVIGATE_GOTO_DEFINITION, doDefinitionSearch);
     CommandManager.register(Strings.CMD_GOTO_DEFINITION_PROJECT, Commands.NAVIGATE_GOTO_DEFINITION_PROJECT, doDefinitionSearchInProject);
     CommandManager.register(Strings.CMD_GOTO_LINE, Commands.NAVIGATE_GOTO_LINE, doGotoLine);

--- a/src/view/CentralControlBar.js
+++ b/src/view/CentralControlBar.js
@@ -323,7 +323,7 @@ define(function (require, exports, module) {
     const _toggleDesignModeCommand = CommandManager.register(Strings.CMD_TOGGLE_DESIGN_MODE,
         Commands.VIEW_TOGGLE_DESIGN_MODE, function () {
             _setEditorCollapsed(!editorCollapsed);
-        });
+        }, { supportsDesignMode: true });
 
     AppInit.htmlReady(function () {
         $bar = $("#centralControlBar");

--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -593,12 +593,12 @@ define(function (require, exports, module) {
     // Register command handlers
     CommandManager.register(Strings.CMD_INCREASE_FONT_SIZE, Commands.VIEW_INCREASE_FONT_SIZE,  _handleIncreaseFontSize);
     CommandManager.register(Strings.CMD_DECREASE_FONT_SIZE, Commands.VIEW_DECREASE_FONT_SIZE,  _handleDecreaseFontSize);
-    CommandManager.register(Strings.CMD_ZOOM_IN, Commands.VIEW_ZOOM_IN,  _handleZoomIn, {eventSource: true});
-    CommandManager.register(Strings.CMD_ZOOM_OUT, Commands.VIEW_ZOOM_OUT,  _handleZoomOut, {eventSource: true});
+    CommandManager.register(Strings.CMD_ZOOM_IN, Commands.VIEW_ZOOM_IN,  _handleZoomIn, {eventSource: true, supportsDesignMode: true});
+    CommandManager.register(Strings.CMD_ZOOM_OUT, Commands.VIEW_ZOOM_OUT,  _handleZoomOut, {eventSource: true, supportsDesignMode: true});
     CommandManager.register(Strings.CMD_RESTORE_FONT_SIZE,  Commands.VIEW_RESTORE_FONT_SIZE,   _handleRestoreFontSize);
     CommandManager.register(Strings.CMD_SCROLL_LINE_UP,     Commands.VIEW_SCROLL_LINE_UP,      _handleScrollLineUp);
     CommandManager.register(Strings.CMD_SCROLL_LINE_DOWN,   Commands.VIEW_SCROLL_LINE_DOWN,    _handleScrollLineDown);
-    CommandManager.register(Strings.CMD_THEMES,             Commands.CMD_THEMES_OPEN_SETTINGS, _handleThemeSettings);
+    CommandManager.register(Strings.CMD_THEMES,             Commands.CMD_THEMES_OPEN_SETTINGS, _handleThemeSettings, { supportsDesignMode: true });
 
     prefs.definePreference("fontSize",   "string", DEFAULT_FONT_SIZE + "px", {
         description: Strings.DESCRIPTION_FONT_SIZE

--- a/src/view/WorkspaceManager.js
+++ b/src/view/WorkspaceManager.js
@@ -735,6 +735,11 @@ define(function (require, exports, module) {
         return _isInDesignMode;
     }
 
+    // Expose on the Phoenix global so leaf modules (e.g. KeyBindingManager) can
+    // check design-mode state without importing WorkspaceManager and creating a
+    // circular dependency.
+    Phoenix.isInDesignMode = isInDesignMode;
+
     /**
      * Sets the design-mode flag and fires EVENT_WORKSPACE_DESIGN_MODE_CHANGE when
      * the value actually changes. Intended to be called by the control bar; other

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -368,6 +368,8 @@
         }
       };
       window.Phoenix.isNativeApp = window.__IS_NATIVE_SHELL__;
+      // Default stub — WorkspaceManager replaces this with its real accessor on load.
+      window.Phoenix.isInDesignMode = function () { return false; };
       window.Phoenix.TRUSTED_ORIGINS[location.origin] = true;
       Phoenix.isSupportedBrowser = Phoenix.isNativeApp ||
               (Phoenix.browser.isDeskTop && ("serviceWorker" in navigator));

--- a/tracking-repos.json
+++ b/tracking-repos.json
@@ -1,5 +1,5 @@
 {
   "phoenixPro": {
-    "commitID": "f027fa5a6bc78abd4425bab16986c79c4de3e4d3"
+    "commitID": "85b05bfa13b79712d6854be27d2b02b9d1fa065f"
   }
 }

--- a/tracking-repos.json
+++ b/tracking-repos.json
@@ -1,5 +1,5 @@
 {
   "phoenixPro": {
-    "commitID": "2bb59b167810e72dbc176412b26b7d83f8062234"
+    "commitID": "f027fa5a6bc78abd4425bab16986c79c4de3e4d3"
   }
 }


### PR DESCRIPTION
So when live preview element is clicked in design mode, the html will try to focus the editor, but since ther eis no editor, the focus shifts to phoenix editor doc body. This is done so that we can move cursor in the code editor in split mode once element is selected in lp. but in design mode, this workflow doesnt exist, so we now dont set focus on the phoenix side.

This results in a new problem where all key events are in the lp iframe and commands like exit design mode, find in files etc wont work any more. so what we do if we forwards all such commands to phoenix from live preview to key binding manager where we modified the command manager for commands to declare if they are supported in design mode or not. This can later be used to selectively show main menu options in design mode.

With this change, the keyboard focus should be stable with focus in both md edito, live preview and any textboxes/ui that takes up focus in phoenix in design mode.