### PR TITLE
Terminal context menu improvements

### DIFF
--- a/src/extensionsIntegrated/Terminal/main.js
+++ b/src/extensionsIntegrated/Terminal/main.js
@@ -846,10 +846,12 @@ define(function (require, exports, module) {
         const active = _getActiveTerminal();
         if (active && active.isAlive) {
             active.focus();
-            navigator.clipboard.readText().then(function (text) {
+            Phoenix.app.clipboardReadText().then(function (text) {
                 if (text) {
                     nodeConnector.execPeer("writeTerminal", {id: active.id, data: text});
                 }
+            }).catch(function (err) {
+                console.error("Terminal paste failed:", err);
             });
         }
     });

--- a/test/spec/Terminal-integ-test.js
+++ b/test/spec/Terminal-integ-test.js
@@ -708,14 +708,14 @@ define(function (require, exports, module) {
                     await openTerminal();
                     await waitForShellReady();
 
-                    // Mock clipboard.readText to return a known string,
-                    // since the test iframe may not have clipboard
-                    // permission (no window focus).
+                    // Mock Phoenix.app.clipboardReadText to return a
+                    // known string, since the test iframe may not have
+                    // clipboard permission (no window focus).
                     const pasteText = "PASTEMARKER456";
-                    const clipboard = testWindow.navigator.clipboard;
-                    spyOn(clipboard, "readText").and.returnValue(
-                        testWindow.Promise.resolve(pasteText)
-                    );
+                    spyOn(testWindow.Phoenix.app, "clipboardReadText")
+                        .and.returnValue(
+                            testWindow.Promise.resolve(pasteText)
+                        );
 
                     // Execute the paste command
                     await CommandManager.execute("terminal.paste");


### PR DESCRIPTION
This PR fixes a terminal context menu bug where clicking the Paste option used to open another paste button (Chromium).                                                                                   