### PR TITLE
fix(ai): add Homebrew + Linuxbrew fallbacks for Claude CLI detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "phoenix",
-    "version": "5.1.7-0",
+    "version": "5.1.9-0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "phoenix",
-            "version": "5.1.7-0",
+            "version": "5.1.9-0",
             "hasInstallScript": true,
             "dependencies": {
                 "@bugsnag/js": "^7.18.0",

--- a/src-node/claude-code-agent.js
+++ b/src-node/claude-code-agent.js
@@ -221,13 +221,21 @@ function _findGlobalClaudeCliWin() {
  * Find the user's globally installed Claude CLI on macOS/Linux.
  */
 function _findGlobalClaudeCliLinuxMac() {
+    const home = process.env.HOME || "";
+    // The fallback list matters most when Phoenix is launched from
+    // Finder/Dock on macOS — that PATH is the minimal
+    // `/usr/bin:/bin:/usr/sbin:/sbin`, so `which claude` won't see
+    // anything in the user's shell-managed dirs. Order is by likelihood:
+    // primary docs-recommended installs first, alternatives last.
     const locations = [
-        "/usr/local/bin/claude",
-        "/usr/bin/claude",
-        (process.env.HOME || "") + "/.local/bin/claude",
-        (process.env.HOME || "") + "/.nvm/versions/node/" +
+        home + "/.local/bin/claude",                      // claude.ai/install.sh (default)
+        "/usr/local/bin/claude",                          // System-wide install / Intel Mac Homebrew
+        "/usr/bin/claude",                                // Distro package
+        home + "/.nvm/versions/node/" +
             (process.version.startsWith("v") ? process.version : "v" + process.version) +
-            "/bin/claude"
+            "/bin/claude",                                // npm global via nvm
+        "/opt/homebrew/bin/claude",                       // Homebrew on Apple Silicon
+        "/home/linuxbrew/.linuxbrew/bin/claude"           // Linuxbrew
     ];
 
     // Try 'which -a' first to find all claude binaries, filtering out node_modules

--- a/src-node/package-lock.json
+++ b/src-node/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@phcode/node-core",
-    "version": "5.1.8-0",
+    "version": "5.1.9-0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@phcode/node-core",
-            "version": "5.1.8-0",
+            "version": "5.1.9-0",
             "hasInstallScript": true,
             "license": "GNU-AGPL3.0",
             "dependencies": {

--- a/tracking-repos.json
+++ b/tracking-repos.json
@@ -1,5 +1,5 @@
 {
   "phoenixPro": {
-    "commitID": "da29089c7397058410514ab3c8d29748bc16558b"
+    "commitID": "11fec38adda6438d047e58ae6b32bced6fb6d48b"
   }
 }


### PR DESCRIPTION
Apple Silicon Macs running `brew install --cask claude-code` land the binary at /opt/homebrew/bin/claude, which we weren't checking. On macOS, when Phoenix is launched from Finder/Dock the inherited PATH is the minimal /usr/bin:/bin:/usr/sbin:/sbin so `which claude` misses anything in shell-managed dirs — making the fallback list the only detection path that works.

Also reorder so the docs-recommended installs (~/.local/bin from install.sh, /usr/local/bin) come first and alternative installs (Homebrew, Linuxbrew) come last.
