### PR TITLE
fix(updater): detect installed AppImage path on Linux

### DIFF
--- a/src-node/package-lock.json
+++ b/src-node/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@phcode/node-core",
-    "version": "5.1.16-0",
+    "version": "5.1.17-0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@phcode/node-core",
-            "version": "5.1.16-0",
+            "version": "5.1.17-0",
             "hasInstallScript": true,
             "license": "GNU-AGPL3.0",
             "dependencies": {

--- a/src/extensionsIntegrated/appUpdater/update-electron.js
+++ b/src/extensionsIntegrated/appUpdater/update-electron.js
@@ -154,17 +154,20 @@ define(function (require, exports, module) {
     /**
      * Check if we're at an upgradable location.
      * For Electron on Linux, we require the AppImage to be in ~/.phoenix-code/
+     * (the path the installer.sh writes to).
      */
     async function isUpgradableLocation() {
         try {
-            const isPackaged = await window.electronAPI.isPackaged();
-            if (!isPackaged) {
+            const installedPath = await window.electronAPI.getInstalledAppPath();
+            if (!installedPath) {
                 return false;
             }
-            const homeDir = await window.electronFSAPI.homeDir();
+            let homeDir = await window.electronFSAPI.homeDir();
+            if (!homeDir.endsWith("/")) {
+                homeDir = homeDir + "/";
+            }
             const phoenixInstallDir = `${homeDir}.phoenix-code/`;
-            const execPath = await window.electronAPI.getExecutablePath();
-            return execPath.startsWith(phoenixInstallDir);
+            return installedPath.startsWith(phoenixInstallDir);
         } catch (e) {
             console.error(e);
             return false;


### PR DESCRIPTION
isUpgradableLocation() was comparing the FUSE-mounted Electron binary path (process.execPath, e.g. /tmp/.mount_*/phoenix-code) against ~/.phoenix-code/, which never matched. Switch to the new electronAPI.getInstalledAppPath() which returns process.env.APPIMAGE on packaged AppImage runs (and null elsewhere), so the upgradable-location check actually passes for installed builds. Also ensure homeDir has a trailing slash, matching the Tauri-side check.

Related desktop api change: https://github.com/phcode-dev/phoenix-desktop/pull/712