### PR TITLE
feat(typescript): auto-enable project-wide code intelligence

### DIFF
--- a/docs/API-Reference/widgets/NotificationUI.md
+++ b/docs/API-Reference/widgets/NotificationUI.md
@@ -74,6 +74,7 @@ CSS class names for notification styles.
 | SUCCESS | <code>string</code> | <code>&quot;style-success&quot;</code> | 
 | ERROR | <code>string</code> | <code>&quot;style-error&quot;</code> | 
 | DANGER | <code>string</code> | <code>&quot;style-danger&quot;</code> | 
+| SUBTLE | <code>string</code> | <code>&quot;style-subtle&quot;</code> | 
 
 <a name="module_widgets/NotificationUI..CLOSE_REASON"></a>
 

--- a/src/extensions/default/TypeScriptSupport/CodeIntelligence.js
+++ b/src/extensions/default/TypeScriptSupport/CodeIntelligence.js
@@ -1,0 +1,405 @@
+/*
+ * GNU AGPL-3.0 License
+ *
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
+ *
+ */
+
+/**
+ * Project-wide code intelligence for JavaScript/TypeScript - on by default.
+ *
+ * vtsls (tsserver) only analyses your *whole* project - cross-file Find Usages, rename,
+ * go-to-definition into other files - when it can find an on-disk `tsconfig.json`/`jsconfig.json`.
+ * Without one it falls back to an "inferred project" scoped to the open file and its imports.
+ *
+ * Rather than nag with a dialog, we make project-wide intelligence the default: the first time a
+ * JS/TS file is opened in a project that has no config, we silently create a `jsconfig.json` and
+ * show an unobtrusive toast ("See Config" / "Enable TypeScript" / "Learn more"). We always create a
+ * `jsconfig.json` - never a `tsconfig.json` - because jsconfig is editor-only (the TS compiler and
+ * bundlers ignore it, so it can never change a build) yet still scopes `.ts` files project-wide.
+ * To opt out, the user opens the config and deletes it; we remember (PREF_CREATED) and won't
+ * recreate it - instead the Problems panel offers a one-click re-enable.
+ *
+ * Desktop-only (the LSP is desktop-only); never runs in test windows (it would write configs into
+ * fixtures and break tests).
+ *
+ * @module extensionsIntegrated/TypeScriptSupport/CodeIntelligence
+ */
+define(function (require, exports, module) {
+
+
+    const ProjectManager = brackets.getModule("project/ProjectManager"),
+        EditorManager = brackets.getModule("editor/EditorManager"),
+        MainViewManager = brackets.getModule("view/MainViewManager"),
+        FileSystem = brackets.getModule("filesystem/FileSystem"),
+        CommandManager = brackets.getModule("command/CommandManager"),
+        Commands = brackets.getModule("command/Commands"),
+        NotificationUI = brackets.getModule("widgets/NotificationUI"),
+        NativeApp = brackets.getModule("utils/NativeApp"),
+        PreferencesManager = brackets.getModule("preferences/PreferencesManager"),
+        StringUtils = brackets.getModule("utils/StringUtils"),
+        Strings = brackets.getModule("strings");
+
+    // Per-project persisted flag: Phoenix has created a config here at least once. We never
+    // auto-create again once set, so deleting the config (the opt-out) sticks; the Problems-panel
+    // row then offers to re-enable.
+    const PREF_CREATED = "tsCodeIntel.created";
+
+    // "Learn more" -> the TypeScript/JavaScript config reference (documents every compilerOption in
+    // the jsconfig.json we generate: module, target, moduleResolution, checkJs, jsx, ...).
+    const DOCS_URL = "https://www.typescriptlang.org/tsconfig/";
+
+    // The single config we ever create. Editor-only (build-safe) and scopes .ts as well as .js.
+    const CONFIG_FILE = "jsconfig.json";
+    // Configs whose presence means the project is already scoped - leave it alone.
+    const EXISTING_CONFIG_FILES = ["tsconfig.json", "jsconfig.json"];
+
+    // Languages that map to a "TypeScript" label.
+    const TS_LANGUAGES = ["typescript", "tsx"];
+
+    // Modern, type-error-free defaults. `jsx: "react"` only affects .jsx/.tsx, harmless elsewhere.
+    // checkJs flips on TypeScript-grade type checking of JS when the user opts in.
+    function _jsConfig(checkJs) {
+        return {
+            compilerOptions: {
+                module: "esnext",
+                target: "esnext",
+                moduleResolution: "bundler",
+                checkJs: !!checkJs,
+                jsx: "react"
+            },
+            exclude: ["node_modules", "dist", "build"]
+        };
+    }
+
+    // Options injected by main.js (kept decoupled from the LSP client wiring).
+    let _options = {};
+    // Project roots we've already evaluated this session (avoids re-scanning on every file switch).
+    const _evaluated = new Set();
+    // Project roots where the user closed the Problems-panel re-enable row this session.
+    const _panelRowClosed = new Set();
+    // The currently-shown toast, so we can dismiss it when the project changes.
+    let _activeNotification = null;
+
+    function _dismissActiveNotification() {
+        if (_activeNotification) {
+            _activeNotification.close();
+            _activeNotification = null;
+        }
+    }
+
+    function _projectRootPath() {
+        const root = ProjectManager.getProjectRoot();
+        return root && root.fullPath;
+    }
+
+    // True if the active project changed since `rootPath` was captured - i.e. the user switched
+    // projects while an await was in flight, so the in-progress result is now stale. (This re-reads
+    // the *current* root on purpose; comparing against the captured `rootPath` is the whole point.)
+    function _projectChangedSince(rootPath) {
+        return _projectRootPath() !== rootPath;
+    }
+
+    function _isCreated() {
+        return !!PreferencesManager.stateManager.get(PREF_CREATED, PreferencesManager.stateManager.PROJECT_CONTEXT);
+    }
+
+    function _setCreated(val) {
+        PreferencesManager.stateManager.set(PREF_CREATED, !!val, PreferencesManager.stateManager.PROJECT_CONTEXT);
+    }
+
+    /**
+     * @return {Promise<boolean>} true if the project root already has a tsconfig/jsconfig.
+     */
+    function _hasProjectConfig() {
+        const rootPath = _projectRootPath();
+        if (!rootPath) {
+            return Promise.resolve(false);
+        }
+        return Promise.all(EXISTING_CONFIG_FILES.map(function (name) {
+            return new Promise(function (resolve) {
+                FileSystem.getFileForPath(rootPath + name).exists(function (err, exists) {
+                    resolve(!err && exists);
+                });
+            });
+        })).then(function (results) {
+            return results.indexOf(true) !== -1;
+        });
+    }
+
+    /**
+     * @return {Promise<boolean>} true if the project contains a real .ts/.tsx file. `.d.ts` ambient
+     * declarations don't count - they're common in plain-JS projects and don't make it a TS project.
+     * Only TypeScript is probed: a project with no .ts is labelled JavaScript by default, so there's
+     * nothing to gain from a separate JS scan.
+     */
+    function _projectHasTsFiles() {
+        return new Promise(function (resolve) {
+            // getAllFiles returns the project's cached file list; `.some()` stops at the first match
+            // instead of collecting every TS file just to check the count.
+            ProjectManager.getAllFiles().done(function (files) {
+                resolve(files.some(function (file) {
+                    return (/\.tsx?$/i).test(file.name) && !(/\.d\.ts$/i).test(file.name);
+                }));
+            }).fail(function () {
+                resolve(false);
+            });
+        });
+    }
+
+    function _openConfig() {
+        const rootPath = _projectRootPath();
+        if (rootPath) {
+            CommandManager.execute(Commands.FILE_OPEN, { fullPath: rootPath + CONFIG_FILE });
+        }
+    }
+
+    /**
+     * Write the jsconfig (creating or updating it), then restart the server so it re-scopes.
+     * @param {boolean} checkJs
+     * @return {Promise<boolean>} resolves true on success
+     */
+    function _writeConfig(checkJs) {
+        return new Promise(function (resolve) {
+            const rootPath = _projectRootPath();
+            if (!rootPath) {
+                resolve(false);
+                return;
+            }
+            const content = JSON.stringify(_jsConfig(checkJs), null, 4) + "\n";
+            FileSystem.getFileForPath(rootPath + CONFIG_FILE).write(content, function (err) {
+                if (err) {
+                    console.error("[TypeScriptSupport] failed to write " + CONFIG_FILE, err);
+                    resolve(false);
+                    return;
+                }
+                _setCreated(true); // remember we own a config here, so deletion = opt-out
+                if (typeof _options.restartServer === "function") {
+                    _options.restartServer();
+                }
+                resolve(true);
+            });
+        });
+    }
+
+    function _learnMore() {
+        NativeApp.openURLInDefaultBrowser(DOCS_URL);
+    }
+
+    // Reusable quiet/subtle NotificationUI surface (theme-matching, not a bright colored toast).
+    const TOAST_STYLE = NotificationUI.NOTIFICATION_STYLES_CSS_CLASS.SUBTLE;
+
+    // Show this toast and remember it so a project switch can dismiss it.
+    function _trackToast(title, $tpl) {
+        _dismissActiveNotification();
+        const notification = NotificationUI.createToastFromTemplate(title, $tpl,
+            // instantOpen: skip the default ~2s open-animation delay so it shows right away.
+            { dismissOnClick: false, toastStyle: TOAST_STYLE, autoCloseTimeS: 30, instantOpen: true });
+        _activeNotification = notification;
+        notification.done(function () {
+            if (_activeNotification === notification) {
+                _activeNotification = null;
+            }
+        });
+        return notification;
+    }
+
+    function _action(label) {
+        return $("<button class='ts-code-intel-action'>").text(label);
+    }
+
+    /**
+     * Unobtrusive "intelligence enabled" toast. For a plain-JS project it also offers a one-click
+     * "Enable TypeScript" (turns on TypeScript-grade type checking via checkJs). No "Undo" - to opt
+     * out the user just opens the config (See Config) and deletes it.
+     * @param {boolean} isTs - label as TypeScript (and hide the "enable TS" button)
+     */
+    function _showEnabledToast(isTs) {
+        const langName = isTs ? Strings.CODE_INTEL_TS : Strings.CODE_INTEL_JS;
+
+        const $tpl = $("<div class='ts-code-intel-toast'>");
+        $("<div class='ts-code-intel-msg'>").text(Strings.CODE_INTEL_ENABLED_MESSAGE).appendTo($tpl);
+        const $btns = $("<div class='ts-code-intel-buttons'>").appendTo($tpl);
+        const $see = _action(Strings.CODE_INTEL_SEE_CONFIG).appendTo($btns);
+        let $enableTs = null;
+        if (!isTs) {
+            $enableTs = _action(Strings.CODE_INTEL_ENABLE_TS).appendTo($btns);
+        }
+        const $learn = _action(Strings.CODE_INTEL_LEARN_MORE).appendTo($btns);
+
+        _trackToast(StringUtils.format(Strings.CODE_INTEL_ENABLED_TITLE, langName), $tpl);
+
+        $see.on("click", function () {
+            _openConfig();
+        });
+        if ($enableTs) {
+            $enableTs.on("click", function () {
+                _writeConfig(true).then(function (ok) {
+                    if (ok) {
+                        _showEnabledToast(true); // relabel as TypeScript (also dismisses this toast)
+                    }
+                });
+            });
+        }
+        $learn.on("click", _learnMore);
+    }
+
+    // ----- Problems-panel re-enable row -----------------------------------------------------------
+    // A banner inside #problems-panel offering to re-enable project-wide intelligence. Shown when a
+    // JS/TS file is active in a project where Phoenix created a config before but it's now gone (the
+    // user deleted it). It lives as a sibling of the results table, so CodeInspection re-rendering
+    // the table doesn't wipe it.
+
+    function _ensurePanelRow() {
+        const $panel = $("#problems-panel");
+        if (!$panel.length) {
+            return null;
+        }
+        let $row = $panel.find(".ts-code-intel-panel-row");
+        if ($row.length) {
+            return $row;
+        }
+        $row = $("<div class='ts-code-intel-panel-row'>").hide();
+        $("<span class='ts-code-intel-panel-text'>").text(Strings.CODE_INTEL_PANEL_TEXT).appendTo($row);
+        $("<button class='btn btn-mini primary ts-code-intel-panel-enable'>")
+            .text(Strings.CODE_INTEL_PANEL_ENABLE)
+            .on("click", function () {
+                promptEnable();
+            })
+            .appendTo($row);
+        $("<a class='ts-code-intel-panel-close'>")
+            .attr("title", Strings.CODE_INTEL_PANEL_DISMISS).html("&times;")
+            .on("click", function () {
+                const rootPath = _projectRootPath();
+                if (rootPath) {
+                    _panelRowClosed.add(rootPath); // session-only: reappears next launch
+                }
+                $row.hide();
+            })
+            .appendTo($row);
+        $panel.children(".toolbar").after($row);
+        return $row;
+    }
+
+    function _updatePanelRow() {
+        if (typeof Phoenix !== "undefined" && Phoenix.isTestWindow) {
+            return;
+        }
+        const $row = _ensurePanelRow();
+        if (!$row) {
+            return;
+        }
+        const rootPath = _projectRootPath();
+        const editor = EditorManager.getActiveEditor();
+        const lang = editor && editor.document && editor.document.getLanguage().getId();
+        const supportedActive = lang && _options.supportedLanguages.indexOf(lang) !== -1;
+        // Show only when a JS/TS file is active, Phoenix created a config here before (so its absence
+        // means the user deleted it), and they didn't close the row this session.
+        if (!rootPath || !supportedActive || !_isCreated() || _panelRowClosed.has(rootPath)) {
+            $row.hide();
+            return;
+        }
+        _hasProjectConfig().then(function (hasConfig) {
+            if (_projectChangedSince(rootPath)) {
+                return;
+            }
+            $row.toggle(!hasConfig);
+        });
+    }
+
+    /**
+     * On the first JS/TS file opened in a config-less, non-dismissed project (once per session),
+     * silently create a jsconfig and surface the unobtrusive toast.
+     * @param {Editor} editor
+     */
+    async function _autoEnable(editor) {
+        if (Phoenix.isTestWindow) {
+            return; // never write configs from a test window - it would pollute fixtures
+        }
+        if (!editor || !editor.document) {
+            return;
+        }
+        const lang = editor.document.getLanguage().getId();
+        if (_options.supportedLanguages.indexOf(lang) === -1) {
+            return;
+        }
+        const rootPath = _projectRootPath();
+        if (!rootPath || _evaluated.has(rootPath)) {
+            return;
+        }
+        _evaluated.add(rootPath);
+        if (_isCreated()) {
+            return; // we created a config here before; if it's gone the user deleted it - don't fight
+        }
+        const hasConfig = await _hasProjectConfig();
+        if (_projectChangedSince(rootPath) || hasConfig) {
+            return; // project switched mid-read, or already scoped - nothing to do
+        }
+        // The opened file being .ts/.tsx is itself proof of a TS project (skip the scan); otherwise
+        // scan for a real .ts file elsewhere in the project.
+        const hasTs = (TS_LANGUAGES.indexOf(lang) !== -1) || (await _projectHasTsFiles());
+        if (_projectChangedSince(rootPath)) {
+            return;
+        }
+        const ok = await _writeConfig(false);
+        if (ok) {
+            _showEnabledToast(hasTs);
+        }
+    }
+
+    /**
+     * Public entry for the Problems-panel re-enable affordance: (re)create the config for the
+     * current project and reuse the same enabled-toast flow as auto-enable. The label comes from the
+     * active file's language (instant) rather than a full project scan, so the toast isn't delayed.
+     */
+    function promptEnable() {
+        const editor = EditorManager.getActiveEditor();
+        const lang = editor && editor.document && editor.document.getLanguage().getId();
+        const isTs = TS_LANGUAGES.indexOf(lang) !== -1;
+        _writeConfig(false).then(function (ok) {
+            if (!ok) {
+                return;
+            }
+            _updatePanelRow(); // config exists again - hide the re-enable row
+            _showEnabledToast(isTs);
+        });
+    }
+
+    /**
+     * @param {{supportedLanguages: Array<string>, restartServer: function}} options
+     */
+    function init(options) {
+        _options = options || {};
+        EditorManager.on("activeEditorChange.tsCodeIntel", function (evt, current) {
+            _autoEnable(current);
+            _updatePanelRow(); // the row depends on the active file's language
+        });
+        // Also catch switches to non-editor views (image/preview) where activeEditorChange may not fire.
+        MainViewManager.on("currentFileChange.tsCodeIntel", _updatePanelRow);
+        // A pending toast belongs to the project that was open when it appeared - drop it on switch;
+        // also refresh the Problems-panel re-enable row for the new project.
+        ProjectManager.on(ProjectManager.EVENT_PROJECT_OPEN + ".tsCodeIntel", function () {
+            _dismissActiveNotification();
+            _updatePanelRow();
+        });
+        // Evaluate the file already showing at startup (the common "restored a JS file" case).
+        _autoEnable(EditorManager.getActiveEditor());
+        _updatePanelRow();
+    }
+
+    exports.init = init;
+    exports.promptEnable = promptEnable;
+});

--- a/src/extensions/default/TypeScriptSupport/main.js
+++ b/src/extensions/default/TypeScriptSupport/main.js
@@ -283,13 +283,15 @@ define(function (require, exports, module) {
             }
         });
 
-        // Restart the server against the new workspace root when the project changes, and
-        // re-evaluate whether the new project type-checks its JS.
+        // Re-point the server at the new workspace root when the project changes, and re-evaluate
+        // whether the new project type-checks its JS. This uses workspace/didChangeWorkspaceFolders
+        // (no process restart, so no tsserver cold start) and only falls back to a full restart for
+        // servers that don't support live workspace-folder changes.
         ProjectManager.on(ProjectManager.EVENT_PROJECT_OPEN, function () {
             _refreshCheckJs();
             if (registered) {
                 loadLSPClient().then(function (LSPClient) {
-                    LSPClient.restartLanguageServer(SERVER_ID);
+                    LSPClient.changeWorkspaceRoot(SERVER_ID);
                 });
             }
         });

--- a/src/extensions/default/TypeScriptSupport/main.js
+++ b/src/extensions/default/TypeScriptSupport/main.js
@@ -34,7 +34,8 @@ define(function (require, exports, module) {
         ProjectManager = brackets.getModule("project/ProjectManager"),
         DocumentManager = brackets.getModule("document/DocumentManager"),
         FileSystem = brackets.getModule("filesystem/FileSystem"),
-        NodeConnector = brackets.getModule("NodeConnector");
+        NodeConnector = brackets.getModule("NodeConnector"),
+        CodeIntelligence = require("./CodeIntelligence");
 
     const SERVER_ID = "typescript";
     const SUPPORTED_LANGUAGES = ["javascript", "typescript", "jsx", "tsx"];
@@ -267,6 +268,19 @@ define(function (require, exports, module) {
         }).finally(function () {
             // Signal for integration tests that the server start has been attempted/settled.
             window._TypeScriptSupportReadyToIntegTest = true;
+        });
+
+        // Offer project-wide code intelligence (creates a default ts/jsconfig) when a JS/TS file is
+        // opened in a project that has no config yet. Projects that already carry one are silent.
+        CodeIntelligence.init({
+            supportedLanguages: SUPPORTED_LANGUAGES,
+            restartServer: function () {
+                if (registered) {
+                    loadLSPClient().then(function (LSPClient) {
+                        LSPClient.restartLanguageServer(SERVER_ID);
+                    });
+                }
+            }
         });
 
         // Restart the server against the new workspace root when the project changes, and

--- a/src/extensions/default/TypeScriptSupport/unittests.js
+++ b/src/extensions/default/TypeScriptSupport/unittests.js
@@ -59,7 +59,18 @@ define(function (require, exports, module) {
             await awaitsFor(function () {
                 return testWindow._TypeScriptSupportReadyToIntegTest;
             }, "TypeScript LSP server to start", 30000);
-        }, 30000);
+
+            // Warm up tsserver. Its very first request pays a large one-time cost - spawning node,
+            // launching vtsls, and loading the TypeScript library + project - which on a slow/loaded
+            // CI runner can exceed a single spec's timeout (fast dev machines never see it). Pay it
+            // once here with a generous budget so every spec below talks to an already-primed server;
+            // later project-switch restarts reuse the warm process and are fast.
+            await SpecRunnerUtils.loadProjectInTestWindow(testFolder + "ts/");
+            await awaitsForDone(SpecRunnerUtils.openProjectFiles(["type-error.ts"]), "warm-up: open type-error.ts");
+            await awaitsFor(function () {
+                return $("#problems-panel").text().includes("not assignable");
+            }, "tsserver to warm up on first cold start", 90000);
+        }, 100000);
 
         afterAll(async function () {
             testWindow = null;
@@ -85,8 +96,8 @@ define(function (require, exports, module) {
             // type-error.ts assigns a string to a `number` -> TS2322 "... not assignable ...".
             await awaitsFor(function () {
                 return panelText().includes("not assignable");
-            }, "TypeScript type error to be reported", 20000);
-        }, 30000);
+            }, "TypeScript type error to be reported", 30000);
+        }, 45000);
 
         it("should report implicit-any in a JS project that opts into checkJs", async function () {
             // js-checkjs has a jsconfig.json with checkJs + noImplicitAny, so the untyped parameter
@@ -94,8 +105,8 @@ define(function (require, exports, module) {
             await _openInProject("js-checkjs/", "implicit.js");
             await awaitsFor(function () {
                 return panelText().includes(IMPLICIT_ANY_MESSAGE);
-            }, "implicit-any to be reported under checkJs", 20000);
-        }, 30000);
+            }, "implicit-any to be reported under checkJs", 30000);
+        }, 45000);
 
         it("should NOT report implicit-any in a plain JS project", async function () {
             // Precondition: confirm the server actually produces implicit-any for this exact code
@@ -103,16 +114,16 @@ define(function (require, exports, module) {
             await _openInProject("js-checkjs/", "implicit.js");
             await awaitsFor(function () {
                 return panelText().includes(IMPLICIT_ANY_MESSAGE);
-            }, "implicit-any under checkJs (precondition)", 20000);
+            }, "implicit-any under checkJs (precondition)", 30000);
 
             // Same code in a plain JS project (no jsconfig / no @ts-check): the "go add types" nag
             // must not appear. Wait for inspection to settle clean, then assert it is absent.
             await _openInProject("js-plain/", "implicit.js");
             await awaitsFor(function () {
                 return $("#status-inspection").hasClass("inspection-valid");
-            }, "plain JS inspection to settle with no problems", 20000);
+            }, "plain JS inspection to settle with no problems", 30000);
             expect(panelText().includes(IMPLICIT_ANY_MESSAGE)).toBe(false);
-        }, 30000);
+        }, 75000);
 
         // ----- hover quick-actions (Go to Definition / Find Usages) -------------------------------
 
@@ -138,7 +149,7 @@ define(function (require, exports, module) {
                 await awaitsFor(async function () {
                     popover = await _hoverPopoverAt(editor, CALL_LINE, CALL_CH);
                     return !!(popover && popover.content && popover.content.find(".lsp-hover-action").length === 2);
-                }, "hover quick actions to appear", 20000);
+                }, "hover quick actions to appear", 30000);
 
                 const labels = popover.content.find(".lsp-hover-action-label").map(function () {
                     return $(this).text();
@@ -158,16 +169,16 @@ define(function (require, exports, module) {
                         $act.trigger("click");
                     }
                     return EditorManager.getCurrentFullEditor().getCursorPos().line === DECL_LINE;
-                }, "Go to Definition to navigate to the declaration", 25000);
+                }, "Go to Definition to navigate to the declaration", 30000);
                 expect(EditorManager.getCurrentFullEditor().getCursorPos().line).toBe(DECL_LINE);
-            }, 40000);
+            }, 75000);
 
             it("hover Find Usages opens the references panel (" + tc.ext + ")", async function () {
                 await _openInProject(tc.folder, tc.file);
                 const editor = EditorManager.getCurrentFullEditor();
                 await awaitsFor(async function () {
                     return !!(await _hoverPopoverAt(editor, CALL_LINE, CALL_CH));
-                }, "hover popover to be available", 20000);
+                }, "hover popover to be available", 30000);
 
                 // "Find Usages" is the right-aligned action; clicking it opens the references panel.
                 // Retry through the hover until the panel opens (the server may still be indexing).
@@ -181,9 +192,9 @@ define(function (require, exports, module) {
                         $end.trigger("click");
                     }
                     return $("#reference-in-files-results").is(":visible");
-                }, "references panel to open", 25000);
+                }, "references panel to open", 30000);
                 expect($("#reference-in-files-results").is(":visible")).toBe(true);
-            }, 40000);
+            }, 75000);
         });
     });
 });

--- a/src/languageTools/DefaultProviders.js
+++ b/src/languageTools/DefaultProviders.js
@@ -57,6 +57,30 @@ define(function (require, exports, module) {
         }
     }
 
+    // Syntax-highlight fenced code blocks (the signature/examples in completion docs) with the
+    // globally available highlight.js, so they read like code instead of flat monospace. Theme-aware
+    // token colours live in src/styles/brackets.less (.lsp-hint-doc-popup, shared with the hover).
+    function _highlightCode(html) {
+        var hljs = (typeof Phoenix !== "undefined") && Phoenix.libs && Phoenix.libs.hljs;
+        if (!hljs) {
+            return html;
+        }
+        var $wrap = $("<div>").html(html);
+        $wrap.find("pre > code").each(function () {
+            var $code = $(this);
+            var match = ($code.attr("class") || "").match(/language-([\w-]+)/);
+            var lang = match && match[1];
+            if (lang && hljs.getLanguage(lang)) {
+                try {
+                    $code.html(hljs.highlight($code.text(), { language: lang }).value).addClass("hljs");
+                } catch (e) {
+                    // leave the block unhighlighted on any hljs error
+                }
+            }
+        });
+        return $wrap.html();
+    }
+
     function _docToHtml(documentation) {
         if (!documentation) {
             return "";
@@ -66,7 +90,7 @@ define(function (require, exports, module) {
             return "";
         }
         try {
-            return marked.parse(md);
+            return _highlightCode(marked.parse(md));
         } catch (e) {
             return _.escape(md);
         }

--- a/src/languageTools/LSPClient.js
+++ b/src/languageTools/LSPClient.js
@@ -167,6 +167,12 @@ define(function (require, exports, module) {
         if (!client) {
             return;
         }
+        if (client._stopping) {
+            // The server is shutting down/restarting. Ignore any late messages it emits during the
+            // teardown window so stale diagnostics from the dying instance don't leak into the fresh
+            // one that replaces it (both share the same serverId).
+            return;
+        }
         if (data.method === "textDocument/publishDiagnostics" && client.lintingProvider) {
             const params = data.params || {};
             // Rewrite the URI to a VFS-based URI so the linting provider keys results by the
@@ -647,6 +653,27 @@ define(function (require, exports, module) {
      * @param {string} serverId
      * @return {Promise<void>}
      */
+    // How long to wait for a server to acknowledge a graceful `shutdown` before we hard-kill it.
+    // Healthy servers reply in well under this; the cap is a failsafe so a slow/buggy/hung server
+    // can't stall the restart indefinitely.
+    const SHUTDOWN_TIMEOUT_MS = 3000;
+
+    // Resolve/reject with `promise`, but reject with a timeout error if it doesn't settle in `ms`.
+    function _withTimeout(promise, ms) {
+        return new Promise(function (resolve, reject) {
+            const timer = setTimeout(function () {
+                reject(new Error("timeout"));
+            }, ms);
+            promise.then(function (value) {
+                clearTimeout(timer);
+                resolve(value);
+            }, function (err) {
+                clearTimeout(timer);
+                reject(err);
+            });
+        });
+    }
+
     async function restartLanguageServer(serverId) {
         const client = clients.get(serverId);
         if (!client) {
@@ -676,11 +703,19 @@ define(function (require, exports, module) {
         client.capabilities = null;
         client._completionCache = null;
         DocumentSync.clearServer(client);
+        // Attempt a graceful LSP shutdown - some servers need it to flush state or clean up child
+        // processes - but BOUND it. The `shutdown` request blocks until the server replies, and a
+        // busy or cold server can be slow (or never reply), which would stall the restart; on a
+        // project switch we'd end up waiting for the old server to finish booting just to tell it to
+        // die, then cold-start a new one (a double penalty on slow CI). Give it a short budget, then
+        // hard-kill regardless. The `exit` notification expects no reply, so it stays cheap.
         try {
-            await conn.execPeer("sendRequest", { serverId: client.serverId, method: "shutdown", params: null });
+            await _withTimeout(
+                conn.execPeer("sendRequest", { serverId: client.serverId, method: "shutdown", params: null }),
+                SHUTDOWN_TIMEOUT_MS);
             await conn.execPeer("sendNotification", { serverId: client.serverId, method: "exit", params: null });
         } catch (e) {
-            // Server may already be dead; fall through to a hard stop.
+            // Timed out, or the server is already dead - fall through to the hard stop.
         }
         await conn.execPeer("stopServer", { serverId: client.serverId });
         client._stopping = false;

--- a/src/languageTools/LSPClient.js
+++ b/src/languageTools/LSPClient.js
@@ -539,6 +539,11 @@ define(function (require, exports, module) {
         const rootVfsPath = (config.rootUriProvider && config.rootUriProvider()) || _projectRootPath();
         const rootUri = rootVfsPath ? pathToServerUri(rootVfsPath) : null;
         const rootName = rootVfsPath ? FileUtils.getBaseName(rootVfsPath) : "root";
+        // Remember the active workspace folder so a later project switch can hand the server the
+        // delta (removed old, added new) via workspace/didChangeWorkspaceFolders - see
+        // changeWorkspaceRoot - instead of a full restart.
+        client.rootUri = rootUri;
+        client.rootName = rootName;
 
         await conn.execPeer("startServer", {
             serverId: client.serverId,
@@ -674,6 +679,53 @@ define(function (require, exports, module) {
         });
     }
 
+    /**
+     * Re-point a running server at the current project root WITHOUT restarting it, by sending
+     * `workspace/didChangeWorkspaceFolders` (remove the old folder, add the new one). This avoids
+     * the cold start a full restart pays on every project switch. Generic: servers that don't
+     * advertise live workspace-folder change support transparently fall back to a full restart.
+     * The open documents themselves are re-synced by DocumentSync's normal editor-change handling.
+     * @param {string} serverId
+     * @return {Promise<void>}
+     */
+    async function changeWorkspaceRoot(serverId) {
+        const client = clients.get(serverId);
+        if (!client) {
+            return;
+        }
+        // Not up yet (e.g. the project switched before init finished) - a (re)start picks up the
+        // current root on its own.
+        if (!client.capabilities) {
+            return restartLanguageServer(serverId);
+        }
+        const wf = client.capabilities.workspace && client.capabilities.workspace.workspaceFolders;
+        // Per the LSP spec changeNotifications is `boolean | string` (a static flag or a dynamic
+        // registration id); either truthy form means the server accepts live folder changes.
+        const supportsLiveChange = !!(wf && wf.supported && wf.changeNotifications);
+        if (!supportsLiveChange) {
+            return restartLanguageServer(serverId);
+        }
+        const newVfsPath = (client.config.rootUriProvider && client.config.rootUriProvider()) || _projectRootPath();
+        const newUri = newVfsPath ? pathToServerUri(newVfsPath) : null;
+        const oldUri = client.rootUri || null;
+        if (newUri === oldUri) {
+            return; // same workspace - nothing to do
+        }
+        const conn = await getConnector();
+        const added = newUri ? [{ uri: newUri, name: FileUtils.getBaseName(newVfsPath) }] : [];
+        const removed = oldUri ? [{ uri: oldUri, name: client.rootName || FileUtils.getBaseName(oldUri) }] : [];
+        await conn.execPeer("sendNotification", {
+            serverId: serverId,
+            method: "workspace/didChangeWorkspaceFolders",
+            params: { event: { added: added, removed: removed } }
+        });
+        client.rootUri = newUri;
+        client.rootName = newVfsPath ? FileUtils.getBaseName(newVfsPath) : null;
+        // Capabilities are unchanged (no restart), but the active file is now in the new project -
+        // refresh the find-references menu state for that context.
+        FindReferencesManager.setMenuItemStateForLanguage();
+    }
+
     async function restartLanguageServer(serverId) {
         const client = clients.get(serverId);
         if (!client) {
@@ -723,6 +775,7 @@ define(function (require, exports, module) {
 
     exports.registerLanguageServer = registerLanguageServer;
     exports.restartLanguageServer = restartLanguageServer;
+    exports.changeWorkspaceRoot = changeWorkspaceRoot;
     exports.pathToServerUri = pathToServerUri;
     exports.serverUriToVfsUri = serverUriToVfsUri;
 });

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -1736,6 +1736,17 @@ define({
     "OPEN_PREFERENNCES": "Open Preferences",
 
     "FIND_ALL_REFERENCES": "Find Usages",
+    // Project-wide code intelligence (TypeScript/JavaScript LSP) - on by default
+    "CODE_INTEL_JS": "JavaScript",
+    "CODE_INTEL_TS": "TypeScript",
+    "CODE_INTEL_ENABLED_TITLE": "{0} Code Intelligence Enabled",
+    "CODE_INTEL_ENABLED_MESSAGE": "Find Usages, Rename, and Go to Definition now work across every file in this project.",
+    "CODE_INTEL_SEE_CONFIG": "See Config",
+    "CODE_INTEL_ENABLE_TS": "Enable TypeScript",
+    "CODE_INTEL_LEARN_MORE": "Learn more",
+    "CODE_INTEL_PANEL_TEXT": "Project-wide code intelligence is off. Enable it for Find Usages, Rename, and Go to Definition across every file — adds a jsconfig.json to the project root.",
+    "CODE_INTEL_PANEL_ENABLE": "Enable",
+    "CODE_INTEL_PANEL_DISMISS": "Dismiss",
     "REFERENCES_IN_FILES": "references",
     "REFERENCE_IN_FILES": "reference",
     "REFERENCES_NO_RESULTS": "No References available for current cursor position",

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -2143,6 +2143,82 @@ a, img {
 }
 
 // LSP hover documentation (rendered inside #quick-view-container)
+// Problems-panel re-enable row (TypeScriptSupport/CodeIntelligence.js).
+.ts-code-intel-panel-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 8px 12px;
+    border-bottom: 1px solid @bc-panel-separator;
+    background: @bc-panel-bg-promoted;
+    font-size: 13px;
+    .ts-code-intel-panel-text {
+        flex: 1;
+        color: @bc-text;
+        line-height: 1.5;
+    }
+    .ts-code-intel-panel-enable {
+        flex: none;
+        margin: 0;
+    }
+    .ts-code-intel-panel-close {
+        flex: none;
+        cursor: pointer;
+        color: @bc-text-quiet;
+        font-size: 17px;
+        line-height: 1;
+        padding: 0 2px;
+        text-decoration: none;
+        &:hover { color: @bc-text; text-decoration: none; }
+    }
+    .dark & {
+        background: @dark-bc-panel-bg-promoted;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+        .ts-code-intel-panel-text { color: @dark-bc-text; }
+        .ts-code-intel-panel-close {
+            color: #888;
+            &:hover { color: @dark-bc-text; }
+        }
+    }
+}
+
+// Project-wide code intelligence toast inner layout (TypeScriptSupport/CodeIntelligence.js).
+// The surface comes from the reusable NotificationUI `SUBTLE` style; this is just the content.
+.ts-code-intel-toast {
+    .ts-code-intel-msg {
+        font-size: 12px;
+        line-height: 1.45;
+        margin: 0;
+    }
+    .ts-code-intel-buttons {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 4px 14px;
+        margin-top: 12px;
+    }
+    // flat text actions - no chunky button chrome
+    .ts-code-intel-action {
+        background: none;
+        border: none;
+        box-shadow: none;
+        margin: 0;
+        padding: 0;
+        font-size: 12px;
+        line-height: 1.6;
+        cursor: pointer;
+        color: #0a6cbf;
+        &:hover { color: #085699; text-decoration: underline; }
+        &:focus { outline: none; box-shadow: none; }
+    }
+    .dark & {
+        .ts-code-intel-action {
+            color: #6cb6ff;
+            &:hover { color: #8cc6ff; }
+        }
+    }
+}
+
 .lsp-hover-quickview {
     text-align: left;
     max-width: 520px;
@@ -3914,6 +3990,29 @@ label input {
     a {
         color: white;
         cursor: pointer;
+    }
+}
+// SUBTLE: a quiet, theme-matching surface instead of a bright colored toast.
+.notification-popup-container.style-subtle {
+    background: #ffffff;
+    color: #5a5f66;
+    border: 1px solid rgba(0, 0, 0, 0.12);
+    .notification-dialog-title {
+        color: #1c1c1c;
+        font-weight: 600;
+        font-size: 13px;
+    }
+    .notification-popup-close-button {
+        color: #9aa0a6;
+        font-weight: 400;
+    }
+    a { cursor: pointer; }
+    .dark & {
+        background: #2b2f36;
+        color: #9aa0a6;
+        border: 1px solid rgba(255, 255, 255, 0.10);
+        .notification-dialog-title { color: #eceef0; }
+        .notification-popup-close-button { color: #9aa0a6; }
     }
 }
 

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -2269,28 +2269,8 @@ a, img {
         }
     }
 
-    // highlight.js token colours for the signature block. The app's global hljs theme is
-    // github-dark (locked, for the always-dark sidebar); override it within the hover so the
-    // signature reads well on the light theme too. The chip background follows the editor theme,
-    // so we use a GitHub-light palette in light mode and a GitHub-dark palette in dark mode.
-    pre code.hljs { background: none; }
-    .hljs-keyword, .hljs-literal, .hljs-doctag, .hljs-meta .hljs-keyword { color: #cf222e; }
-    .hljs-string, .hljs-regexp, .hljs-meta-string { color: #0a3069; }
-    .hljs-title, .hljs-title.function_, .hljs-title.class_, .hljs-section { color: #6639ba; }
-    .hljs-built_in, .hljs-type, .hljs-class .hljs-title { color: #953800; }
-    .hljs-number, .hljs-symbol, .hljs-bullet { color: #0550ae; }
-    .hljs-attr, .hljs-attribute, .hljs-property, .hljs-variable, .hljs-params { color: @bc-text-emphasized; }
-    .hljs-comment, .hljs-quote, .hljs-meta { color: #6e7781; }
-
-    .dark & {
-        .hljs-keyword, .hljs-literal, .hljs-doctag, .hljs-meta .hljs-keyword { color: #ff7b72; }
-        .hljs-string, .hljs-regexp, .hljs-meta-string { color: #a5d6ff; }
-        .hljs-title, .hljs-title.function_, .hljs-title.class_, .hljs-section { color: #d2a8ff; }
-        .hljs-built_in, .hljs-type, .hljs-class .hljs-title { color: #ffa657; }
-        .hljs-number, .hljs-symbol, .hljs-bullet { color: #79c0ff; }
-        .hljs-attr, .hljs-attribute, .hljs-property, .hljs-variable, .hljs-params { color: @dark-bc-text-emphasized; }
-        .hljs-comment, .hljs-quote, .hljs-meta { color: #8b949e; }
-    }
+    // hljs token colours for the signature block are shared with the code-hint doc popup -
+    // see the `.lsp-hover-quickview, .lsp-hint-doc-popup` rule below.
 
     // Inline code: parameter names, types, identifiers.
     code {
@@ -2433,6 +2413,31 @@ a, img {
 }
 
 // LSP code-hint documentation popup (shown beside the code hint list)
+// Shared highlight.js token colours for both LSP popups (hover signature + code-hint docs). The
+// app's global hljs theme is github-dark (locked, for the always-dark sidebar); these override it
+// so highlighted code reads well on the light theme too - GitHub-light palette in light mode,
+// GitHub-dark in dark mode. `&` is the popup selector, so `.dark &` scopes both correctly.
+.lsp-hover-quickview, .lsp-hint-doc-popup {
+    pre code.hljs { background: none; }
+    .hljs-keyword, .hljs-literal, .hljs-doctag, .hljs-meta .hljs-keyword { color: #cf222e; }
+    .hljs-string, .hljs-regexp, .hljs-meta-string { color: #0a3069; }
+    .hljs-title, .hljs-title.function_, .hljs-title.class_, .hljs-section { color: #6639ba; }
+    .hljs-built_in, .hljs-type, .hljs-class .hljs-title { color: #953800; }
+    .hljs-number, .hljs-symbol, .hljs-bullet { color: #0550ae; }
+    .hljs-attr, .hljs-attribute, .hljs-property, .hljs-variable, .hljs-params { color: @bc-text-emphasized; }
+    .hljs-comment, .hljs-quote, .hljs-meta { color: #6e7781; }
+
+    .dark & {
+        .hljs-keyword, .hljs-literal, .hljs-doctag, .hljs-meta .hljs-keyword { color: #ff7b72; }
+        .hljs-string, .hljs-regexp, .hljs-meta-string { color: #a5d6ff; }
+        .hljs-title, .hljs-title.function_, .hljs-title.class_, .hljs-section { color: #d2a8ff; }
+        .hljs-built_in, .hljs-type, .hljs-class .hljs-title { color: #ffa657; }
+        .hljs-number, .hljs-symbol, .hljs-bullet { color: #79c0ff; }
+        .hljs-attr, .hljs-attribute, .hljs-property, .hljs-variable, .hljs-params { color: @dark-bc-text-emphasized; }
+        .hljs-comment, .hljs-quote, .hljs-meta { color: #8b949e; }
+    }
+}
+
 .lsp-hint-doc-popup {
     display: none;
     position: fixed;

--- a/src/widgets/NotificationUI.js
+++ b/src/widgets/NotificationUI.js
@@ -83,7 +83,9 @@ define(function (require, exports, module) {
         WARNING: "style-warning",
         SUCCESS: "style-success",
         ERROR: "style-error",
-        DANGER: "style-danger"
+        DANGER: "style-danger",
+        // A quiet, theme-matching surface (not a bright colored toast) for low-key notifications.
+        SUBTLE: "style-subtle"
     };
 
     /**

--- a/test/spec/EditorCommandHandlers-integ-test.js
+++ b/test/spec/EditorCommandHandlers-integ-test.js
@@ -191,35 +191,44 @@ define(function (require, exports, module) {
 
         describe("Editor Navigation Commands", function () {
             it("should jump to definition", async function () {
-                var promise,
-                    selection;
-                promise = CommandManager.execute(Commands.CMD_ADD_TO_WORKINGSET_AND_OPEN, {fullPath: testPath + "/test.js"});
-                await awaitsForDone(promise, "Open into working set");
-
+                var selection;
+                await awaitsForDone(
+                    CommandManager.execute(Commands.CMD_ADD_TO_WORKINGSET_AND_OPEN, {fullPath: testPath + "/test.js"}),
+                    "Open into working set");
                 myEditor = EditorManager.getCurrentFullEditor();
-                myEditor.setCursorPos({line: 5, ch: 8});
-                await awaits(1500); // for the code intelligence framework to prime up
-                promise = CommandManager.execute(Commands.NAVIGATE_JUMPTO_DEFINITION);
-                await awaitsForDone(promise, "Jump To Definition");
 
-                selection = myEditor.getSelection();
                 if (window.Phoenix.isNativeApp) {
-                    // Desktop has the LSP server (vtsls), which now provides jump-to-definition
-                    // for JavaScript (higher priority than the built-in Tern provider). vtsls
-                    // returns the full declaration range of testMe and we jump to its start
-                    // (the `function` keyword), giving a collapsed cursor at {0,0} - whereas Tern
-                    // selects the identifier name. Both correctly land on the testMe definition.
+                    // Desktop has the LSP server (vtsls), which provides jump-to-definition for
+                    // JavaScript at a higher priority than the built-in Tern provider. vtsls returns
+                    // testMe's full declaration range and we jump to its start (the `function`
+                    // keyword), giving a collapsed cursor at {0,0} - whereas Tern selects the
+                    // identifier name. The server can take a moment to prime after the file opens, so
+                    // retry the jump until the LSP result lands rather than using a fixed wait (which
+                    // flakes on slow CI: before vtsls is ready, Tern answers with {0,9}-{0,15}).
+                    await awaitsFor(async function () {
+                        myEditor.setCursorPos({line: 5, ch: 8});
+                        await awaitsForDone(CommandManager.execute(Commands.NAVIGATE_JUMPTO_DEFINITION),
+                            "Jump To Definition");
+                        var sel = myEditor.getSelection();
+                        return sel.start.line === 0 && sel.start.ch === 0 &&
+                            sel.end.line === 0 && sel.end.ch === 0;
+                    }, "LSP jump-to-definition to land on the testMe declaration", 30000);
+                    selection = myEditor.getSelection();
                     expect(fixSel(selection)).toEql(fixSel({
                         start: {line: 0, ch: 0},
                         end: {line: 0, ch: 0}
                     }));
                 } else {
+                    myEditor.setCursorPos({line: 5, ch: 8});
+                    await awaitsForDone(CommandManager.execute(Commands.NAVIGATE_JUMPTO_DEFINITION),
+                        "Jump To Definition");
+                    selection = myEditor.getSelection();
                     expect(fixSel(selection)).toEql(fixSel({
                         start: {line: 0, ch: 9},
                         end: {line: 0, ch: 15}
                     }));
                 }
-            });
+            }, 35000);
         });
 
         if(window.Phoenix.isNativeApp) {


### PR DESCRIPTION
On the first JS/TS file opened in a config-less project, create a jsconfig.json so vtsls scopes the whole project (cross-file Find Usages, Rename, Go to Definition) and show an unobtrusive toast with See Config / Enable TypeScript / Learn more. The toast uses a new reusable SUBTLE NotificationUI style and opens instantly (instantOpen).

Deleting the config opts out (remembered per project via a 'created' flag, so it is not recreated); the Problems panel then shows a re-enable row for JS/TS files. Always creates jsconfig.json (editor-only, never affects builds) which still scopes .ts files. Desktop-only; skipped in test windows.
