### PR TITLE
fix: show platform display path instead of /tauri/ virtual path for media files

### DIFF
--- a/src/editor/ImageViewer.js
+++ b/src/editor/ImageViewer.js
@@ -67,7 +67,7 @@ define(function (require, exports, module) {
         this._scale = 100;           // 100%
         this._scaleDivInfo = null;   // coordinates of hidden scale sticker
 
-        this.relPath = ProjectManager.makeProjectRelativeIfPossible(this.file.fullPath);
+        this.relPath = ProjectManager.getProjectRelativeOrDisplayPath(this.file.fullPath);
 
         this.$imagePath = this.$el.find(".image-path");
         this.$imagePreview = this.$el.find(".image-preview");
@@ -108,7 +108,7 @@ define(function (require, exports, module) {
          * so we just need to see if the file has the same path as our image
          */
         if (this.file.fullPath === newPath) {
-            this.relPath = ProjectManager.makeProjectRelativeIfPossible(newPath);
+            this.relPath = ProjectManager.getProjectRelativeOrDisplayPath(newPath);
             this.$imagePath.text(this.relPath).attr("title", this.relPath);
         }
     };

--- a/src/editor/MediaViewer.js
+++ b/src/editor/MediaViewer.js
@@ -117,7 +117,7 @@ define(function (require, exports, module) {
         this._naturalWidth = 0;
         this._naturalHeight = 0;
 
-        this.relPath = ProjectManager.makeProjectRelativeIfPossible(this.file.fullPath);
+        this.relPath = ProjectManager.getProjectRelativeOrDisplayPath(this.file.fullPath);
 
         this.$mediaPath = this.$el.find(".media-path");
         this.$mediaPreview = this.$el.find(".media-preview");
@@ -175,7 +175,7 @@ define(function (require, exports, module) {
      */
     MediaView.prototype._onFilenameChange = function (e, oldPath, newPath) {
         if (this.file.fullPath === newPath) {
-            this.relPath = ProjectManager.makeProjectRelativeIfPossible(newPath);
+            this.relPath = ProjectManager.getProjectRelativeOrDisplayPath(newPath);
             this.$mediaPath.text(this.relPath).attr("title", this.relPath);
         }
     };


### PR DESCRIPTION
Media and image preview panes used makeProjectRelativeIfPossible(), which returns out-of-project paths unmodified, leaking the /tauri/ virtual path prefix into the header for files outside the current project. Use getProjectRelativeOrDisplayPath() so the path is run through Phoenix.app.getDisplayPath() and shown as the real platform path.
