### PR TITLE
feat(ai): strings and styles for enable-AI checkbox in settings dialog

### DIFF
--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -2737,6 +2737,8 @@ define({
     "AI_SETTINGS_NAME_REQUIRED": "Provider name is required.",
     "AI_SETTINGS_NAME_DUPLICATE": "A provider with this name already exists.",
     "AI_SETTINGS_DONE": "Done",
+    "AI_SETTINGS_ENABLE_AI": "Enable AI features",
+    "AI_SETTINGS_ENABLE_AI_NOTE": "Turns all AI features in {APP_NAME} on or off. Takes effect after restart — you can enable it again anytime from <span class='ai-settings-menu-path'>View menu &gt; Enable AI</span>.",
 
     // demo start - Phoenix Code Playground - Interactive Onboarding
     "DEMO_SECTION1_TITLE": "Edit in Live Preview",

--- a/src/styles/Extn-AIChatPanel.less
+++ b/src/styles/Extn-AIChatPanel.less
@@ -3499,7 +3499,7 @@
 
     .ai-settings-provider-url {
         font-size: @ai-text-meta;
-        color: @bc-text-quiet;
+        color: @bc-text-medium;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
@@ -3601,6 +3601,62 @@
                     color: @dark-bc-text-quiet;
                     opacity: 0.7;
                 }
+            }
+        }
+    }
+
+    .ai-settings-enable-row {
+        display: flex;
+        align-items: flex-start;
+        gap: 8px;
+        margin: 0;
+        cursor: pointer;
+
+        input[type="checkbox"] {
+            margin: 2px 0 0;
+            flex-shrink: 0;
+            cursor: pointer;
+        }
+    }
+
+    .ai-settings-enable-text {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        min-width: 0;
+    }
+
+    .ai-settings-enable-label {
+        font-size: @ai-text-body;
+        font-weight: 600;
+        color: @bc-text;
+
+        .dark & {
+            color: @dark-bc-text;
+        }
+    }
+
+    .ai-settings-enable-note {
+        font-size: @ai-text-meta;
+        color: @bc-text-medium;
+
+        .dark & {
+            color: @dark-bc-text-quiet;
+        }
+
+        .ai-settings-menu-path {
+            display: inline-block;
+            padding: 0 5px;
+            border: 1px solid @bc-panel-border;
+            border-radius: 3px;
+            background: @bc-panel-bg-alt;
+            color: @bc-text-medium;
+            white-space: nowrap;
+
+            .dark & {
+                border-color: @dark-bc-panel-border;
+                background: @dark-bc-panel-bg-alt;
+                color: @dark-bc-text-medium;
             }
         }
     }


### PR DESCRIPTION
Companion to the phoenix-pro change adding an 'Enable AI features' checkbox to the Claude Code settings dialog. Adds the two strings and the checkbox row/note/menu-path-chip styles. Also bumps the settings dialog secondary text (note, provider URL) from quiet to medium in light theme for readability.

<img width="618" height="471" alt="image" src="https://github.com/user-attachments/assets/459e0e45-a175-4686-b4c6-ba18c61f7b17" />
