### PR TITLE
ci: fix patch version bump PR push, upgrade actions to node24 runtimes

### DIFF
--- a/.github/workflows/patch-version-bump.yml
+++ b/.github/workflows/patch-version-bump.yml
@@ -9,12 +9,15 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version: 24
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           ref: main
+          # keep the checkout token in the local git config so that
+          # peter-evans/create-pull-request can push the bump branch
+          persist-credentials: true
       - name: Bump patch version
         run: |
           npm ci
@@ -26,7 +29,7 @@ jobs:
 
       - name: Create Bump patch version Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: 'ci: bump patch version to ${{ env.PHOENIX_VERSION }}'
           committer: GitHub <noreply@github.com>


### PR DESCRIPTION
checkout v5+ defaults persist-credentials to false, so set it explicitly to keep the token in the local git config for create-pull-request to push.

- actions/setup-node v3 -> v7
- actions/checkout v3 -> v7
- peter-evans/create-pull-request v4 -> v8

