### PR TITLE
fix: windows auto update fails as node 24 cannot load \\?\ prefixed script paths

### DIFF
--- a/src/extensionsIntegrated/appUpdater/main.js
+++ b/src/extensionsIntegrated/appUpdater/main.js
@@ -345,6 +345,11 @@ define(function (require, exports, module) {
             window.__TAURI__.path.resolveResource("src-node/installer/launch-windows-installer.js")
                 .then(async nodeSrcPath=>{
                     // this is not supposed to work in linux.
+                    // Strip Windows UNC prefix (\\?\) that Tauri adds on Windows as
+                    // Node 24 cannot load the entry script from \\?\ prefixed paths.
+                    if(nodeSrcPath.startsWith('\\\\?\\')){
+                        nodeSrcPath = nodeSrcPath.slice(4);
+                    }
                     const argsArray = [nodeSrcPath, appdataDir];
                     const command = window.__TAURI__.shell.Command.sidecar('phnode', argsArray);
                     command.on('close', data => {

--- a/src/tauri-updater.html
+++ b/src/tauri-updater.html
@@ -64,6 +64,11 @@
             window.__TAURI__.path.resolveResource("src-node/installer/download-file.js")
                 .then(async nodeSrcPath=>{
                     // this is not supposed to work in linux.
+                    // Strip Windows UNC prefix (\\?\) that Tauri adds on Windows as
+                    // Node 24 cannot load the entry script from \\?\ prefixed paths.
+                    if(nodeSrcPath.startsWith('\\\\?\\')){
+                        nodeSrcPath = nodeSrcPath.slice(4);
+                    }
                     const argsArray = [nodeSrcPath, argJson];
                     const command = window.__TAURI__.shell.Command.sidecar('phnode', argsArray);
                     command.on('close', data => {


### PR DESCRIPTION
Tauri's resolveResource() returns \\?\ long-path prefixed paths on windows, and the Node 24 based phnode sidecar crashes at startup when given such an entry script path (EISDIR on lstat 'C:'). This made the updater report a download error before the download even began.

node-loader.js already strips the prefix for the main node boot; apply the same strip to the two missed updater call sites (installer download and quit-time windows installer launch).
