### PR TITLE
fix(live-preview): release LiveHTMLDocument's doc ref when file is deleted

### DIFF
--- a/src/LiveDevelopment/MultiBrowserImpl/documents/LiveHTMLDocument.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/documents/LiveHTMLDocument.js
@@ -61,6 +61,9 @@ define(function (require, exports, module) {
         this._onChange = this._onChange.bind(this);
         this.doc.on("change", this._onChange);
 
+        this._onDeleted = this._onDeleted.bind(this);
+        this.doc.on("deleted", this._onDeleted);
+
         this._onRelated = this._onRelated.bind(this);
         this.protocol.on("DocumentRelated", this._onRelated);
 
@@ -152,6 +155,7 @@ define(function (require, exports, module) {
     LiveHTMLDocument.prototype.close = function () {
         this.doc.releaseRef();
         this.doc.off("change", this._onChange);
+        this.doc.off("deleted", this._onDeleted);
         this.protocol.off("DocumentRelated", this._onRelated);
         this.protocol.off("StylesheetAdded", this._onStylesheetAdded);
         this.protocol.off("StylesheetRemoved", this._onStylesheetRemoved);
@@ -159,6 +163,19 @@ define(function (require, exports, module) {
         this.protocol.off("ScriptRemoved", this._onScriptRemoved);
 
         this.parentClass.close.call(this);
+    };
+
+    /**
+     * @private
+     * Handles the backing Document's file being deleted from disk (eg. from the file tree).
+     * Without this, our extra addRef() on the doc (on top of any editor's own ref) would never
+     * be released - close() is otherwise only called by the live preview session lifecycle, not
+     * in response to the file disappearing.
+     * @param {$.Event} event
+     */
+    LiveHTMLDocument.prototype._onDeleted = function (event) {
+        this.close();
+        this.trigger("deleted", [this]);
     };
 
     /**

--- a/tracking-repos.json
+++ b/tracking-repos.json
@@ -1,5 +1,5 @@
 {
   "phoenixPro": {
-    "commitID": "f07435fe2714e57ca69f49634255aee36b4802ca"
+    "commitID": "a69d2ed60ccb04bd245508fb2b4df943d2f43cfa"
   }
 }


### PR DESCRIPTION
LiveHTMLDocument holds its own addRef() on the doc it's previewing, on top of any editor's ref, but only released it from close() - which is driven by the live preview session lifecycle, not by the file disappearing. Deleting the actively-previewed HTML file from the file tree left that ref dangling forever.

Mirrors LiveCSSDocument's existing "deleted" handling, which already does this correctly.
