### PR TITLE
feat(lsp): show a picker for jump-to-definition with multiple targets

### DIFF
--- a/src/features/QuickViewManager.js
+++ b/src/features/QuickViewManager.js
@@ -241,6 +241,23 @@ define(function (require, exports, module) {
         animationRequest,
         quickViewLocked = false;
 
+    // True while some other menu-like UI is open - the top menu bar, a context menu (including the
+    // editor's right-click menu), the autocomplete Code Hints list, or an InlineMenu picker like
+    // jump-to-definition's multi-target picker (see languageTools/DefaultProviders.js) or Extract
+    // to Variable/Function. QuickView shouldn't pop up while any of those has the user's attention.
+    // All of them share the same underlying convention - a `<li class="dropdown ...">` root that
+    // gets an "open" class added while shown (see command/Menus.js openMenu()/registerContextMenu()
+    // and the codehint-menu/inlinemenu-menu markup in CodeHintList.js/widgets/InlineMenu.js) - so
+    // one generic selector covers all of them, including any future dropdown-based popup, without
+    // needing to name each one. Checked live at draw time, deliberately not via an imperative
+    // suppress/unsuppress pairing: those callers can close their popup through several different
+    // paths (Esc, selecting an item, clicking elsewhere - InlineMenu in particular doesn't notify
+    // on a plain click-away), and a state flag that isn't reliably unset on every one of those
+    // paths gets stuck "suppressed" forever.
+    function _isOtherEditorPopupOpen() {
+        return $(".dropdown.open").length > 0;
+    }
+
     // Constants
     const CMD_ENABLE_QUICK_VIEW       = "view.enableQuickView",
         QUICK_VIEW_EDITOR_MARKER = 'quickViewMark',
@@ -599,7 +616,7 @@ define(function (require, exports, module) {
             clientY: event.clientY
         };
 
-        if (!enabled || quickViewLocked
+        if (!enabled || quickViewLocked || _isOtherEditorPopupOpen()
             || $previewContainer[0].contains(window.document.activeElement)) {
             // activeElement check as, if the popup has an active element, say a text input, user may
             // move the mouse outside popup to type in the input, in which case we should not close popup.

--- a/src/languageTools/DefaultProviders.js
+++ b/src/languageTools/DefaultProviders.js
@@ -953,6 +953,38 @@ define(function (require, exports, module) {
         return SIGNATURE_HLJS_LANG[id] || id;
     }
 
+    // A location's identity for deduplication - same file and same start *line*, deliberately not
+    // also the start character. Locations from different requests (definition vs. implementation)
+    // routinely name the same declaration while anchored at different columns on that declaration's
+    // line - e.g. gotoDefinition landing at column 0 (the very start of "export class JohnClass
+    // extends MyBaseClass") while gotoImplementation for the same class lands at the "JohnClass"
+    // identifier a few columns in. Keying on the exact character missed that case entirely (shown
+    // as two near-identical "JohnClass" entries instead of one) - a jump target is realistically
+    // always alone on its line, so same file + same line is a safe stand-in for "same target".
+    function _locationKey(location) {
+        return location.uri + ":" + location.range.start.line;
+    }
+
+    // Combines `primary` with `extras`, keeping first-seen order and dropping any of `extras` that
+    // point at the same place as `primary` or one another. Used so a location gotoDefinition
+    // already resolved is never silently thrown away in favor of gotoImplementation's answer - see
+    // fallBackToImplementations below - even though in practice the two usually end up naming the
+    // same target anyway (a single "definition" resolution for a polymorphic call almost always
+    // turns out to be one of the concrete implementations, not the base/interface declaration
+    // itself - LSP has no request that reliably returns that separately).
+    function mergeLocations(primary, extras) {
+        var seen = {},
+            merged = [];
+        [primary].concat(extras).forEach(function (location) {
+            var key = _locationKey(location);
+            if (!seen[key]) {
+                seen[key] = true;
+                merged.push(location);
+            }
+        });
+        return merged;
+    }
+
     function JumpToDefProvider(client) {
         this.client = client;
     }
@@ -1027,7 +1059,15 @@ define(function (require, exports, module) {
         // shown via a code-excerpt side popup as the user hovers/arrows through items, reusing the
         // exact same LSP hint documentation popup mechanism (_showDocPopup/_hideDocPopup) that the
         // autocomplete Code Hints list already uses for its side docs panel.
-        function showJumpTargetPicker(locations) {
+        //
+        // `implementationStartIndex` (optional): when the list is [declaration, ...implementations]
+        // (see fallBackToImplementations/mergeLocations - declaration is always first), this is the
+        // index implementations start at, so those rows get a small "Implementation" badge on the
+        // right - the declaration row otherwise looks identical to any of them, and with everything
+        // merged into one list there's no other visual cue for which is which. Omitted (or equal to
+        // locations.length) when the list is server-returned multi-definition results instead, none
+        // of which are "implementations" in this sense - no rows get the badge.
+        function showJumpTargetPicker(locations, implementationStartIndex) {
             Metrics.countEvent(Metrics.EVENT_TYPE.LSP, "def", "Multi." + metricLabel);
 
             var lineCache = {};
@@ -1052,6 +1092,18 @@ define(function (require, exports, module) {
                 // instead of context.
                 if (dirPath) {
                     name += " <span class=\"jump-to-def-item-path\">" + _.escape(dirPath) + "</span>";
+                }
+
+                // Plain inline content, same as the spans above - deliberately not a flex wrapper:
+                // that was tried and reliably added ~11px of unexplained row height, because a
+                // block-level flex child inside InlineMenu's own inline <span> wrapper
+                // (widgets/InlineMenu.js _addItem) gets boxed in an anonymous block that still
+                // carries the parent's own line-height as a "strut". Plain inline content doesn't
+                // have that problem.
+                if (implementationStartIndex !== undefined && index >= implementationStartIndex) {
+                    name += " <i class=\"fa fa-code-branch jump-to-def-item-badge\" title=\"" +
+                        _.escape(Strings.JUMPTO_DEFINITION_IMPLEMENTATION_BADGE) +
+                        "\" aria-hidden=\"true\"></i>";
                 }
 
                 return { id: index, name: name };
@@ -1161,12 +1213,13 @@ define(function (require, exports, module) {
                 filePath: docPath,
                 cursorPos: pos
             }).done(function (implResult) {
-                var implLocations = Array.isArray(implResult) ? implResult : (implResult ? [implResult] : []);
-                if (implLocations.length > 1) {
+                var implLocations = Array.isArray(implResult) ? implResult : (implResult ? [implResult] : []),
+                    merged = mergeLocations(singleLocation, implLocations);
+                if (merged.length > 1) {
                     Metrics.countEvent(Metrics.EVENT_TYPE.LSP, "def", "Impl." + metricLabel);
-                    showJumpTargetPicker(implLocations);
+                    showJumpTargetPicker(merged, 1); // merged[0] is always the declaration slot
                 } else {
-                    jumpToLocation(singleLocation);
+                    jumpToLocation(merged[0]);
                 }
             }).fail(function () {
                 jumpToLocation(singleLocation);
@@ -1651,4 +1704,5 @@ define(function (require, exports, module) {
     exports.hideHintDocPopup = _hideDocPopup;
     exports._docPopupHtml = _docPopupHtml; // exposed for unit tests
     exports._buildJumpToDefExcerpt = buildExcerpt; // exposed for unit tests
+    exports._mergeJumpToDefLocations = mergeLocations; // exposed for unit tests
 });

--- a/src/languageTools/DefaultProviders.js
+++ b/src/languageTools/DefaultProviders.js
@@ -32,15 +32,21 @@ define(function (require, exports, module) {
     var EditorManager = require("editor/EditorManager"),
       DocumentManager = require("document/DocumentManager"),
       PreferencesManager = require("preferences/PreferencesManager"),
+      ProjectManager = require("project/ProjectManager"),
       CommandManager = require("command/CommandManager"),
       Commands = require("command/Commands"),
       StringMatch = require("utils/StringMatch"),
       CodeInspection = require("language/CodeInspection"),
+      LanguageManager = require("language/LanguageManager"),
+      QuickViewManager = require("features/QuickViewManager"),
+      FileSystem = require("filesystem/FileSystem"),
       PathConverters = require("languageTools/PathConverters"),
       TabstopManager = require("editor/TabstopManager"),
       Strings = require("strings"),
       StringUtils = require("utils/StringUtils"),
       Metrics = require("utils/Metrics"),
+      FileUtils = require("file/FileUtils"),
+      InlineMenu = require("widgets/InlineMenu").InlineMenu,
       marked = require("thirdparty/marked.min"),
       matcher = new StringMatch.StringMatcher({
         preferPrefixMatches: true
@@ -265,14 +271,17 @@ define(function (require, exports, module) {
             _hideDocPopup();
             return;
         }
-        var $menu = $hint.closest(".codehint-menu");
+        // .inlinemenu-menu too: the jump-to-definition multi-target picker (see
+        // JumpToDefProvider.doJumpToDef -> showJumpTargetPicker) reuses this same side-popup
+        // mechanism, via InlineMenu, to show a code excerpt for the hovered/selected target.
+        var $menu = $hint.closest(".codehint-menu, .inlinemenu-menu");
         if (!docHtml || !$menu.length) {
             _hideDocPopup();
             return;
         }
         // Make the popup a child of the hint menu so it is removed automatically when the menu is
-        // removed (CodeHintList.close() always does $hintMenu.remove()). This ties its lifecycle
-        // strictly to the code-hint list, regardless of which teardown path fires. It uses
+        // removed (CodeHintList.close()/InlineMenu.close() always remove $hintMenu). This ties its
+        // lifecycle strictly to the list, regardless of which teardown path fires. It uses
         // position:fixed, so it is still placed in viewport coordinates and is never clipped.
         if (!$lspDocPopup || !$lspDocPopup.parent().is($menu)) {
             $lspDocPopup = $("<div>").addClass("lsp-hint-doc-popup").appendTo($menu);
@@ -811,6 +820,139 @@ define(function (require, exports, module) {
         EditorManager.getCurrentFullEditor().setCursorPos(curPos.line, curPos.ch, true);
     }
 
+    var DECLARATION_SCAN_LIMIT = 200; // lines to search upward/downward before giving up
+    var EXCERPT_BODY_MAX_LINES = 6;   // cap on the target's own block (target line included)
+
+    function _indentOf(line) {
+        return /^[ \t]*/.exec(line)[0].length;
+    }
+
+    // Scans upward from just above lineIdx for the nearest non-blank line indented *less* than
+    // lineIdx's own line - i.e. the line that opens whatever block/scope lineIdx sits inside.
+    // Language-agnostic on purpose: rather than hand-listing every language's "class"/"def"/"fn"/
+    // "func"/... declaration keywords (which is both never-ending and TS-biased in practice), this
+    // works the same way for any brace- or indentation-scoped language, the same technique editors'
+    // "sticky scroll"/breadcrumb features use. A member a few lines below "class JohnClass extends
+    // MyBaseClass {" is more indented than that line, so this reliably lands there regardless of
+    // what keyword the language actually uses. Best effort only: inconsistent indentation (or a
+    // target already at column 0) just means the excerpt starts at the target line itself instead.
+    function findEnclosingDeclarationLine(lines, lineIdx) {
+        var from = Math.min(lineIdx, lines.length - 1),
+            targetIndent = _indentOf(lines[from]);
+        if (targetIndent === 0) {
+            return null;
+        }
+        var to = Math.max(0, from - DECLARATION_SCAN_LIMIT);
+        for (var i = from - 1; i >= to; i--) {
+            if (!lines[i].trim()) {
+                continue; // skip blank lines - they carry no indentation signal
+            }
+            if (_indentOf(lines[i]) < targetIndent) {
+                return i;
+            }
+        }
+        return null;
+    }
+
+    // Mirrors findEnclosingDeclarationLine, but forward: scans from just below lineIdx for the
+    // nearest non-blank line indented at or less than lineIdx's own - i.e. where the block lineIdx
+    // opens actually closes (its own closing brace, in most brace-style languages, or the start of
+    // whatever comes next at the same level). Used to show a truncated target's own block honestly
+    // (with a trailing "...") instead of just grabbing a fixed number of lines regardless of
+    // whether that cuts the block short or spills past its end into unrelated code that follows.
+    function findBlockEndLine(lines, lineIdx) {
+        var indent = _indentOf(lines[lineIdx]),
+            to = Math.min(lines.length - 1, lineIdx + DECLARATION_SCAN_LIMIT);
+        for (var i = lineIdx + 1; i <= to; i++) {
+            if (!lines[i].trim()) {
+                continue;
+            }
+            if (_indentOf(lines[i]) <= indent) {
+                return i;
+            }
+        }
+        return null;
+    }
+
+    // True if any line strictly between startExclusive and endExclusive has real content - used so
+    // a "..." marker is only ever shown when something is actually being hidden, never just
+    // because two things happen to be on non-adjacent line numbers (blank lines don't count as
+    // "something hidden").
+    function _hasNonBlankLineBetween(lines, startExclusive, endExclusive) {
+        for (var i = startExclusive + 1; i < endExclusive; i++) {
+            if (lines[i].trim()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // A short, fixed-shape code excerpt around a jump target: the enclosing declaration line (if
+    // found nearby, e.g. "class JohnClass extends MyBaseClass {"), then its own block - never the
+    // declaration's other members (a sibling method, however small, is still unrelated to why this
+    // particular target was picked), so the popup reads the same way every time instead of
+    // sometimes including siblings and sometimes not depending on how much fits. The block itself
+    // is capped independently the same way (see findBlockEndLine) - a long body gets its own "..."
+    // without needing the declaration side to also collapse. A "..." marker is only ever inserted
+    // where it's true - between the declaration and the target when a member actually sits between
+    // them, and after the block only when it was actually cut short - never as a fixed decoration.
+    // Lines are shown in full - the popup already scrolls horizontally for a long line (same as
+    // the signature/documentation code blocks it shares that behavior with).
+    function buildExcerpt(lines, targetLineIdx) {
+        var declLine = findEnclosingDeclarationLine(lines, targetLineIdx),
+            indent = /^[ \t]*/.exec(lines[targetLineIdx])[0],
+            blockEnd = findBlockEndLine(lines, targetLineIdx),
+            naturalEnd = blockEnd !== null ?
+                blockEnd : Math.min(lines.length - 1, targetLineIdx + EXCERPT_BODY_MAX_LINES - 1),
+            bodyEnd = Math.min(naturalEnd, targetLineIdx + EXCERPT_BODY_MAX_LINES - 1),
+            bodyLines = lines.slice(targetLineIdx, bodyEnd + 1);
+
+        if (bodyEnd < naturalEnd) {
+            bodyLines.push(indent + "...");
+        }
+
+        if (declLine === null) {
+            return bodyLines.join("\n");
+        }
+
+        var headerLines = _hasNonBlankLineBetween(lines, declLine, targetLineIdx) ?
+            [lines[declLine], indent + "..."] : [lines[declLine]];
+
+        return headerLines.concat(bodyLines).join("\n");
+    }
+
+    // Text of `path` split into lines, preferring an already-open (possibly unsaved) document
+    // over a disk read, since a jump target may already be open and edited.
+    function getFileLines(path) {
+        var openDoc = DocumentManager.getOpenDocumentForPath(path);
+        if (openDoc) {
+            return $.Deferred().resolve(openDoc.getText().split("\n")).promise();
+        }
+
+        var deferred = $.Deferred();
+        FileSystem.getFileForPath(path).read(function (err, content) {
+            if (err || typeof content !== "string") {
+                deferred.reject();
+            } else {
+                deferred.resolve(content.split("\n"));
+            }
+        });
+        return deferred.promise();
+    }
+
+    // highlight.js language id for a jump target's own file (not the currently active editor's -
+    // a target may be in a different language/file than the one you jumped from). Reuses the same
+    // js/jsx -> ts/tsx aliasing as signature blocks (see SIGNATURE_HLJS_LANG below _docPopupHtml)
+    // since hljs's TS grammar is a strict superset and highlights plain JS/JSX fine.
+    function excerptHljsLang(path) {
+        var language = LanguageManager.getLanguageForPath(path),
+            id = language && language.getId();
+        if (!id) {
+            return "javascript";
+        }
+        return SIGNATURE_HLJS_LANG[id] || id;
+    }
+
     function JumpToDefProvider(client) {
         this.client = client;
     }
@@ -844,43 +986,209 @@ define(function (require, exports, module) {
             return null;
         }
 
-        const pos = editor.getCursorPos(),
+        const client = this.client,
+            pos = editor.getCursorPos(),
             docPath = editor.document.file._path,
             docPathUri = PathConverters.pathToUri(docPath),
-            metricLabel = this.client._metricLabel,
+            metricLabel = client._metricLabel,
             $deferredHints = $.Deferred();
 
-        this.client.gotoDefinition({
+        // Opens (if needed) and moves the cursor to a single resolved {uri, range} location.
+        function jumpToLocation(location) {
+            var docUri = location.uri,
+                startCurPos = {
+                    line: location.range.start.line,
+                    ch: location.range.start.character
+                };
+
+            if (docUri !== docPathUri) {
+                let documentPath = PathConverters.uriToPath(docUri);
+                CommandManager.execute(Commands.FILE_OPEN, {
+                        fullPath: documentPath
+                    })
+                    .done(function () {
+                        setJumpPosition(startCurPos);
+                        $deferredHints.resolve();
+                    })
+                    .fail(function () {
+                        $deferredHints.reject();
+                    });
+            } else { //definition is in current document
+                setJumpPosition(startCurPos);
+                $deferredHints.resolve();
+            }
+        }
+
+        // Builds the near-cursor picker listing every candidate location, Code-Hints-style:
+        // mouse click or keyboard Up/Down + Enter to select, Esc/click-away to cancel. See #3093.
+        //
+        // Rows themselves stay compact (filename + line:col, matching Code Hints' row density) -
+        // disambiguating same-named overrides (which class/function a candidate is in) is instead
+        // shown via a code-excerpt side popup as the user hovers/arrows through items, reusing the
+        // exact same LSP hint documentation popup mechanism (_showDocPopup/_hideDocPopup) that the
+        // autocomplete Code Hints list already uses for its side docs panel.
+        function showJumpTargetPicker(locations) {
+            Metrics.countEvent(Metrics.EVENT_TYPE.LSP, "def", "Multi." + metricLabel);
+
+            var lineCache = {};
+            function linesFor(path) {
+                if (!lineCache[path]) {
+                    lineCache[path] = getFileLines(path);
+                }
+                return lineCache[path];
+            }
+
+            var items = locations.map(function (location, index) {
+                var path = PathConverters.uriToPath(location.uri),
+                    relPath = ProjectManager.makeProjectRelativeIfPossible(path),
+                    dirPath = FileUtils.getDirectoryPath(relPath),
+                    line = location.range.start.line + 1,
+                    col = location.range.start.character + 1,
+                    name = "<span class=\"jump-to-def-item-file\">" + _.escape(FileUtils.getBaseName(path)) +
+                        "</span> <span class=\"jump-to-def-item-loc\">" + line + ":" + col + "</span>";
+
+                // Only append the directory when there is one to show - for a project-root file
+                // dirPath is "", and repeating the filename we already showed above adds noise
+                // instead of context.
+                if (dirPath) {
+                    name += " <span class=\"jump-to-def-item-path\">" + _.escape(dirPath) + "</span>";
+                }
+
+                return { id: index, name: name };
+            });
+
+            var inlineMenu = new InlineMenu(editor, Strings.JUMPTO_DEFINITION_SELECT_TARGET);
+
+            // Guards against a slower file read for an earlier hover resolving after a later one
+            // and clobbering the popup with stale content.
+            var hoverToken = 0;
+
+            function showExcerptFor(id) {
+                var myToken = ++hoverToken,
+                    location = locations[id],
+                    path = PathConverters.uriToPath(location.uri),
+                    line = location.range.start.line + 1,
+                    // Left: filename, plus a dimmer " - <directory>" only when this candidate is
+                    // in a different file than the one the jump was invoked from (no point telling
+                    // you "you're in script.js" when you already are). Right: the line, flush to
+                    // the popup's edge.
+                    nameHtml = _.escape(FileUtils.getBaseName(path)),
+                    titleHtml;
+
+                if (path !== docPath) {
+                    var dirPath = FileUtils.getDirectoryPath(ProjectManager.makeProjectRelativeIfPossible(path))
+                        .replace(/\/$/, "");
+                    if (dirPath) {
+                        nameHtml += " <span class=\"jump-to-def-excerpt-title-path\">- " +
+                            _.escape(dirPath) + "</span>";
+                    }
+                }
+
+                titleHtml = "<div class=\"jump-to-def-excerpt-title\">" +
+                    "<span class=\"jump-to-def-excerpt-title-name\">" + nameHtml + "</span>" +
+                    "<span class=\"jump-to-def-excerpt-title-line\">" +
+                        _.escape(StringUtils.format(Strings.JUMPTO_DEFINITION_LINE_LABEL, line)) +
+                    "</span></div>";
+
+                linesFor(path).done(function (lines) {
+                    if (myToken !== hoverToken) {
+                        return;
+                    }
+                    var excerpt = buildExcerpt(lines, location.range.start.line),
+                        codeHtml = "";
+                    if (excerpt.trim()) {
+                        try {
+                            codeHtml = _highlightCode(marked.parse(
+                                "```" + excerptHljsLang(path) + "\n" + excerpt + "\n```"
+                            ));
+                        } catch (e) {
+                            codeHtml = "<pre>" + _.escape(excerpt) + "</pre>";
+                        }
+                    }
+                    _showDocPopup(inlineMenu.$menu.find("ul.dropdown-menu"), titleHtml + codeHtml);
+                }).fail(function () {
+                    if (myToken === hoverToken) {
+                        _hideDocPopup();
+                    }
+                });
+            }
+
+            inlineMenu.onHover(function (id) {
+                // The very first selection (index 0) is set synchronously inside InlineMenu.open(),
+                // before $menu has been appended to the DOM - _showDocPopup's positioning needs a
+                // connected element, so defer just that one call by a tick.
+                if (!inlineMenu.$menu.closest("body").length) {
+                    setTimeout(function () { showExcerptFor(id); }, 0);
+                } else {
+                    showExcerptFor(id);
+                }
+            });
+
+            inlineMenu.onSelect(function (id) {
+                _hideDocPopup();
+                inlineMenu.close();
+                jumpToLocation(locations[id]);
+            });
+
+            inlineMenu.onClose(function () {
+                _hideDocPopup();
+                inlineMenu.close();
+                $deferredHints.reject();
+            });
+
+            // Dismiss a quickview that happened to already be showing (e.g. the user pressed
+            // Ctrl+J while hovering something). QuickViewManager itself won't show a new one while
+            // this picker's .inlinemenu-menu.open is in the DOM - checked live, not via a
+            // suppress/close pairing, so it can't get stuck if the picker closes via a path other
+            // than onSelect/onClose (e.g. clicking elsewhere - InlineMenu doesn't notify on that).
+            QuickViewManager.hideQuickView();
+            inlineMenu.open(items);
+        }
+
+        // A single definition location is frequently just the base/interface declaration for a
+        // polymorphic call (obj.method() where obj's type has several concrete overrides) - LSP's
+        // "go to definition" intentionally resolves to one canonical declaration for that case.
+        // When that happens, ask the server for implementations too: if it has more than one,
+        // that's the real "which override did you mean" answer the user is after. See #3093.
+        function fallBackToImplementations(singleLocation) {
+            var serverCapabilities = client.getServerCapabilities();
+            if (!serverCapabilities || !serverCapabilities.implementationProvider) {
+                jumpToLocation(singleLocation);
+                return;
+            }
+
+            client.gotoImplementation({
+                filePath: docPath,
+                cursorPos: pos
+            }).done(function (implResult) {
+                var implLocations = Array.isArray(implResult) ? implResult : (implResult ? [implResult] : []);
+                if (implLocations.length > 1) {
+                    Metrics.countEvent(Metrics.EVENT_TYPE.LSP, "def", "Impl." + metricLabel);
+                    showJumpTargetPicker(implLocations);
+                } else {
+                    jumpToLocation(singleLocation);
+                }
+            }).fail(function () {
+                jumpToLocation(singleLocation);
+            });
+        }
+
+        client.gotoDefinition({
             filePath: docPath,
             cursorPos: pos
         }).done(function (msgObj) {
-            //For Older servers
+            if (Array.isArray(msgObj) && msgObj.length > 1) {
+                showJumpTargetPicker(msgObj);
+                return;
+            }
+
+            //For Older servers that always return an array
             if (Array.isArray(msgObj)) {
                 msgObj = msgObj[msgObj.length - 1];
             }
 
             if (msgObj && msgObj.range) {
-                var docUri = msgObj.uri,
-                    startCurPos = {};
-                startCurPos.line = msgObj.range.start.line;
-                startCurPos.ch = msgObj.range.start.character;
-
-                if (docUri !== docPathUri) {
-                    let documentPath = PathConverters.uriToPath(docUri);
-                    CommandManager.execute(Commands.FILE_OPEN, {
-                            fullPath: documentPath
-                        })
-                        .done(function () {
-                            setJumpPosition(startCurPos);
-                            $deferredHints.resolve();
-                        })
-                        .fail(function () {
-                            $deferredHints.reject();
-                        });
-                } else { //definition is in current document
-                    setJumpPosition(startCurPos);
-                    $deferredHints.resolve();
-                }
+                fallBackToImplementations(msgObj);
             } else {
                 // No definition at this position (servers answer null/[] - e.g. tsserver while it
                 // is still loading the project). MUST settle: an unresolved deferred here leaves
@@ -1342,4 +1650,5 @@ define(function (require, exports, module) {
     exports.showHintDocPopup = _showDocPopup;
     exports.hideHintDocPopup = _hideDocPopup;
     exports._docPopupHtml = _docPopupHtml; // exposed for unit tests
+    exports._buildJumpToDefExcerpt = buildExcerpt; // exposed for unit tests
 });

--- a/src/languageTools/LSPClient.js
+++ b/src/languageTools/LSPClient.js
@@ -341,6 +341,7 @@ define(function (require, exports, module) {
         "textDocument/signatureHelp": "Sig",
         "textDocument/hover": "Hover",
         "textDocument/definition": "Def",
+        "textDocument/implementation": "Impl",
         "textDocument/references": "Ref",
         "textDocument/codeAction": "Fix",
         "completionItem/resolve": "Res",
@@ -570,14 +571,15 @@ define(function (require, exports, module) {
         return deferred.promise();
     };
 
-    LanguageClient.prototype.gotoDefinition = function (params) {
-        const self = this;
+    // Shared by gotoDefinition/gotoImplementation - both are "resolve a position to one or more
+    // {uri, range} locations" requests that only differ in LSP method name.
+    function _requestLocations(client, params, method) {
         const deferred = $.Deferred();
         (async function () {
             try {
-                await DocumentSync.flush(self, params.filePath);
-                const result = await self._request("textDocument/definition", {
-                    textDocument: { uri: self.uriForPath(params.filePath) },
+                await DocumentSync.flush(client, params.filePath);
+                const result = await client._request(method, {
+                    textDocument: { uri: client.uriForPath(params.filePath) },
                     position: _positionOf(params.cursorPos)
                 });
                 if (!result || (Array.isArray(result) && !result.length)) {
@@ -600,6 +602,18 @@ define(function (require, exports, module) {
             }
         }());
         return deferred.promise();
+    }
+
+    LanguageClient.prototype.gotoDefinition = function (params) {
+        return _requestLocations(this, params, "textDocument/definition");
+    };
+
+    // Finds concrete implementations of the symbol at a position. Used as a fallback when
+    // gotoDefinition resolves to a single canonical declaration (e.g. a base class/interface
+    // method) for what is actually a polymorphic call site - see DefaultProviders.js doJumpToDef
+    // and https://github.com/phcode-dev/phoenix/issues/3093.
+    LanguageClient.prototype.gotoImplementation = function (params) {
+        return _requestLocations(this, params, "textDocument/implementation");
     };
 
     LanguageClient.prototype.findReferences = function (params) {

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -1579,6 +1579,7 @@ define({
     "CMD_JUMPTO_DEFINITION": "Go to Definition",
     "JUMPTO_DEFINITION_SELECT_TARGET": "Select a definition",
     "JUMPTO_DEFINITION_LINE_LABEL": "Line {0}",
+    "JUMPTO_DEFINITION_IMPLEMENTATION_BADGE": "Implementation",
     "CMD_SHOW_PARAMETER_HINT": "Show Parameter Hint",
     "NO_ARGUMENTS": "<no parameters>",
     "CODE_HINT_IMPORT_FROM_N": "{0} imports…",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -1577,6 +1577,8 @@ define({
 
     // extensions/default/JavaScriptCodeHints
     "CMD_JUMPTO_DEFINITION": "Go to Definition",
+    "JUMPTO_DEFINITION_SELECT_TARGET": "Select a definition",
+    "JUMPTO_DEFINITION_LINE_LABEL": "Line {0}",
     "CMD_SHOW_PARAMETER_HINT": "Show Parameter Hint",
     "NO_ARGUMENTS": "<no parameters>",
     "CODE_HINT_IMPORT_FROM_N": "{0} imports…",

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -2639,6 +2639,39 @@ a, img {
     p:first-child { margin-top: 0; }
     p:last-child { margin-bottom: 0; }
 
+    // File + line label the jump-to-definition multi-target picker prepends before its code
+    // excerpt - see languageTools/DefaultProviders.js showJumpTargetPicker()/showExcerptFor().
+    // Filename (+ dimmer directory, when the candidate isn't in the file you jumped from) on the
+    // left, line number flush to the right.
+    .jump-to-def-excerpt-title {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        gap: 10px;
+        font-size: 11px;
+        color: @bc-text-medium;
+        margin-bottom: 4px;
+
+        .dark & {
+            color: @dark-bc-text-medium;
+        }
+
+        &-name {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        &-path {
+            opacity: 0.6;
+        }
+
+        &-line {
+            flex: 0 0 auto;
+            white-space: nowrap;
+        }
+    }
+
     // Headings (e.g. the package-name header in npm hint docs): kill the browser's large default
     // margins - a first-child heading otherwise adds its top margin to the popup's own padding and
     // the spacing reads top-heavy vs the bottom.

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -694,28 +694,42 @@ a:focus {
             }
         }
 
-        // Styles used for inlinemenu widget header
+        // Styles used for inlinemenu widget header. @bc-bg-tool-bar/@bc-inlinemenu-text used to be
+        // identical in light and dark variants (a dark toolbar-grey chip that clashed against an
+        // otherwise light dropdown in light theme) - use the theme-aware "muted panel" pair instead,
+        // same tokens as this picker's own .jump-to-def-item-path, so the header reads as a subtle
+        // section label rather than a mismatched dark badge.
         li.inlinemenu-header a {
-            background-color: @bc-bg-tool-bar;
-            color: @bc-inlinemenu-text;
+            background-color: @bc-panel-bg-alt;
+            color: @bc-text-medium;
             padding-bottom: 5px;
 
             .dark & {
-                background-color: @dark-bc-bg-tool-bar;
-                color: @dark-bc-inlinemenu-text;
-                padding-bottom: 5px;
+                background-color: @dark-bc-panel-bg-alt;
+                color: @dark-bc-text-medium;
             }
 
             &:hover {
-                background-color: @bc-bg-tool-bar;
-                color: @bc-inlinemenu-text;
-                padding-bottom: 5px;
+                background-color: @bc-panel-bg-alt;
+                color: @bc-text-medium;
 
                 .dark & {
-                    background-color: @dark-bc-bg-tool-bar;
-                    color: @dark-bc-inlinemenu-text;
-                    padding-bottom: 5px;
+                    background-color: @dark-bc-panel-bg-alt;
+                    color: @dark-bc-text-medium;
                 }
+            }
+        }
+
+        // Muted directory suffix on jump-to-definition's multi-target picker items - see
+        // languageTools/DefaultProviders.js showJumpTargetPicker(). Scoped here since
+        // .quick-open-path (used for the same muted-path look in QuickOpen) only applies under
+        // .quick-search-container.
+        .jump-to-def-item-path {
+            color: @bc-text-medium;
+            font-size: 11px;
+
+            .dark & {
+                color: @dark-bc-text-medium;
             }
         }
 

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -733,6 +733,33 @@ a:focus {
             }
         }
 
+        // "Implementation" marker shown flush right on a jump-to-definition item's row when the
+        // row represents one (see showJumpTargetPicker's implementationStartIndex) - the
+        // declaration row and its implementations otherwise look identical once merged into one
+        // list, with nothing else to tell them apart. Right-aligned via float, deliberately not
+        // display:flex on a wrapper: that was tried and reliably added ~11px of unexplained row
+        // height, because a block-level flex child inside InlineMenu's own inline <span> wrapper
+        // (widgets/InlineMenu.js _addItem) gets boxed in an anonymous block that still carries the
+        // parent's own line-height as a "strut". A float is taken out of normal flow entirely, so
+        // it reaches its containing block (the menu item's <a>, which is display:block) without
+        // that side effect.
+        .jump-to-def-item-badge {
+            float: right;
+            font-size: 11px;
+            color: @bc-text-medium;
+            // fa-code-branch reads as a vertical git-branch glyph by default - lay it on its side
+            // so it reads more like a generic "derives from" mark than a literal branch icon.
+            transform: rotate(90deg);
+            // li a's own right padding (see the shared "li a" rule above) is 20px, sized for plain
+            // text - pull the badge back into most of that so it doesn't float in its own patch of
+            // empty space, while still leaving a little breathing room off the popup's edge.
+            margin-right: -14px;
+
+            .dark & {
+                color: @dark-bc-text-medium;
+            }
+        }
+
         li {
             a {
                 // Less padding than on menus. More padding on top than bottom

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -694,27 +694,35 @@ a:focus {
             }
         }
 
-        // Styles used for inlinemenu widget header. @bc-bg-tool-bar/@bc-inlinemenu-text used to be
-        // identical in light and dark variants (a dark toolbar-grey chip that clashed against an
-        // otherwise light dropdown in light theme) - use the theme-aware "muted panel" pair instead,
-        // same tokens as this picker's own .jump-to-def-item-path, so the header reads as a subtle
-        // section label rather than a mismatched dark badge.
+        // Styles used for inlinemenu widget header. Previously a solid @bc-panel-bg-alt chip -
+        // against the menu's own @bc-menu-bg/@dark-bc-menu-bg surface (white / near-black) that
+        // read as a mismatched floating block sitting on top of the list, especially in dark theme.
+        // Instead, keep it on the same surface as the rest of the menu (no background at all) and
+        // read it as a plain muted title with a hairline divider separating it from the items
+        // below. Same treatment as the code-excerpt popup's own title bar
+        // (.jump-to-def-excerpt-title in brackets.less), so the two pieces of one picker look like
+        // one cohesive, deliberately minimal surface instead of two.
         li.inlinemenu-header a {
-            background-color: @bc-panel-bg-alt;
+            background-color: transparent;
             color: @bc-text-medium;
-            padding-bottom: 5px;
+            padding-top: 6px;
+            padding-bottom: 6px;
+            // Same divider color this menu family already uses for its .divider rule above, so the
+            // header's separator reads as an intentional, on-brand line rather than an arbitrary
+            // one-off - and unlike a low-alpha white/black overlay, it stays visible against the
+            // near-black @dark-bc-menu-bg surface.
+            border-bottom: 1px solid @bc-menu-separator;
 
             .dark & {
-                background-color: @dark-bc-panel-bg-alt;
                 color: @dark-bc-text-medium;
+                border-bottom-color: @dark-bc-menu-separator;
             }
 
             &:hover {
-                background-color: @bc-panel-bg-alt;
+                background-color: transparent;
                 color: @bc-text-medium;
 
                 .dark & {
-                    background-color: @dark-bc-panel-bg-alt;
                     color: @dark-bc-text-medium;
                 }
             }

--- a/test/UnitTestSuite.js
+++ b/test/UnitTestSuite.js
@@ -36,6 +36,7 @@ define(function (require, exports, module) {
     require("spec/EditorRedraw-test");
     require("spec/EditorCommandHandlers-test");
     require("spec/EditorCommandHandlers-integ-test");
+    require("spec/JumpToDefinitionMultiTarget-integ-test");
     require("spec/EditorManager-test");
     require("spec/EncodingDetector-test");
     require("spec/EventDispatcher-test");

--- a/test/spec/JumpToDefinitionMultiTarget-integ-test.js
+++ b/test/spec/JumpToDefinitionMultiTarget-integ-test.js
@@ -1,0 +1,700 @@
+/*
+ * GNU AGPL-3.0 License
+ *
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
+ * Original work Copyright (c) 2012 - 2021 Adobe Systems Incorporated. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
+ *
+ */
+
+/*global jasmine, describe, it, expect, afterEach, beforeAll, afterAll, awaitsForDone, awaitsForFail, awaitsFor */
+
+define(function (require, exports, module) {
+
+
+    // Load dependent modules
+    var SpecRunnerUtils = require("spec/SpecRunnerUtils"),
+        KeyEvent        = require("utils/KeyEvent"),
+        Commands        = require("command/Commands"),
+        EditorManager,      // loaded from brackets.test
+        CommandManager,
+        JumpToDefManager,   // loaded via brackets.getModule - not exposed on brackets.test
+        DefaultProviders,
+        PathConverters;
+
+    var testPath = SpecRunnerUtils.getTestPath("/spec/JumpToDefinitionMultiTarget-test-files"),
+        testWindow,
+        $;
+
+    // Fixture positions (0-based line/character), matching the class hierarchy from
+    // https://github.com/phcode-dev/phoenix/issues/3093 - a base class method overridden by
+    // several subclasses, called polymorphically via greet(person).
+    var POLY_FILE = "polymorphism.js",
+        ALICE_FILE = "aliceClass.js",
+        BASE_SAYHELLO   = { file: POLY_FILE,  line: 3,  ch: 4 },   // MyBaseClass.sayHello
+        JOHN_SAYHELLO   = { file: POLY_FILE,  line: 9,  ch: 4 },   // JohnClass.sayHello
+        JANE_SAYHELLO   = { file: POLY_FILE,  line: 15, ch: 4 },   // JaneClass.sayHello
+        ALICE_SAYHELLO  = { file: ALICE_FILE, line: 5,  ch: 4 },   // AliceClass.sayHello (other file)
+        CALL_SITE       = { line: 21, ch: 11 };                    // person.sayHello() in greet()
+
+    describe("LegacyInteg:Jump to Definition - multiple targets", function () {
+
+        var mockProvider;
+
+        beforeAll(async function () {
+            testWindow = await SpecRunnerUtils.createTestWindowAndRun({forceReload: true});
+            $ = testWindow.$;
+            CommandManager = testWindow.brackets.test.CommandManager;
+            EditorManager  = testWindow.brackets.test.EditorManager;
+
+            var modules = await new Promise(function (resolve) {
+                testWindow.brackets.getModule(
+                    ["features/JumpToDefManager", "languageTools/DefaultProviders", "languageTools/PathConverters"],
+                    function (jumpToDefManager, defaultProviders, pathConverters) {
+                        resolve({
+                            JumpToDefManager: jumpToDefManager,
+                            DefaultProviders: defaultProviders,
+                            PathConverters: pathConverters
+                        });
+                    }
+                );
+            });
+            JumpToDefManager = modules.JumpToDefManager;
+            DefaultProviders = modules.DefaultProviders;
+            PathConverters   = modules.PathConverters;
+
+            await SpecRunnerUtils.loadProjectInTestWindow(testPath);
+        }, 30000);
+
+        afterAll(async function () {
+            testWindow       = null;
+            $                = null;
+            CommandManager   = null;
+            EditorManager    = null;
+            JumpToDefManager = null;
+            DefaultProviders = null;
+            PathConverters   = null;
+            await SpecRunnerUtils.closeTestWindow();
+        }, 30000);
+
+        afterEach(async function () {
+            if (mockProvider) {
+                JumpToDefManager.removeJumpToDefProvider(mockProvider, ["javascript"]);
+                mockProvider = null;
+            }
+            await awaitsForDone(CommandManager.execute(Commands.FILE_CLOSE_ALL, { _forceClose: true }),
+                "close all files");
+        });
+
+        // Registers a mock jump-to-def provider at a priority above the real Tern/LSP providers,
+        // so NAVIGATE_JUMPTO_DEFINITION exercises the exact production picker logic in
+        // DefaultProviders.js's doJumpToDef() against a deterministic, canned response instead of
+        // depending on what a real language server decides to resolve (see #3093 / PR #3098).
+        //
+        // `implementation` (optional) configures the textDocument/implementation fallback used
+        // when gotoDefinition resolves to a single location - see #3093 comment thread: a lone
+        // definition is often just the base/interface declaration for a polymorphic call, so
+        // doJumpToDef additionally asks the server for implementations when it advertises the
+        // implementationProvider capability.
+        //   implementation.result:   array/object gotoImplementation resolves with (default: none)
+        //   implementation.rejects:  true to make gotoImplementation reject instead
+        //   implementation.spy:      optional fn called whenever gotoImplementation is invoked
+        function registerMockProvider(definitionResult, implementation) {
+            mockProvider = new DefaultProviders.JumpToDefProvider({
+                servesDocument: function () { return true; },
+                getServerCapabilities: function () {
+                    return { definitionProvider: true, implementationProvider: !!implementation };
+                },
+                gotoDefinition: function () {
+                    return $.Deferred().resolve(definitionResult).promise();
+                },
+                gotoImplementation: function () {
+                    if (implementation && implementation.spy) {
+                        implementation.spy();
+                    }
+                    var deferred = $.Deferred();
+                    if (implementation && implementation.rejects) {
+                        deferred.reject();
+                    } else {
+                        deferred.resolve(implementation && implementation.result);
+                    }
+                    return deferred.promise();
+                },
+                _metricLabel: "mockTest"
+            });
+            JumpToDefManager.registerJumpToDefProvider(mockProvider, ["javascript"], 1000);
+        }
+
+        function locationFor(target) {
+            return {
+                uri: PathConverters.pathToUri(testPath + "/" + target.file),
+                range: {
+                    start: { line: target.line, character: target.ch },
+                    end: { line: target.line, character: target.ch + "sayHello".length }
+                }
+            };
+        }
+
+        async function openPolymorphismFile() {
+            await awaitsForDone(
+                CommandManager.execute(Commands.CMD_ADD_TO_WORKINGSET_AND_OPEN,
+                    { fullPath: testPath + "/" + POLY_FILE }),
+                "open " + POLY_FILE
+            );
+            var editor = EditorManager.getCurrentFullEditor();
+            editor.setCursorPos(CALL_SITE.line, CALL_SITE.ch);
+            return editor;
+        }
+
+        function getOpenMenuItems() {
+            return $(".inlinemenu-menu.open .inlinemenu-item");
+        }
+
+        async function awaitPickerOpen(expectedCount) {
+            await awaitsFor(function () {
+                return getOpenMenuItems().length === expectedCount;
+            }, "jump target picker to open with " + expectedCount + " items", 3000);
+        }
+
+        it("should show a dropdown near the cursor listing every candidate", async function () {
+            registerMockProvider([locationFor(BASE_SAYHELLO), locationFor(JOHN_SAYHELLO), locationFor(JANE_SAYHELLO)]);
+            await openPolymorphismFile();
+
+            CommandManager.execute(Commands.NAVIGATE_JUMPTO_DEFINITION);
+            await awaitPickerOpen(3);
+
+            // it's a cursor-anchored dropdown, not a top-of-editor ModalBar
+            expect($(".modal-bar").length).toBe(0);
+
+            var itemsText = getOpenMenuItems().text();
+            expect(itemsText).toContain("polymorphism.js");
+            expect(itemsText).toContain("4:5");   // BASE_SAYHELLO, 1-based
+            expect(itemsText).toContain("10:5");  // JOHN_SAYHELLO, 1-based
+            expect(itemsText).toContain("16:5");  // JANE_SAYHELLO, 1-based
+
+            // dismiss so afterEach's FILE_CLOSE_ALL doesn't hit a "save changes?" dialog concern
+            SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_ESCAPE, "keydown", $(".inlinemenu-menu.open")[0]);
+        });
+
+        it("should jump to the clicked target in the current document", async function () {
+            registerMockProvider([locationFor(BASE_SAYHELLO), locationFor(JOHN_SAYHELLO), locationFor(JANE_SAYHELLO)]);
+            var editor = await openPolymorphismFile();
+
+            var jumpPromise = CommandManager.execute(Commands.NAVIGATE_JUMPTO_DEFINITION);
+            await awaitPickerOpen(3);
+
+            getOpenMenuItems().eq(1).trigger("click");   // JohnClass.sayHello
+            await awaitsForDone(jumpPromise, "jump to clicked target");
+
+            expect(getOpenMenuItems().length).toBe(0);
+            var pos = editor.getCursorPos();
+            expect(pos.line).toBe(JOHN_SAYHELLO.line);
+            expect(pos.ch).toBe(JOHN_SAYHELLO.ch);
+        });
+
+        it("should open the target file when the picked target is in a different document", async function () {
+            registerMockProvider([locationFor(BASE_SAYHELLO), locationFor(ALICE_SAYHELLO)]);
+            await openPolymorphismFile();
+
+            var jumpPromise = CommandManager.execute(Commands.NAVIGATE_JUMPTO_DEFINITION);
+            await awaitPickerOpen(2);
+
+            getOpenMenuItems().eq(1).trigger("click");   // AliceClass.sayHello, in aliceClass.js
+            await awaitsForDone(jumpPromise, "jump to target in a different file");
+
+            var editor = EditorManager.getCurrentFullEditor();
+            expect(editor.document.file.name).toBe(ALICE_FILE);
+            var pos = editor.getCursorPos();
+            expect(pos.line).toBe(ALICE_SAYHELLO.line);
+            expect(pos.ch).toBe(ALICE_SAYHELLO.ch);
+        });
+
+        it("should navigate and select purely by keyboard", async function () {
+            registerMockProvider([locationFor(BASE_SAYHELLO), locationFor(JOHN_SAYHELLO), locationFor(JANE_SAYHELLO)]);
+            var editor = await openPolymorphismFile();
+
+            var jumpPromise = CommandManager.execute(Commands.NAVIGATE_JUMPTO_DEFINITION);
+            await awaitPickerOpen(3);
+
+            var $menu = $(".inlinemenu-menu.open")[0];
+            // selection starts on item 0 (MyBaseClass); Down, Down -> item 2 (JaneClass)
+            SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_DOWN, "keydown", $menu);
+            SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_DOWN, "keydown", $menu);
+            SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_RETURN, "keydown", $menu);
+
+            await awaitsForDone(jumpPromise, "jump via keyboard selection");
+
+            expect(getOpenMenuItems().length).toBe(0);
+            var pos = editor.getCursorPos();
+            expect(pos.line).toBe(JANE_SAYHELLO.line);
+            expect(pos.ch).toBe(JANE_SAYHELLO.ch);
+        });
+
+        it("should dismiss without navigating on Escape", async function () {
+            registerMockProvider([locationFor(BASE_SAYHELLO), locationFor(JOHN_SAYHELLO), locationFor(JANE_SAYHELLO)]);
+            var editor = await openPolymorphismFile();
+            var posBefore = editor.getCursorPos();
+
+            var jumpPromise = CommandManager.execute(Commands.NAVIGATE_JUMPTO_DEFINITION);
+            await awaitPickerOpen(3);
+
+            SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_ESCAPE, "keydown", $(".inlinemenu-menu.open")[0]);
+
+            await awaitsForFail(jumpPromise, "Esc rejects the jump instead of hanging");
+
+            expect(getOpenMenuItems().length).toBe(0);
+            var posAfter = editor.getCursorPos();
+            expect(posAfter.line).toBe(posBefore.line);
+            expect(posAfter.ch).toBe(posBefore.ch);
+        });
+
+        it("should jump immediately with no picker when only one location is returned", async function () {
+            registerMockProvider([locationFor(BASE_SAYHELLO)]);
+            var editor = await openPolymorphismFile();
+
+            await awaitsForDone(CommandManager.execute(Commands.NAVIGATE_JUMPTO_DEFINITION),
+                "immediate jump for a single target");
+
+            expect(getOpenMenuItems().length).toBe(0);
+            var pos = editor.getCursorPos();
+            expect(pos.line).toBe(BASE_SAYHELLO.line);
+            expect(pos.ch).toBe(BASE_SAYHELLO.ch);
+        });
+
+        it("should fall back to implementations when a single definition is just the base declaration",
+            async function () {
+                // gotoDefinition resolves to the base declaration only (as real LSP servers do for
+                // this exact polymorphic-call repro - see #3093); the server also advertises
+                // implementationProvider and, when asked, knows about all 3 concrete overrides.
+                registerMockProvider([locationFor(BASE_SAYHELLO)], {
+                    result: [locationFor(JOHN_SAYHELLO), locationFor(JANE_SAYHELLO), locationFor(ALICE_SAYHELLO)]
+                });
+                await openPolymorphismFile();
+
+                var jumpPromise = CommandManager.execute(Commands.NAVIGATE_JUMPTO_DEFINITION);
+                await awaitPickerOpen(3);
+
+                getOpenMenuItems().eq(2).trigger("click");   // AliceClass.sayHello
+                await awaitsForDone(jumpPromise, "jump to an implementation after the fallback");
+
+                var editor = EditorManager.getCurrentFullEditor();
+                expect(editor.document.file.name).toBe(ALICE_FILE);
+                var pos = editor.getCursorPos();
+                expect(pos.line).toBe(ALICE_SAYHELLO.line);
+                expect(pos.ch).toBe(ALICE_SAYHELLO.ch);
+            });
+
+        it("should jump straight to the definition when implementations adds nothing new", async function () {
+            // implementationProvider is advertised, but the server has nothing extra to offer
+            // (0 or 1 results) - doJumpToDef must not show an empty/single-item picker.
+            registerMockProvider([locationFor(BASE_SAYHELLO)], { result: [] });
+            var editor = await openPolymorphismFile();
+
+            await awaitsForDone(CommandManager.execute(Commands.NAVIGATE_JUMPTO_DEFINITION),
+                "direct jump when implementations is empty");
+
+            expect(getOpenMenuItems().length).toBe(0);
+            var pos = editor.getCursorPos();
+            expect(pos.line).toBe(BASE_SAYHELLO.line);
+            expect(pos.ch).toBe(BASE_SAYHELLO.ch);
+        });
+
+        it("should jump straight to the definition when the implementation request fails", async function () {
+            // A failed/unsupported implementation lookup must not break or hang the ordinary
+            // single-definition jump.
+            registerMockProvider([locationFor(BASE_SAYHELLO)], { rejects: true });
+            var editor = await openPolymorphismFile();
+
+            await awaitsForDone(CommandManager.execute(Commands.NAVIGATE_JUMPTO_DEFINITION),
+                "direct jump when the implementation request rejects");
+
+            expect(getOpenMenuItems().length).toBe(0);
+            var pos = editor.getCursorPos();
+            expect(pos.line).toBe(BASE_SAYHELLO.line);
+            expect(pos.ch).toBe(BASE_SAYHELLO.ch);
+        });
+
+        it("should not query implementations when the server doesn't advertise the capability",
+            async function () {
+                var implementationSpy = jasmine.createSpy("gotoImplementation");
+                // registerMockProvider only sets implementationProvider:true when an `implementation`
+                // options object is passed - omit it here to simulate a server without the capability,
+                // but still wire the spy in manually to prove it's never called.
+                registerMockProvider([locationFor(BASE_SAYHELLO)]);
+                mockProvider.client.gotoImplementation = implementationSpy;
+                var editor = await openPolymorphismFile();
+
+                await awaitsForDone(CommandManager.execute(Commands.NAVIGATE_JUMPTO_DEFINITION),
+                    "direct jump without ever consulting implementations");
+
+                expect(implementationSpy).not.toHaveBeenCalled();
+                expect(getOpenMenuItems().length).toBe(0);
+                var pos = editor.getCursorPos();
+                expect(pos.line).toBe(BASE_SAYHELLO.line);
+                expect(pos.ch).toBe(BASE_SAYHELLO.ch);
+            });
+
+        // buildExcerpt() is pure line-array -> string logic (no editor/DOM needed), so these test
+        // it directly rather than through the picker's hover UI - see
+        // DefaultProviders.js showJumpTargetPicker()/showExcerptFor()/buildExcerpt(). The excerpt
+        // is the enclosing declaration line (if found, via findEnclosingDeclarationLine), then the
+        // target's own block (via findBlockEndLine, capped independently with its own "..." if it
+        // runs long). A sibling member between the declaration and the target is never shown,
+        // however small - it isn't why this target was picked. Each "..." marker - top and bottom -
+        // is only ever inserted where something real is actually being hidden: a member between
+        // the declaration and target for the top one, more of the block than fits for the bottom
+        // one. Adjacent declaration+target (nothing real between them, blank lines included) shows
+        // no top marker at all - it would be actively misleading to imply something was hidden
+        // when nothing was.
+        describe("excerpt building", function () {
+
+            it("should not show a ... between declaration and target when they're directly adjacent",
+                function () {
+                    // JohnClass/JaneClass in the real polymorphism.js fixture are exactly this
+                    // shape: sayHello() is the class's only member, right after the declaration.
+                    var lines = [
+                        "class MyBaseClass {",
+                        "    sayHello() {",
+                        "        console.log(\"Hello from MyBaseClass\");",
+                        "    }",
+                        "}",
+                        "",
+                        "class JohnClass extends MyBaseClass {",
+                        "    sayHello() {",
+                        "        console.log(\"Hello from JohnClass\");",
+                        "    }",
+                        "}"
+                    ];
+                    var excerpt = DefaultProviders._buildJumpToDefExcerpt(lines, 7); // "    sayHello() {"
+
+                    expect(excerpt).toBe([
+                        "class JohnClass extends MyBaseClass {",
+                        "    sayHello() {",
+                        "        console.log(\"Hello from JohnClass\");",
+                        "    }"
+                    ].join("\n"));
+                    expect(excerpt).not.toContain("...");
+                });
+
+            it("should not show a ... when only a blank line sits between declaration and target",
+                function () {
+                    var lines = ["class Foo {", "", "  sayHello() {", "    console.log(1);", "  }", "}"];
+                    var excerpt = DefaultProviders._buildJumpToDefExcerpt(lines, 2); // "  sayHello() {"
+
+                    expect(excerpt).toBe([
+                        "class Foo {",
+                        "  sayHello() {",
+                        "    console.log(1);",
+                        "  }"
+                    ].join("\n"));
+                    expect(excerpt).not.toContain("...");
+                });
+
+            it("should always collapse to declaration + ... + target, even when a sibling would fit",
+                function () {
+                    var lines = [
+                        "class AliceClass extends MyBaseClass {",
+                        "  yellow() {",
+                        "    console.log(\"not so soon\");",
+                        "  }",
+                        "  sayHello() {",
+                        "    console.log(\"Hello, Alice!\");",
+                        "  }",
+                        "}"
+                    ];
+                    var excerpt = DefaultProviders._buildJumpToDefExcerpt(lines, 4); // "  sayHello() {"
+
+                    // declaration, then "...", then just sayHello's own block - yellow() is never
+                    // shown, even though there'd be plenty of room for it
+                    expect(excerpt).toBe([
+                        "class AliceClass extends MyBaseClass {",
+                        "  ...",
+                        "  sayHello() {",
+                        "    console.log(\"Hello, Alice!\");",
+                        "  }"
+                    ].join("\n"));
+                    expect(excerpt).not.toContain("yellow");
+                    expect(excerpt).not.toContain("not so soon");
+                });
+
+            it("should collapse to declaration + ... + target when many members sit in between",
+                function () {
+                    var lines = ["class BigClass extends MyBaseClass {"];
+                    for (var i = 1; i <= 9; i++) {
+                        lines.push("  method" + i + "() {");
+                        lines.push("    doThing" + i + "();");
+                        lines.push("  }");
+                    }
+                    var targetLine = lines.length; // where the 10th method starts
+                    lines.push("  sayHello() {");
+                    lines.push("    console.log(\"Hello, Big!\");");
+                    lines.push("  }");
+                    lines.push("}");
+
+                    var excerpt = DefaultProviders._buildJumpToDefExcerpt(lines, targetLine);
+                    var excerptLines = excerpt.split("\n");
+
+                    // declaration line is never lost, even though the target is far below it...
+                    expect(excerptLines[0]).toBe("class BigClass extends MyBaseClass {");
+                    // ...collapsed with a single marker line...
+                    expect(excerptLines[1]).toBe("  ...");
+                    // ...and none of the 9 unrelated sibling methods leak into the excerpt just to
+                    // fill space - only the target's own lines follow the marker.
+                    expect(excerpt).not.toContain("method1(");
+                    expect(excerpt).not.toContain("method9(");
+                    expect(excerpt).not.toContain("doThing");
+                    expect(excerptLines[2]).toBe("  sayHello() {");
+                    expect(excerptLines[3]).toBe("    console.log(\"Hello, Big!\");");
+                });
+
+            it("should not show a trailing ... when the target's own block ends naturally, even if " +
+                "more code follows it in the file", function () {
+                // sayHello's block is short and closes with its own "}" well before the file
+                // ends - a sibling method (unrelated to sayHello's own block) follows right
+                // after. The bottom marker must track sayHello's own natural end, not just
+                // "is there more file left".
+                var lines = [
+                    "class Foo {",
+                    "  sayHello() {",
+                    "    console.log(\"hi\");",
+                    "  }",
+                    "  anotherMethod() {",
+                    "    console.log(\"unrelated\");",
+                    "  }",
+                    "}"
+                ];
+                var excerpt = DefaultProviders._buildJumpToDefExcerpt(lines, 1); // "  sayHello() {"
+
+                expect(excerpt).toBe([
+                    "class Foo {",
+                    "  sayHello() {",
+                    "    console.log(\"hi\");",
+                    "  }"
+                ].join("\n"));
+                expect(excerpt).not.toContain("...");
+                expect(excerpt).not.toContain("anotherMethod");
+            });
+
+            it("should collapse a long target body to its own ... marker instead of silently cutting it",
+                function () {
+                    var lines = [
+                        "class AliceClass extends MyBaseClass {",
+                        "  yellow() {",
+                        "    console.log(\"not so soon\");",
+                        "  }",
+                        "  sayHello() {"
+                    ];
+                    for (var i = 0; i < 20; i++) {
+                        lines.push("    console.log(\"Hello, Alice!\");");
+                    }
+                    lines.push("  }");
+                    lines.push("}");
+
+                    var excerpt = DefaultProviders._buildJumpToDefExcerpt(lines, 4); // "  sayHello() {"
+                    var excerptLines = excerpt.split("\n");
+
+                    // declaration + "..." as always (yellow() is still never shown), then the
+                    // target's own block, capped with its own separate "..." rather than showing
+                    // all 20 repeated lines - the two markers are independent
+                    expect(excerptLines[0]).toBe("class AliceClass extends MyBaseClass {");
+                    expect(excerptLines[1]).toBe("  ...");
+                    expect(excerptLines[2]).toBe("  sayHello() {");
+                    expect(excerpt).not.toContain("yellow");
+                    expect(excerpt).not.toContain("not so soon");
+                    // honestly marked as cut off, not silently stopped
+                    var lastLine = excerptLines[excerptLines.length - 1];
+                    expect(lastLine).toBe("  ...");
+                    expect(excerptLines.filter(function (l) {
+                        return l.indexOf("Hello, Alice!") !== -1;
+                    }).length).toBeLessThan(20);
+                });
+
+            it("should show forward from the target's own block with no collapsing when nothing encloses it",
+                function () {
+                    var lines = [
+                        "function topLevelOne() {}",
+                        "function sayHello() {",
+                        "  console.log(\"top level\");",
+                        "}",
+                        "function topLevelThree() {}"
+                    ];
+                    var excerpt = DefaultProviders._buildJumpToDefExcerpt(lines, 1); // top-level, indent 0
+
+                    expect(excerpt).not.toContain("...");
+                    // sayHello's own block only - never spills into the unrelated function after it
+                    expect(excerpt).toBe(lines.slice(1, 4).join("\n"));
+                    expect(excerpt).not.toContain("topLevelThree");
+                });
+        });
+
+        // Everything above stubs the LSP client, so the picker/excerpt logic is tested
+        // deterministically regardless of what any real language server does. This one instead
+        // exercises the exact #3093 repro - a real Ctrl+J at obj.sayHello() - against vtsls, the
+        // actual TypeScript server Phoenix ships, so a regression can't hide behind every mocked
+        // test still passing. Desktop-only: vtsls has no browser-build equivalent (Tern there
+        // doesn't do multi-target resolution the same way - see EditorCommandHandlers-integ-test.js
+        // for the same window.Phoenix.isNativeApp split on the single-target case).
+        if (window.Phoenix.isNativeApp) {
+            describe("real vtsls server (desktop only)", function () {
+                // AliceClass lives in a separate file (realLspAliceClass.js, require()'d from
+                // REAL_FILE) - John/Jane cover the same-file case, Alice covers a picker candidate
+                // whose item/excerpt must show a different filename and whose click must actually
+                // switch files, both against a real server-provided URI rather than a mock one.
+                var REAL_FILE = "realLspPolymorphism.js",
+                    REAL_ALICE_FILE = "realLspAliceClass.js",
+                    REAL_CALL_LINE = 34; // 0-based: "  obj.sayHello();" in REAL_FILE
+
+                beforeAll(async function () {
+                    // Cold-start the language server here (spawn vtsls + tsserver loading the
+                    // TypeScript library) so the actual test below only needs to budget for an
+                    // already-warm request - see the identical warm-up in
+                    // EditorCommandHandlers-integ-test.js.
+                    await awaitsForDone(
+                        CommandManager.execute(Commands.CMD_ADD_TO_WORKINGSET_AND_OPEN,
+                            { fullPath: testPath + "/" + REAL_FILE }),
+                        "warm-up: open " + REAL_FILE
+                    );
+                    var LSPClient = await new Promise(function (resolve) {
+                        testWindow.brackets.getModule(["languageTools/LSPClient"], resolve);
+                    });
+                    await awaitsFor(function () {
+                        return LSPClient.isLintingProviderActive("javascript");
+                    }, "the TypeScript language server to finish its cold start", 90000);
+                    await awaitsForDone(CommandManager.execute(Commands.FILE_CLOSE_ALL, { _forceClose: true }),
+                        "close warm-up file");
+                }, 120000);
+
+                function itemIndexContaining(substr) {
+                    var idx = -1;
+                    getOpenMenuItems().each(function (i, el) {
+                        if ($(el).text().indexOf(substr) !== -1) {
+                            idx = i;
+                        }
+                    });
+                    return idx;
+                }
+
+                async function excerptTextForItem(index) {
+                    getOpenMenuItems().eq(index).trigger("mouseover");
+                    await new Promise(function (resolve) { setTimeout(resolve, 400); });
+                    // the whole popup, not just $(".lsp-hint-doc-popup pre") - the title (filename
+                    // + line) is a sibling <div> outside the <pre>, not inside it
+                    return $(".lsp-hint-doc-popup").text();
+                }
+
+                // One jump attempt capped at 3s (same pattern/reasoning as
+                // EditorCommandHandlers-integ-test.js's attemptJumpToDefinition): a hung or
+                // not-yet-ready request just counts as a failed attempt so awaitsFor can retry
+                // instead of the whole budget being pinned on one slow request. Stashes the
+                // command's own promise on lastJumpPromise so a successful attempt's picker can be
+                // interacted with afterward without re-invoking the command (which would open a
+                // second picker on top of the one already showing).
+                var lastJumpPromise = null;
+                function attemptOpenPicker(editor, line, ch) {
+                    return new Promise(function (resolve) {
+                        editor.setCursorPos(line, ch);
+                        lastJumpPromise = CommandManager.execute(Commands.NAVIGATE_JUMPTO_DEFINITION);
+                        setTimeout(function () { resolve(getOpenMenuItems().length); }, 3000);
+                    });
+                }
+
+                it("should show the multi-target picker and correct excerpts for a real click " +
+                    "on obj.sayHello()", async function () {
+                    await awaitsForDone(
+                        CommandManager.execute(Commands.CMD_ADD_TO_WORKINGSET_AND_OPEN,
+                            { fullPath: testPath + "/" + REAL_FILE }),
+                        "open " + REAL_FILE
+                    );
+                    var editor = EditorManager.getCurrentFullEditor(),
+                        callLine = editor.document.getLine(REAL_CALL_LINE),
+                        callCh = callLine.indexOf("sayHello") + 2;
+
+                    await awaitsFor(async function () {
+                        return (await attemptOpenPicker(editor, REAL_CALL_LINE, callCh)) === 3;
+                    }, "vtsls to resolve obj.sayHello() to John/Jane/Alice's 3 implementations", 20000, 500);
+
+                    var johnIdx = itemIndexContaining("17:3"), // JohnClass.sayHello, 1-based
+                        janeIdx = itemIndexContaining("23:3"), // JaneClass.sayHello, 1-based
+                        aliceIdx = itemIndexContaining("13:3"); // AliceClass.sayHello, 1-based
+                    expect(johnIdx).toBeGreaterThan(-1);
+                    expect(janeIdx).toBeGreaterThan(-1);
+                    expect(aliceIdx).toBeGreaterThan(-1);
+
+                    // Same-file candidates (John/Jane) show REAL_FILE's own name, not the other
+                    // file's - and John/Jane sayHello is each class's only member, directly
+                    // adjacent to the declaration, so no "..." should be implied where nothing
+                    // was hidden.
+                    var johnItemText = getOpenMenuItems().eq(johnIdx).text();
+                    expect(johnItemText).toContain(REAL_FILE);
+                    expect(johnItemText).not.toContain(REAL_ALICE_FILE);
+                    var johnExcerpt = await excerptTextForItem(johnIdx);
+                    expect(johnExcerpt).toContain(REAL_FILE);
+                    expect(johnExcerpt).not.toContain(REAL_ALICE_FILE);
+                    expect(johnExcerpt).toContain("class JohnClass extends MyBaseClass {");
+                    expect(johnExcerpt).toContain("Hello, John!");
+                    expect(johnExcerpt).not.toContain("...");
+
+                    var janeExcerpt = await excerptTextForItem(janeIdx);
+                    expect(janeExcerpt).toContain("class JaneClass extends MyBaseClass {");
+                    expect(janeExcerpt).toContain("Hello, Jane!");
+                    expect(janeExcerpt).not.toContain("...");
+
+                    // Alice lives in a different file (REAL_ALICE_FILE) - the item/excerpt must
+                    // say so using the real server-provided URI, not REAL_FILE's name. yellow()
+                    // sits between the declaration and sayHello (top "..."), and sayHello's own
+                    // body is 21 lines long (bottom "...") - both collapse markers should fire in
+                    // the same excerpt, yellow() itself never shown.
+                    var aliceItemText = getOpenMenuItems().eq(aliceIdx).text();
+                    expect(aliceItemText).toContain(REAL_ALICE_FILE);
+                    var aliceExcerpt = await excerptTextForItem(aliceIdx);
+                    expect(aliceExcerpt).toContain(REAL_ALICE_FILE);
+                    expect(aliceExcerpt).toContain("class AliceClass extends MyBaseClass {");
+                    expect(aliceExcerpt).not.toContain("yellow");
+                    expect(aliceExcerpt).not.toContain("not so soon");
+                    expect((aliceExcerpt.match(/\.\.\./g) || []).length).toBe(2);
+                    var helloAliceCount = (aliceExcerpt.match(/Hello, Alice!/g) || []).length;
+                    expect(helloAliceCount).toBeGreaterThan(0);
+                    expect(helloAliceCount).toBeLessThan(21);
+
+                    // Click Alice's candidate (on the picker already open from the last
+                    // successful attempt above) and confirm the jump actually switches to
+                    // REAL_ALICE_FILE and lands on the right line there.
+                    getOpenMenuItems().eq(aliceIdx).trigger("click");
+                    await awaitsForDone(lastJumpPromise, "jump to AliceClass.sayHello");
+
+                    expect(getOpenMenuItems().length).toBe(0);
+                    var aliceEditor = EditorManager.getCurrentFullEditor();
+                    expect(aliceEditor.document.file.name).toBe(REAL_ALICE_FILE);
+                    var pos = aliceEditor.getCursorPos();
+                    expect(pos.line).toBe(12); // "  sayHello() {" in AliceClass, 0-based
+                }, 35000);
+            });
+        }
+
+        it("should no-op without a picker when no definition is found", async function () {
+            registerMockProvider([]);
+            var editor = await openPolymorphismFile();
+            var posBefore = editor.getCursorPos();
+
+            await awaitsForFail(CommandManager.execute(Commands.NAVIGATE_JUMPTO_DEFINITION),
+                "no definition found rejects instead of hanging");
+
+            expect(getOpenMenuItems().length).toBe(0);
+            var posAfter = editor.getCursorPos();
+            expect(posAfter.line).toBe(posBefore.line);
+            expect(posAfter.ch).toBe(posBefore.ch);
+        });
+    });
+});

--- a/test/spec/JumpToDefinitionMultiTarget-integ-test.js
+++ b/test/spec/JumpToDefinitionMultiTarget-integ-test.js
@@ -284,9 +284,16 @@ define(function (require, exports, module) {
                 await openPolymorphismFile();
 
                 var jumpPromise = CommandManager.execute(Commands.NAVIGATE_JUMPTO_DEFINITION);
-                await awaitPickerOpen(3);
+                // 4, not 3: the base declaration gotoDefinition resolved is a genuinely distinct
+                // location here (unlike a real server, where it usually turns out to be one of the
+                // implementations - see mergeLocations()) and must not be silently dropped in favor
+                // of the implementation results.
+                await awaitPickerOpen(4);
 
-                getOpenMenuItems().eq(2).trigger("click");   // AliceClass.sayHello
+                var itemsText = getOpenMenuItems().text();
+                expect(itemsText).toContain("4:5"); // BASE_SAYHELLO, 1-based - never discarded
+
+                getOpenMenuItems().eq(3).trigger("click");   // AliceClass.sayHello (now 4th: base, John, Jane, Alice)
                 await awaitsForDone(jumpPromise, "jump to an implementation after the fallback");
 
                 var editor = EditorManager.getCurrentFullEditor();
@@ -294,6 +301,23 @@ define(function (require, exports, module) {
                 var pos = editor.getCursorPos();
                 expect(pos.line).toBe(ALICE_SAYHELLO.line);
                 expect(pos.ch).toBe(ALICE_SAYHELLO.ch);
+            });
+
+        it("should not duplicate the base declaration when it already matches an implementation",
+            async function () {
+                // The common real-world case (see #3093 comment thread and live testing): the
+                // single "definition" location coincides with one of the implementations (same
+                // file/position, possibly just a wider range) - it must collapse into that entry,
+                // not add a redundant 4th item.
+                registerMockProvider([locationFor(JOHN_SAYHELLO)], {
+                    result: [locationFor(JOHN_SAYHELLO), locationFor(JANE_SAYHELLO), locationFor(ALICE_SAYHELLO)]
+                });
+                await openPolymorphismFile();
+
+                CommandManager.execute(Commands.NAVIGATE_JUMPTO_DEFINITION);
+                await awaitPickerOpen(3);
+
+                SpecRunnerUtils.simulateKeyEvent(KeyEvent.DOM_VK_ESCAPE, "keydown", $(".inlinemenu-menu.open")[0]);
             });
 
         it("should jump straight to the definition when implementations adds nothing new", async function () {
@@ -536,6 +560,75 @@ define(function (require, exports, module) {
                     // sayHello's own block only - never spills into the unrelated function after it
                     expect(excerpt).toBe(lines.slice(1, 4).join("\n"));
                     expect(excerpt).not.toContain("topLevelThree");
+                });
+        });
+
+        // mergeLocations() is pure array logic - see doJumpToDef's fallBackToImplementations(),
+        // which uses it so a location gotoDefinition already resolved is never silently discarded
+        // in favor of gotoImplementation's answer.
+        describe("location merging", function () {
+            function loc(uri, line, ch) {
+                return {
+                    uri: uri,
+                    range: { start: { line: line, character: ch }, end: { line: line, character: ch + 1 } }
+                };
+            }
+
+            it("should keep a genuinely distinct primary location as its own extra entry, listed first",
+                function () {
+                    var primary = loc("file:///base.js", 1, 2),
+                        extras = [loc("file:///a.js", 5, 2), loc("file:///b.js", 9, 2)],
+                        merged = DefaultProviders._mergeJumpToDefLocations(primary, extras);
+
+                    expect(merged.length).toBe(3);
+                    expect(merged[0]).toBe(primary);
+                    expect(merged[1]).toBe(extras[0]);
+                    expect(merged[2]).toBe(extras[1]);
+                });
+
+            it("should not duplicate an extra that matches the primary location", function () {
+                // extras[1] has the same file/start position as primary, just a different
+                // range.end (as real servers commonly do - see #3093 comment thread and live
+                // testing) - the two are functionally identical (only range.start is ever
+                // used), so it doesn't matter which of the pair survives the dedup, only that
+                // there isn't a redundant duplicate entry in the result.
+                var primary = {
+                        uri: "file:///a.js",
+                        range: { start: { line: 5, character: 2 }, end: { line: 40, character: 3 } }
+                    },
+                    extras = [loc("file:///x.js", 1, 2), loc("file:///a.js", 5, 2), loc("file:///y.js", 9, 2)],
+                    merged = DefaultProviders._mergeJumpToDefLocations(primary, extras);
+
+                expect(merged.length).toBe(3);
+                expect(merged[0]).toBe(primary); // primary is processed first, so it's the one kept
+                expect(merged[1]).toBe(extras[0]);
+                expect(merged[2]).toBe(extras[2]);
+            });
+
+            it("should also dedupe duplicate extras against each other", function () {
+                var primary = loc("file:///a.js", 1, 2),
+                    extras = [loc("file:///b.js", 5, 2), loc("file:///b.js", 5, 2)],
+                    merged = DefaultProviders._mergeJumpToDefLocations(primary, extras);
+
+                expect(merged.length).toBe(2);
+            });
+
+            it("should dedupe locations on the same line at different columns, not just exact matches",
+                function () {
+                    // Real repro: gotoDefinition on a class reference lands at column 0 (the very
+                    // start of "export class JohnClass extends MyBaseClass"), while
+                    // gotoImplementation for that same class lands at the "JohnClass" identifier a
+                    // few columns in - same declaration, same line, different column. Keying
+                    // dedup on the exact character missed this and showed JohnClass twice.
+                    var primary = {
+                            uri: "file:///impx.js",
+                            range: { start: { line: 6, character: 0 }, end: { line: 8, character: 1 } }
+                        },
+                        extras = [loc("file:///impx.js", 6, 13)],
+                        merged = DefaultProviders._mergeJumpToDefLocations(primary, extras);
+
+                    expect(merged.length).toBe(1);
+                    expect(merged[0]).toBe(primary);
                 });
         });
 

--- a/test/spec/JumpToDefinitionMultiTarget-test-files/aliceClass.js
+++ b/test/spec/JumpToDefinitionMultiTarget-test-files/aliceClass.js
@@ -1,0 +1,11 @@
+// A third override living in its own file, used to exercise the "jump target is in a
+// different document" branch of doJumpToDef's picker (see JumpToDefinitionMultiTarget-integ-test.js).
+const { MyBaseClass } = require("./polymorphism");
+
+class AliceClass extends MyBaseClass {
+    sayHello() {
+        console.log("Hello from AliceClass");
+    }
+}
+
+module.exports = { AliceClass };

--- a/test/spec/JumpToDefinitionMultiTarget-test-files/polymorphism.js
+++ b/test/spec/JumpToDefinitionMultiTarget-test-files/polymorphism.js
@@ -1,0 +1,25 @@
+// Fixture modeled on the https://github.com/phcode-dev/phoenix/issues/3093 repro: a base class
+// whose method is overridden by several subclasses, called polymorphically.
+class MyBaseClass {
+    sayHello() {
+        console.log("Hello from MyBaseClass");
+    }
+}
+
+class JohnClass extends MyBaseClass {
+    sayHello() {
+        console.log("Hello from JohnClass");
+    }
+}
+
+class JaneClass extends MyBaseClass {
+    sayHello() {
+        console.log("Hello from JaneClass");
+    }
+}
+
+function greet(person) {
+    person.sayHello();
+}
+
+module.exports = { MyBaseClass, JohnClass, JaneClass, greet };

--- a/test/spec/JumpToDefinitionMultiTarget-test-files/realLspAliceClass.js
+++ b/test/spec/JumpToDefinitionMultiTarget-test-files/realLspAliceClass.js
@@ -1,0 +1,38 @@
+// AliceClass lives here, separate from realLspPolymorphism.js, so the real-vtsls spec in
+// JumpToDefinitionMultiTarget-integ-test.js can verify the picker/excerpt correctly show and open
+// a candidate in a different file (real server-provided URI, not a hand-built mock one). It has an
+// extra sibling method (yellow) and a long sayHello body so the same real jump also exercises both
+// excerpt collapse cases (a member between the declaration and target, and a target body too long
+// to show in full) alongside John/Jane's plain adjacent-declaration case in the other file.
+const { MyBaseClass } = require("./realLspPolymorphism");
+
+class AliceClass extends MyBaseClass {
+  yellow() {
+    console.log("not so soon");
+  }
+  sayHello() {
+    console.log("Hello, Alice!");
+    console.log("Hello, Alice!");
+    console.log("Hello, Alice!");
+    console.log("Hello, Alice!");
+    console.log("Hello, Alice!");
+    console.log("Hello, Alice!");
+    console.log("Hello, Alice!");
+    console.log("Hello, Alice!");
+    console.log("Hello, Alice!");
+    console.log("Hello, Alice!");
+    console.log("Hello, Alice!");
+    console.log("Hello, Alice!");
+    console.log("Hello, Alice!");
+    console.log("Hello, Alice!");
+    console.log("Hello, Alice!");
+    console.log("Hello, Alice!");
+    console.log("Hello, Alice!");
+    console.log("Hello, Alice!");
+    console.log("Hello, Alice!");
+    console.log("Hello, Alice!");
+    console.log("Hello, Alice!");
+  }
+}
+
+module.exports = { AliceClass };

--- a/test/spec/JumpToDefinitionMultiTarget-test-files/realLspPolymorphism.js
+++ b/test/spec/JumpToDefinitionMultiTarget-test-files/realLspPolymorphism.js
@@ -1,0 +1,38 @@
+// Real-LSP repro fixture (see #3093) - used only by the native-app "real vtsls" spec in
+// JumpToDefinitionMultiTarget-integ-test.js, deliberately kept separate from the mocked-provider
+// fixtures (polymorphism.js / aliceClass.js) used by the rest of that file's tests.
+//
+// AliceClass lives in realLspAliceClass.js (imported below) rather than here, same split as the
+// mocked fixtures - so the picker's cross-file candidate (a different filename shown/opened) is
+// exercised against a real server-provided URI too, not just the hand-built mock ones.
+const { AliceClass } = require("./realLspAliceClass");
+
+class MyBaseClass {
+  sayHello() {
+    throw new Error("Method not implemented");
+  }
+}
+
+class JohnClass extends MyBaseClass {
+  sayHello() {
+    console.log("Hello, John!");
+  }
+}
+
+class JaneClass extends MyBaseClass {
+  sayHello() {
+    console.log("Hello, Jane!");
+  }
+}
+
+const myArray = [
+  new JohnClass(),
+  new JaneClass(),
+  new AliceClass()
+];
+
+for (const obj of myArray) {
+  obj.sayHello();
+}
+
+module.exports = { MyBaseClass, JohnClass, JaneClass };


### PR DESCRIPTION
Fixes #3093.

<img width="683" height="274" alt="image" src="https://github.com/user-attachments/assets/121b2e04-d877-4316-a939-69d1d6e149ab" />
<img width="683" height="274" alt="image" src="https://github.com/user-attachments/assets/4ab78ebc-cee8-42a4-af3b-6e3a30956def" />


https://github.com/user-attachments/assets/4b00d57e-7910-45b8-811a-821282c81e80


When `textDocument/definition` resolves to multiple locations (e.g. a
polymorphic call with several overrides), Phoenix used to silently jump
to whichever one was last in the array. This shows a Code-Hints-style
dropdown at the cursor instead, listing every candidate, mouse- and
keyboard-navigable — reusing the existing `InlineMenu` widget.

- Each item shows a hover/keyboard-driven code excerpt so same-named
  overrides in different classes are distinguishable.
- If `definition` resolves to just the base declaration,
  `implementation` is also queried and merged in (declaration first,
  deduped by file+line), since that's the common polymorphic case.
  Merged-in rows get a small badge to mark them as implementations.
- Adds `LSPClient.gotoImplementation()`.
- Hover quickview is suppressed while the picker (or any other
  dropdown/menu) is open.

Tests: `JumpToDefinitionMultiTarget-integ-test.js` — picker
interaction (mocked provider), merge/dedup logic, excerpt-building
logic, and a desktop-only real-vtsls repro.
