### PR TITLE
Fix: Escape key exits full screen on macOS desktop

### DIFF
--- a/docs/API-Reference/editor/Editor.md
+++ b/docs/API-Reference/editor/Editor.md
@@ -1703,3 +1703,18 @@ Constant: Bulls-eye mode, strictly center the text always.
 
 ## CENTERING\_MARGIN
 **Kind**: global constant  
+<a name="getMarkOptionTabstopOutline"></a>
+
+## getMarkOptionTabstopOutline()
+Mark option for a subdued outline box, used to show every remaining stop of an active
+snippet/tab-stop session (see editor/TabstopManager.js) so the user can see at a glance how
+many fields are left and where, even for the ones they haven't tabbed to yet.
+
+**Kind**: global function  
+<a name="getMarkOptionTabstopOutlineActive"></a>
+
+## getMarkOptionTabstopOutlineActive()
+Mark option for the bold/active variant of the above, layered on top of it for whichever stop
+is currently selected in an active snippet/tab-stop session.
+
+**Kind**: global function  

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -1355,6 +1355,9 @@ define(function (require, exports, module) {
         if (!handled && _handleKey(shortcut)) {
             event.stopPropagation();
             event.preventDefault();
+        } else if (!handled && event.key === "Escape" && Phoenix.isNativeApp && brackets.platform === "mac") {
+            // unhandled Esc reaching the native macOS window exits full screen
+            event.preventDefault();
         }
     }
 


### PR DESCRIPTION
**Closing as the appropriate fix should come at a shell level**


On macOS desktop, pressing Escape when nothing in the app was using it (for example after clicking the sidebar) made the app leave full screen. The unhandled key was reaching the native window, which treats Escape as exit full screen.

This change stops the unhandled Escape key from reaching the window. Escape still works as before in the editor, terminal and dialogs. Only affects the macOS desktop app.