### PR TITLE
feat: add web.phcode.dev as the production web domain

### DIFF
--- a/docs/API-Reference/editor/Editor.md
+++ b/docs/API-Reference/editor/Editor.md
@@ -1703,3 +1703,18 @@ Constant: Bulls-eye mode, strictly center the text always.
 
 ## CENTERING\_MARGIN
 **Kind**: global constant  
+<a name="getMarkOptionTabstopOutline"></a>
+
+## getMarkOptionTabstopOutline()
+Mark option for a subdued outline box, used to show every remaining stop of an active
+snippet/tab-stop session (see editor/TabstopManager.js) so the user can see at a glance how
+many fields are left and where, even for the ones they haven't tabbed to yet.
+
+**Kind**: global function  
+<a name="getMarkOptionTabstopOutlineActive"></a>
+
+## getMarkOptionTabstopOutlineActive()
+Mark option for the bold/active variant of the above, layered on top of it for whichever stop
+is currently selected in an active snippet/tab-stop session.
+
+**Kind**: global function  

--- a/src-node/package-lock.json
+++ b/src-node/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@phcode/node-core",
-    "version": "5.2.4-0",
+    "version": "5.3.0-0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@phcode/node-core",
-            "version": "5.2.4-0",
+            "version": "5.3.0-0",
             "hasInstallScript": true,
             "license": "GNU-AGPL3.0",
             "dependencies": {

--- a/src/brackets.config.dist.json
+++ b/src/brackets.config.dist.json
@@ -1,9 +1,9 @@
 {
-    "googleAnalyticsID"       : "G-FBK9RP5YK2",
+    "googleAnalyticsID"       : "G-G3DTS3ZR09",
     "googleAnalyticsIDDesktop": "G-M7MX9BYZZ3",
     "mixPanelID"              : "8cb6814f733e37c05cc59b4adad26407",
     "coreAnalyticsID"         : "phoenix",
-    "coreAnalyticsAppName"    : "phoenix-prod",
+    "coreAnalyticsAppName"    : "phoenix-web",
     "coreAnalyticsAppNameDesktop"    : "desktop-prod",
     "environment"             : "production",
     "buildtype"               : "production",

--- a/src/index.html
+++ b/src/index.html
@@ -47,14 +47,14 @@
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://phcode.dev/" />
+    <meta property="og:url" content="https://web.phcode.dev/" />
     <meta property="og:title" content="Phoenix Code | Code Creatively" />
     <meta property="og:description" content="A text editor designed to make coding as intuitive and fun as playing a video game - specially crafted for web developers, designers, and students." />
     <meta property="og:image" content="assets/images/socialcard.png" />
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image" />
-    <meta property="twitter:url" content="https://phcode.dev/" />
+    <meta property="twitter:url" content="https://web.phcode.dev/" />
     <meta property="twitter:title" content="Phoenix Code | Code Creatively" />
     <meta property="twitter:description" content="A text editor designed to make coding as intuitive and fun as playing a video game - specially crafted for web developers, designers, and students." />
     <meta property="twitter:image" content="assets/images/socialcard.png" />
@@ -73,10 +73,10 @@
     <script>
         if(["dev.phcode.dev", "staging.phcode.dev"].includes(location.hostname)
             && localStorage.getItem("devDomainsEnabled") !== "true"){
-            alert("Hello explorer, you have reached a development version of phcode.dev that is not for general use and could be very unstable." +
+            alert("Hello explorer, you have reached a development version of Phoenix Code that is not for general use and could be very unstable." +
                 `\n\nIf you know what you are doing and what to visit the dev site, please go to https://${location.hostname}/devEnable.html to enable dev site and visit again.` +
-                "\n\nYou will now be redirected to phcode.dev.");
-            window.location = "https://phcode.dev";
+                "\n\nYou will now be redirected to web.phcode.dev.");
+            window.location = "https://web.phcode.dev";
         }
         if(window.electronAppAPI) {
             window.__ELECTRON__ = true;
@@ -446,6 +446,7 @@
                     'https://phcode.live': true, // phcode prod live preview server
                     'https://ai-panel-onboarding.phcode.dev': true, // Ai panel onboarding iframes
                     'https://phcode.dev': true,
+                    'https://web.phcode.dev': true, // prod web
                     'https://dev.phcode.dev': true,
                     'https://staging.phcode.dev': true,
                     'https://create.phcode.dev': true

--- a/src/live-preview-loader.html
+++ b/src/live-preview-loader.html
@@ -94,10 +94,14 @@
             'http://127.0.0.1:5000': true, // playwright tests
             'https://phcode.live': true, // phcode prod live preview server
             'https://phcode.dev': true,
+            'https://web.phcode.dev': true, // prod web
             'https://dev.phcode.dev': true,
             'https://staging.phcode.dev': true,
             'https://create.phcode.dev': true
         };
+        // this page is always served from the phoenix origin, so trust it whichever domain that is.
+        // keeps the loader working on any new phoenix host without another edit here.
+        TRUSTED_ORIGINS[location.origin] = true;
         let okMessageTemplate;
 
         function isTrustedURL(url) {

--- a/src/loggerSetup.js
+++ b/src/loggerSetup.js
@@ -28,6 +28,7 @@
         "phtauri://localhost", // mac or linux desktop
         "https://phtauri.localhost", //windows desktop
         "https://phcode.dev", // prod
+        "https://web.phcode.dev", // prod web
         "https://create.phcode.dev", // extension authoring prod
         "https://dev.phcode.dev", // dev url
         "https://staging.phcode.dev" // staging url
@@ -236,8 +237,8 @@
     function _isSafePathForLogging(pathText) {
         const lower = pathText.toLowerCase();
         const safeStarts = ["phtauri://", "https://phtauri.localhost", "http://localhost",
-            "https://localhost", "https://phcode.dev", "https://create.phcode.dev",
-            "https://dev.phcode.dev", "https://staging.phcode.dev",
+            "https://localhost", "https://phcode.dev", "https://web.phcode.dev",
+            "https://create.phcode.dev", "https://dev.phcode.dev", "https://staging.phcode.dev",
             "/usr/", "/lib/", "/lib64/", "/opt/", "/snap/", "/bin/", "/sbin/", "/etc/",
             "/system/", "/applications/", "c:\\program files", "c:\\windows"];
         for(let prefix of safeStarts){

--- a/src/robots.txt
+++ b/src/robots.txt
@@ -37,7 +37,7 @@ Disallow: /assets/
 Disallow: /test/
 
 # XML sitemaps
-Sitemap: https://phcode.dev/sitemap-phcode.xml
+Sitemap: https://web.phcode.dev/sitemap-phcode.xml
 Sitemap: https://sitemaps.phcode.io/sitemap-phcode.xml
 
 # more sitemap urls can be given here, but just 1 for now.

--- a/src/sitemap-phcode.xml
+++ b/src/sitemap-phcode.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <!-- Please also modify the file at sitemaps.phcode.io/sitemap-phcode.xml if modifying this file-->
   <url>
-    <loc>https://phcode.dev/download/</loc>
+    <loc>https://web.phcode.dev/download/</loc>
     <changefreq>daily</changefreq>
   </url>
   <url>
@@ -10,7 +10,7 @@
     <changefreq>daily</changefreq>
   </url>
   <url>
-    <loc>https://phcode.dev/</loc>
+    <loc>https://web.phcode.dev/</loc>
     <changefreq>daily</changefreq>
   </url>
   <url>

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -363,6 +363,7 @@
           'https://phcode.live': true, // phcode prod live preview server
           'https://ai-panel-onboarding.phcode.dev': true, // Ai panel onboarding iframes
           'https://phcode.dev': true,
+          'https://web.phcode.dev': true, // prod web
           'https://dev.phcode.dev': true,
           'https://staging.phcode.dev': true,
           'https://create.phcode.dev': true


### PR DESCRIPTION
web.phcode.dev becomes the new home for the hosted web app, with phcode.dev deprecated shortly after.

Most of the app is origin-relative and boots on a new host unchanged (service worker scope, VFS base URL, PWA manifest, CSP). What needed fixing are the places that compare against a hardcoded list of known origins:

- Phoenix.TRUSTED_ORIGINS in src/index.html and test/SpecRunner.html, which is also serialized into live preview pages as TRUSTED_ORIGINS_EMBED.
- The duplicate list in live-preview-loader.html. This page also lacked the TRUSTED_ORIGINS[location.origin] = true self-add that the other two copies have, so it is the one origin list that could not adapt to a new host on its own. Added.
- loggableURLS in loggerSetup.js. This is a startsWith prefix match, so https://web.phcode.dev/ did not match https://phcode.dev and Bugsnag would have been silently disabled on the new domain. Same for the safeStarts list, which decides whether our own URLs survive path redaction in error reports.

Deprecation of phcode.dev:
- The dev/staging interstitial now redirects to web.phcode.dev instead of the domain being retired. web.phcode.dev is deliberately not added to that gated-hostname list, it is production.
- og:url, twitter:url, the robots.txt sitemap line and sitemap-phcode.xml point at the new home. Both domains serve the same artifact during the overlap, so this consolidates SEO and link previews.

Analytics for the prod web build move to a new GA property and core-analytics app name so the retired endpoint stops accruing data. Desktop GA, desktop app name and MixPanel are unchanged, the desktop app is not moving origins.

Note that phcode.live must allowlist the new origin in its own docs/trustedOrigins.js, and account.phcode.dev needs CORS for it with Allow-Credentials, otherwise login and live preview fail silently.
