### PR TITLE
feat: migrate browser data from the legacy web origin to web.phcode.dev

### DIFF
--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -461,6 +461,9 @@ define(function (require, exports, module) {
     /** Toggles auto update */
     exports.HELP_AUTO_UPDATE            = "help.autoUpdate";             // shortcuts integrated extension
 
+    /** Migrates browser data from the legacy web origin */
+    exports.HELP_MIGRATE_DATA           = "help.migrateData";           // MigrateAssist integrated extension
+
     // Working Set Configuration
     /** Sorts working set by order files were added */
     exports.CMD_WORKINGSET_SORT_BY_ADDED  = "cmd.sortWorkingSetByAdded";     // WorkingSetSort.js       _handleSort()

--- a/src/extensionsIntegrated/MigrateAssist/constants.js
+++ b/src/extensionsIntegrated/MigrateAssist/constants.js
@@ -1,0 +1,206 @@
+/*
+ * GNU AGPL-3.0 License
+ *
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
+ *
+ */
+
+/**
+ * Shared configuration for the one time move off the legacy web origin onto web.phcode.dev.
+ *
+ * Everything that has to change when the rollout moves forward lives here: the two origins and the
+ * sunset date. `LEGACY_ORIGIN` points at staging while the flow is being validated end to end;
+ * flipping it to https://phcode.dev is the only edit needed to go live.
+ *
+ * @module extensionsIntegrated/MigrateAssist/constants
+ */
+define(function (require, exports, module) {
+
+    // Domain names, package ids and store urls are brand identifiers rather than prose. They must
+    // render identically in every locale, so they stay here instead of going through strings.js.
+
+    /**
+     * The origin we are migrating away from. Switch to "https://phcode.dev" once the flow has been
+     * validated against staging.
+     * @type {string}
+     */
+    const LEGACY_ORIGIN = "https://staging.phcode.dev";
+
+    /**
+     * The origin we are migrating to.
+     * @type {string}
+     */
+    const NEW_ORIGIN = "https://web.phcode.dev";
+
+    /**
+     * Human readable form of the above, used inside translated sentences via StringUtils.format.
+     */
+    const LEGACY_DOMAIN_NAME = "phcode.dev";
+    const NEW_DOMAIN_NAME = "web.phcode.dev";
+
+    /**
+     * The day the legacy origin stops serving. Month is 0 based, so 8 is September.
+     * @type {number}
+     */
+    const SUNSET_DATE = Date.UTC(2026, 8, 1);
+
+    /**
+     * Android/ChromeOS Trusted Web Activity that wraps the legacy origin. Users launched from this
+     * package need an app update rather than a browser navigation, see sunset-dialog.js.
+     */
+    const TWA_PACKAGE_ID = "prod.phcode.twa";
+    const TWA_REFERRER_PREFIX = `android-app://${TWA_PACKAGE_ID}`;
+    const TWA_STORE_URL = `https://play.google.com/store/apps/details?id=${TWA_PACKAGE_ID}`;
+
+    /**
+     * PhStore key recording that the migration already ran. Once set, the automatic path never runs
+     * again and the user has to ask for it from the Help menu.
+     * @type {string}
+     */
+    const MIGRATION_DONE_KEY = "migrateAssist.v1.done";
+
+    /**
+     * Dev only override, so the whole cross origin flow can be exercised on one dev server.
+     * http://localhost:8000 and http://127.0.0.1:8000 are different origins with separate IndexedDB
+     * but the same files, and both are already trusted, so they make a usable legacy/new pair.
+     * Set localStorage.MIGRATE_ORIGINS_OVERRIDE to {"legacy": "...", "target": "..."}.
+     */
+    const ORIGINS_OVERRIDE_KEY = "MIGRATE_ORIGINS_OVERRIDE";
+
+    let _override = null;
+    function _getOverride() {
+        if (_override) {
+            return _override;
+        }
+        _override = {};
+        // Mirrors the accounts server override in index.html: dev builds only, never in tests, so a
+        // stray localStorage value can never redirect a production user to an attacker's origin.
+        if (Phoenix.isTestWindow || !Phoenix.config || Phoenix.config.environment !== "dev") {
+            return _override;
+        }
+        try {
+            const parsed = JSON.parse(localStorage.getItem(ORIGINS_OVERRIDE_KEY));
+            if (parsed && typeof parsed.legacy === "string" && typeof parsed.target === "string") {
+                _override = parsed;
+                console.log("MigrateAssist: using dev origin override", _override);
+            }
+        } catch (e) {
+            console.warn("MigrateAssist: could not read origin override, using defaults", e);
+        }
+        return _override;
+    }
+
+    /**
+     * The origin holding the data to be moved.
+     * @return {string}
+     */
+    function getLegacyOrigin() {
+        return _getOverride().legacy || LEGACY_ORIGIN;
+    }
+
+    /**
+     * The origin the data is being moved into.
+     * @return {string}
+     */
+    function getNewOrigin() {
+        return _getOverride().target || NEW_ORIGIN;
+    }
+
+    /**
+     * True when this window is the site being retired.
+     * @return {boolean}
+     */
+    function isLegacyOrigin() {
+        return !Phoenix.isNativeApp && location.origin === getLegacyOrigin();
+    }
+
+    /**
+     * True when this window is the new home.
+     * @return {boolean}
+     */
+    function isNewOrigin() {
+        return !Phoenix.isNativeApp && location.origin === getNewOrigin();
+    }
+
+    /**
+     * URL of the helper page on the legacy origin.
+     *
+     * Both origins serve the same artifact with the same layout, so the helper sits at the same path
+     * prefix as the page asking for it. In production that is the origin root; on the dev server the
+     * app lives under /src/, and hardcoding "/" there would 404.
+     * @return {string}
+     */
+    function getMigrateAssistURL() {
+        const pathname = location.pathname;
+        const prefix = pathname.substring(0, pathname.lastIndexOf("/") + 1);
+        return `${getLegacyOrigin()}${prefix}migrateAssist.html`;
+    }
+
+    /**
+     * Safari and iOS are deliberately out of scope for the automatic migration. This is a product
+     * decision rather than a technical limit; the same site iframe would very likely work there too.
+     * @return {boolean}
+     */
+    function isMigrationSupportedBrowser() {
+        return !(Phoenix.browser.desktop.isSafari || Phoenix.browser.mobile.isIos);
+    }
+
+    /**
+     * True when the app was launched from our own Trusted Web Activity. document.referrer only
+     * reflects the initial navigation, so callers should read this once at boot and cache it.
+     * @return {boolean}
+     */
+    function isTWALaunch() {
+        return (document.referrer || "").startsWith(TWA_REFERRER_PREFIX);
+    }
+
+    /**
+     * Whole days left before the legacy origin is retired, floored at 0.
+     * @param {number} [now] current time in ms, for tests
+     * @return {number}
+     */
+    function daysToSunset(now) {
+        const millisPerDay = 24 * 60 * 60 * 1000;
+        const remaining = SUNSET_DATE - (typeof now === "number" ? now : Date.now());
+        if (remaining <= 0) {
+            return 0;
+        }
+        return Math.ceil(remaining / millisPerDay);
+    }
+
+    /**
+     * @param {number} [now] current time in ms, for tests
+     * @return {boolean} true once the legacy origin is expected to be gone
+     */
+    function isPastSunset(now) {
+        return (typeof now === "number" ? now : Date.now()) >= SUNSET_DATE;
+    }
+
+    exports.LEGACY_DOMAIN_NAME = LEGACY_DOMAIN_NAME;
+    exports.NEW_DOMAIN_NAME = NEW_DOMAIN_NAME;
+    exports.SUNSET_DATE = SUNSET_DATE;
+    exports.TWA_STORE_URL = TWA_STORE_URL;
+    exports.MIGRATION_DONE_KEY = MIGRATION_DONE_KEY;
+    exports.getLegacyOrigin = getLegacyOrigin;
+    exports.getMigrateAssistURL = getMigrateAssistURL;
+    exports.getNewOrigin = getNewOrigin;
+    exports.isLegacyOrigin = isLegacyOrigin;
+    exports.isNewOrigin = isNewOrigin;
+    exports.isMigrationSupportedBrowser = isMigrationSupportedBrowser;
+    exports.isTWALaunch = isTWALaunch;
+    exports.daysToSunset = daysToSunset;
+    exports.isPastSunset = isPastSunset;
+});

--- a/src/extensionsIntegrated/MigrateAssist/html/migrate-progress.html
+++ b/src/extensionsIntegrated/MigrateAssist/html/migrate-progress.html
@@ -1,0 +1,25 @@
+<div class="migrate-assist-dialog template modal">
+    <div class="modal-header">
+        <h1 class="dialog-title">{{Strings.MIGRATE_PROGRESS_TITLE}}</h1>
+    </div>
+    <div class="modal-body">
+        <div class="dialog-message">
+            <p class="migrate-assist-intro">{{introMessage}}</p>
+            <div class="progress-bar-container">
+                <div class="progress-bar-background">
+                    <div class="progress progress-bar-foreground migrate-assist-bar" style="width: 0%"></div>
+                </div>
+            </div>
+            <p class="migrate-assist-status">{{Strings.PLEASE_WAIT}}</p>
+            <p class="migrate-assist-detail forced-hidden"></p>
+        </div>
+    </div>
+    <div class="modal-footer">
+        <button class="dialog-button btn forced-hidden migrate-assist-close" data-button-id="close">
+            {{Strings.CLOSE}}
+        </button>
+        <button class="dialog-button btn primary forced-hidden migrate-assist-reload" data-button-id="reload">
+            {{Strings.MIGRATE_RELOAD_NOW}}
+        </button>
+    </div>
+</div>

--- a/src/extensionsIntegrated/MigrateAssist/main.js
+++ b/src/extensionsIntegrated/MigrateAssist/main.js
@@ -1,0 +1,76 @@
+/*
+ * GNU AGPL-3.0 License
+ *
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
+ *
+ */
+
+/**
+ * Entry point for the one time move off the legacy web origin onto web.phcode.dev.
+ *
+ * Which half runs depends purely on which origin this window is:
+ *  - on the origin being retired, announce the move once per boot (sunset-dialog);
+ *  - on the new origin, quietly check whether anything is left behind and pull it across
+ *    (migrator), plus register the Help menu entry that lets the user ask for it again later.
+ *
+ * Anywhere else, including the desktop app, this module does nothing at all.
+ *
+ * Styling lives in `../../styles/Extn-MigrateAssist.less`.
+ *
+ * @module extensionsIntegrated/MigrateAssist/main
+ */
+define(function (require, exports, module) {
+    const AppInit = require("utils/AppInit"),
+        CommandManager = require("command/CommandManager"),
+        Commands = require("command/Commands"),
+        Menus = require("command/Menus"),
+        Strings = require("strings"),
+        Constants = require("./constants"),
+        SunsetDialog = require("./sunset-dialog"),
+        Migrator = require("./migrator");
+
+    function _initLegacyOrigin() {
+        if (Phoenix.isTestWindow) {
+            return;
+        }
+        SunsetDialog.show();
+    }
+
+    function _initNewOrigin() {
+        // The menu entry is only registered here, so it can never show up on the legacy origin or on
+        // desktop. It is also skipped on Safari/iOS, where the migration is deliberately not
+        // implemented: offering an action we do not honour would be worse than not offering it.
+        if (!Phoenix.isTestWindow && Constants.isMigrationSupportedBrowser()) {
+            CommandManager.register(Strings.CMD_MIGRATE_DATA, Commands.HELP_MIGRATE_DATA, function () {
+                Migrator.runManually();
+            });
+            // Anchored to About rather than to Check for Updates: the updater only registers its
+            // command on the desktop build, so on the web the anchor would not exist and this would
+            // silently fall through to the very bottom of the menu.
+            Menus.getMenu(Menus.AppMenuBar.HELP_MENU)
+                .addMenuItem(Commands.HELP_MIGRATE_DATA, "", Menus.BEFORE, Commands.HELP_ABOUT);
+        }
+        Migrator.runOnBoot();
+    }
+
+    AppInit.appReady(function () {
+        if (Constants.isLegacyOrigin()) {
+            _initLegacyOrigin();
+        } else if (Constants.isNewOrigin()) {
+            _initNewOrigin();
+        }
+    });
+});

--- a/src/extensionsIntegrated/MigrateAssist/migrator.js
+++ b/src/extensionsIntegrated/MigrateAssist/migrator.js
@@ -1,0 +1,364 @@
+/*
+ * GNU AGPL-3.0 License
+ *
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
+ *
+ */
+
+/**
+ * Pulls projects, preferences and extensions across from the origin being retired.
+ *
+ * Runs on the new origin only. A hidden iframe on the legacy origin (see src/migrateAssist.html)
+ * zips one top level folder at a time and streams it over postMessage; this side reassembles each
+ * zip and hands it to ZipUtils.unzipBinDataToLocation, which writes files without deleting anything
+ * first. That gives us exactly the collision rule we want, source wins and extras survive.
+ *
+ * The automatic path is silent unless there is genuinely something to move. The manual path, driven
+ * from the Help menu, always reports what happened, because an explicit user action that appears to
+ * do nothing is worse than no action at all.
+ *
+ * @module extensionsIntegrated/MigrateAssist/migrator
+ */
+define(function (require, exports, module) {
+    const Dialogs = require("widgets/Dialogs"),
+        DefaultDialogs = require("widgets/DefaultDialogs"),
+        Mustache = require("thirdparty/mustache/mustache"),
+        Strings = require("strings"),
+        StringUtils = require("utils/StringUtils"),
+        Metrics = require("utils/Metrics"),
+        ZipUtils = require("utils/ZipUtils"),
+        PreferencesManager = require("preferences/PreferencesManager"),
+        CommandManager = require("command/CommandManager"),
+        Commands = require("command/Commands"),
+        Constants = require("./constants"),
+        progressTemplate = require("text!./html/migrate-progress.html");
+
+    const HANDSHAKE_TIMEOUT_MS = 15000,
+        BUNDLE_TIMEOUT_MS = 120000,
+        IFRAME_ID = "migrate-assist-frame";
+
+    const RESULT_MIGRATED = "migrated",
+        RESULT_NOTHING = "nothing",
+        RESULT_UNREACHABLE = "unreachable";
+
+    let migrationRunning = false;
+
+    /**
+     * Talks to the helper page on the legacy origin. Resolves once the scan comes back; individual
+     * bundles are then requested one at a time so only one zip is ever in memory.
+     */
+    function _createBridge() {
+        const legacyOrigin = Constants.getLegacyOrigin();
+        const iframe = document.createElement("iframe");
+        iframe.id = IFRAME_ID;
+        iframe.setAttribute("title", "data migration helper");
+        iframe.style.display = "none";
+
+        let pendingScan = null,
+            bundleHandler = null,
+            destroyed = false;
+
+        function _onMessage(event) {
+            // Both checks matter: the origin proves who sent it, the source proves it came from our
+            // frame rather than any other iframe sharing this window's message bus.
+            if (event.origin !== legacyOrigin || event.source !== iframe.contentWindow) {
+                return;
+            }
+            const data = event.data;
+            if (!data || typeof data !== "object") {
+                return;
+            }
+            if (data.type === "MIGRATE_READY" && pendingScan) {
+                iframe.contentWindow.postMessage({ type: "MIGRATE_SCAN" }, legacyOrigin);
+            } else if (data.type === "MIGRATE_SCAN_RESULT" && pendingScan) {
+                const resolve = pendingScan;
+                pendingScan = null;
+                resolve(data);
+            } else if (bundleHandler) {
+                bundleHandler(data);
+            }
+        }
+
+        // Registered before the src is set. The frame can post READY faster than the next microtask,
+        // and attaching afterwards loses the handshake and hangs until the timeout.
+        window.addEventListener("message", _onMessage);
+
+        function destroy() {
+            if (destroyed) {
+                return;
+            }
+            destroyed = true;
+            window.removeEventListener("message", _onMessage);
+            if (iframe.parentNode) {
+                iframe.parentNode.removeChild(iframe);
+            }
+        }
+
+        function scan() {
+            return new Promise((resolve, reject) => {
+                const timer = setTimeout(() => {
+                    pendingScan = null;
+                    // Covers the origin being offline, refusing to be framed, or simply not having
+                    // this page deployed yet.
+                    reject(new Error("timed out waiting for " + legacyOrigin));
+                }, HANDSHAKE_TIMEOUT_MS);
+                pendingScan = function (result) {
+                    clearTimeout(timer);
+                    resolve(result);
+                };
+                iframe.src = Constants.getMigrateAssistURL() + "?parentOrigin="
+                    + encodeURIComponent(location.origin);
+                document.body.appendChild(iframe);
+            });
+        }
+
+        /**
+         * Requests one bundle and reassembles its chunks into a single ArrayBuffer.
+         */
+        function fetchBundle(id) {
+            return new Promise((resolve, reject) => {
+                const chunks = [];
+                let expected = -1,
+                    received = 0;
+                const timer = setTimeout(() => {
+                    bundleHandler = null;
+                    reject(new Error("timed out receiving " + id));
+                }, BUNDLE_TIMEOUT_MS);
+
+                bundleHandler = function (data) {
+                    if (data.id !== id) {
+                        return;
+                    }
+                    if (data.type === "MIGRATE_ERROR") {
+                        clearTimeout(timer);
+                        bundleHandler = null;
+                        reject(new Error(data.message));
+                    } else if (data.type === "MIGRATE_BUNDLE_META") {
+                        expected = data.chunkCount;
+                    } else if (data.type === "MIGRATE_CHUNK") {
+                        chunks[data.index] = data.chunk;
+                        received = received + 1;
+                        if (data.last || (expected > 0 && received === expected)) {
+                            clearTimeout(timer);
+                            bundleHandler = null;
+                            const total = chunks.reduce((sum, c) => sum + c.byteLength, 0);
+                            const merged = new Uint8Array(total);
+                            let offset = 0;
+                            for (const chunk of chunks) {
+                                merged.set(new Uint8Array(chunk), offset);
+                                offset = offset + chunk.byteLength;
+                            }
+                            resolve(merged.buffer);
+                        }
+                    }
+                };
+                iframe.contentWindow.postMessage({ type: "MIGRATE_BUNDLE", id: id }, legacyOrigin);
+            });
+        }
+
+        return { scan, fetchBundle, destroy };
+    }
+
+    function _showProgressDialog(bundleCount) {
+        const dialog = Dialogs.showModalDialogUsingTemplate(
+            Mustache.render(progressTemplate, {
+                Strings: Strings,
+                introMessage: StringUtils.format(Strings.MIGRATE_PROGRESS_INTRO,
+                    Constants.LEGACY_DOMAIN_NAME)
+            }),
+            false // no auto dismiss, the transfer must not be interrupted half way
+        );
+        const $dlg = dialog.getElement();
+        let bundlesDone = 0;
+
+        return {
+            dialog: dialog,
+            setWaiting: function (index, name) {
+                // The remote side is zipping. Nothing to count yet, so pulse rather than sit at 0%.
+                $dlg.find(".migrate-assist-bar").addClass("migrate-assist-bar-indeterminate");
+                $dlg.find(".migrate-assist-status")
+                    .text(StringUtils.format(Strings.MIGRATE_PROGRESS_PREPARING, name, index + 1, bundleCount));
+            },
+            setBundleProgress: function (index, name, doneFiles, totalFiles) {
+                $dlg.find(".migrate-assist-bar").removeClass("migrate-assist-bar-indeterminate");
+                bundlesDone = index;
+                const withinBundle = totalFiles ? (doneFiles / totalFiles) : 0;
+                const overall = Math.min(100, Math.round(((bundlesDone + withinBundle) / bundleCount) * 100));
+                $dlg.find(".migrate-assist-bar").css("width", `${overall}%`);
+                $dlg.find(".migrate-assist-status")
+                    .text(StringUtils.format(Strings.MIGRATE_PROGRESS_STATUS, name, index + 1, bundleCount));
+            },
+            finish: function (summary) {
+                $dlg.find(".migrate-assist-bar")
+                    .removeClass("migrate-assist-bar-indeterminate")
+                    .css("width", "100%");
+                $dlg.find(".migrate-assist-intro").text(Strings.MIGRATE_DONE_TITLE);
+                $dlg.find(".migrate-assist-status").text(summary.message);
+                if (summary.detail) {
+                    $dlg.find(".migrate-assist-detail").removeClass("forced-hidden").text(summary.detail);
+                }
+                $dlg.find(".migrate-assist-reload").removeClass("forced-hidden").on("click", function () {
+                    CommandManager.execute(Commands.APP_RELOAD);
+                });
+                $dlg.find(".migrate-assist-close").removeClass("forced-hidden").on("click", function () {
+                    dialog.close();
+                });
+            }
+        };
+    }
+
+    async function _applyPreferences(prefsText) {
+        // Flush first. The in memory user scope is authoritative, so overwriting the file underneath
+        // it would just get clobbered by the next save.
+        await PreferencesManager.save();
+        const prefFile = PreferencesManager.getUserPrefFile();
+        await Phoenix.VFS.writeFileAsync(prefFile, prefsText, "utf8");
+        // Tell the preference system the file changed so the scope reloads and listeners, including
+        // the theme, pick it up without a restart.
+        PreferencesManager.fileChanged(prefFile);
+    }
+
+    function _applyPhStore(phStore) {
+        for (const key of Object.keys(phStore || {})) {
+            PhStore.setItem(key, phStore[key]);
+        }
+    }
+
+    /**
+     * @param {boolean} manual true when the user asked for this from the Help menu
+     * @return {Promise<string>} one of RESULT_MIGRATED, RESULT_NOTHING, RESULT_UNREACHABLE
+     */
+    async function run(manual) {
+        if (migrationRunning) {
+            return RESULT_NOTHING;
+        }
+        migrationRunning = true;
+        const bridge = _createBridge();
+        let progress = null;
+        try {
+            const scan = await bridge.scan();
+            if (!scan.hasData || !scan.bundles.length) {
+                Metrics.countEvent(Metrics.EVENT_TYPE.PLATFORM, "migrateAssist",
+                    manual ? "manualNothing" : "autoNothing");
+                return RESULT_NOTHING;
+            }
+
+            Metrics.countEvent(Metrics.EVENT_TYPE.PLATFORM, "migrateAssist",
+                manual ? "manualStart" : "autoStart");
+            progress = _showProgressDialog(scan.bundles.length);
+
+            const failed = [];
+            let migratedFiles = 0;
+            for (let i = 0; i < scan.bundles.length; i++) {
+                const bundle = scan.bundles[i];
+                const name = bundle.dest.substring(bundle.dest.lastIndexOf("/") + 1);
+                progress.setWaiting(i, name);
+                try {
+                    const buffer = await bridge.fetchBundle(bundle.id);
+                    await ZipUtils.unzipBinDataToLocation(buffer, bundle.dest, false,
+                        function (doneCount, totalCount) {
+                            progress.setBundleProgress(i, name, doneCount, totalCount);
+                            return true; // must be explicit, see unzipBinDataToLocation
+                        });
+                    migratedFiles = migratedFiles + bundle.fileCount;
+                } catch (err) {
+                    // One bad folder should not cost the user everything else.
+                    console.error("MigrateAssist: bundle failed", bundle.id, err);
+                    failed.push(name);
+                }
+            }
+
+            if (scan.prefs) {
+                try {
+                    await _applyPreferences(scan.prefs);
+                } catch (err) {
+                    console.error("MigrateAssist: could not apply preferences", err);
+                    failed.push("phcode.json");
+                }
+            }
+            _applyPhStore(scan.phStore);
+
+            PhStore.setItem(Constants.MIGRATION_DONE_KEY, {
+                at: Date.now(),
+                files: migratedFiles,
+                failed: failed.length
+            });
+            Metrics.countEvent(Metrics.EVENT_TYPE.PLATFORM, "migrateAssist",
+                failed.length ? "completedWithErrors" : "completed");
+
+            progress.finish({
+                message: StringUtils.format(Strings.MIGRATE_DONE_MESSAGE, migratedFiles),
+                detail: failed.length
+                    ? StringUtils.format(Strings.MIGRATE_DONE_PARTIAL, failed.join(", "))
+                    : null
+            });
+            return RESULT_MIGRATED;
+        } catch (err) {
+            console.error("MigrateAssist: migration could not run", err);
+            Metrics.countEvent(Metrics.EVENT_TYPE.PLATFORM, "migrateAssist",
+                manual ? "manualUnreachable" : "autoUnreachable");
+            if (progress) {
+                progress.dialog.close();
+            }
+            return RESULT_UNREACHABLE;
+        } finally {
+            migrationRunning = false;
+            bridge.destroy();
+        }
+    }
+
+    /**
+     * Boot time entry point. Stays completely silent unless there is something to move, and never
+     * runs again once the migration has succeeded.
+     */
+    function runOnBoot() {
+        if (!Constants.isNewOrigin() || Phoenix.isNativeApp || Phoenix.isTestWindow) {
+            return;
+        }
+        if (!Constants.isMigrationSupportedBrowser()) {
+            return;
+        }
+        if (PhStore.getItem(Constants.MIGRATION_DONE_KEY)) {
+            return;
+        }
+        // Once the legacy origin is gone there is nothing to probe, so the feature disables itself
+        // rather than opening a doomed iframe on every boot forever.
+        if (Constants.isPastSunset()) {
+            return;
+        }
+        run(false);
+    }
+
+    /**
+     * Help menu entry point. Ignores the done flag and the sunset date, and always says what
+     * happened.
+     */
+    async function runManually() {
+        const result = await run(true);
+        if (result === RESULT_NOTHING) {
+            Dialogs.showModalDialog(DefaultDialogs.DIALOG_ID_INFO,
+                Strings.MIGRATE_NOTHING_TITLE,
+                StringUtils.format(Strings.MIGRATE_NOTHING_MESSAGE, Constants.LEGACY_DOMAIN_NAME));
+        } else if (result === RESULT_UNREACHABLE) {
+            Dialogs.showModalDialog(DefaultDialogs.DIALOG_ID_ERROR,
+                Strings.MIGRATE_UNREACHABLE_TITLE,
+                StringUtils.format(Strings.MIGRATE_UNREACHABLE_MESSAGE, Constants.LEGACY_DOMAIN_NAME));
+        }
+    }
+
+    exports.runOnBoot = runOnBoot;
+    exports.runManually = runManually;
+});

--- a/src/extensionsIntegrated/MigrateAssist/sunset-dialog.js
+++ b/src/extensionsIntegrated/MigrateAssist/sunset-dialog.js
@@ -1,0 +1,132 @@
+/*
+ * GNU AGPL-3.0 License
+ *
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
+ *
+ */
+
+/**
+ * The "we are moving" dialog, shown on the origin being retired on every boot.
+ *
+ * Three variants, differing only in the primary button and the closing sentence:
+ *  - default, sends the user to the new site where their data migrates automatically;
+ *  - Trusted Web Activity, sends the user to the Play Store instead, because the installed app only
+ *    trusts the legacy origin and navigating it elsewhere would surface a browser URL bar inside
+ *    what looks like an app;
+ *  - Safari/iOS, where the automatic migration is deliberately not implemented, so those users are
+ *    told to download their projects by hand rather than being left to find out at the cutoff.
+ *
+ * @module extensionsIntegrated/MigrateAssist/sunset-dialog
+ */
+define(function (require, exports, module) {
+    const Dialogs = require("widgets/Dialogs"),
+        DefaultDialogs = require("widgets/DefaultDialogs"),
+        Strings = require("strings"),
+        StringUtils = require("utils/StringUtils"),
+        Metrics = require("utils/Metrics"),
+        Constants = require("./constants");
+
+    const BTN_GO_NEW_SITE = "goNewSite",
+        BTN_UPDATE_APP = "updateApp",
+        BTN_STAY = "stay";
+
+    // document.referrer only reflects the navigation that opened this document, so read it once
+    // before anything can navigate and hold on to the answer.
+    const isTWA = Constants.isTWALaunch();
+
+    function _buildMessage() {
+        const paragraphs = [];
+
+        paragraphs.push(StringUtils.format(Strings.MIGRATE_MOVING_MESSAGE,
+            Constants.LEGACY_DOMAIN_NAME, Constants.NEW_DOMAIN_NAME));
+
+        if (!Constants.isPastSunset()) {
+            const days = Constants.daysToSunset();
+            paragraphs.push(StringUtils.format(
+                days === 1 ? Strings.MIGRATE_SUNSET_COUNTDOWN_ONE : Strings.MIGRATE_SUNSET_COUNTDOWN,
+                days, Constants.LEGACY_DOMAIN_NAME));
+        }
+
+        if (!Constants.isMigrationSupportedBrowser()) {
+            paragraphs.push(Strings.MIGRATE_MANUAL_DOWNLOAD_NOTE);
+        } else if (isTWA) {
+            paragraphs.push(Strings.MIGRATE_TWA_UPDATE_NOTE);
+            paragraphs.push(StringUtils.format(Strings.MIGRATE_TWA_BROWSER_LINK,
+                Constants.getNewOrigin(), Constants.NEW_DOMAIN_NAME));
+        } else {
+            paragraphs.push(StringUtils.format(Strings.MIGRATE_DATA_SAFE_NOTE, Constants.NEW_DOMAIN_NAME));
+        }
+
+        return paragraphs.map((text) => `<p>${text}</p>`).join("");
+    }
+
+    function _buildButtons() {
+        // "Stay here" is a real choice, not a nag dismiss. On managed ChromeOS fleets the Play Store
+        // can be blocked outright, so the update button may be a dead end through no fault of the
+        // user, and the app has to keep working for them.
+        const stayButton = {
+            className: Dialogs.DIALOG_BTN_CLASS_NORMAL,
+            id: BTN_STAY,
+            text: Strings.MIGRATE_STAY_HERE
+        };
+        if (isTWA) {
+            return [
+                stayButton,
+                {
+                    className: Dialogs.DIALOG_BTN_CLASS_PRIMARY,
+                    id: BTN_UPDATE_APP,
+                    text: Strings.MIGRATE_UPDATE_APP
+                }
+            ];
+        }
+        return [
+            stayButton,
+            {
+                className: Dialogs.DIALOG_BTN_CLASS_PRIMARY,
+                id: BTN_GO_NEW_SITE,
+                text: Strings.MIGRATE_GO_TO_NEW_SITE
+            }
+        ];
+    }
+
+    /**
+     * Shows the dialog. Called once per boot on the legacy origin; dismissing it is per boot only,
+     * so the user is reminded again next time rather than being able to silence it permanently.
+     */
+    function show() {
+        const variant = !Constants.isMigrationSupportedBrowser() ? "safari" : (isTWA ? "twa" : "web");
+        Metrics.countEvent(Metrics.EVENT_TYPE.PLATFORM, "migrateAssist", `sunsetShown.${variant}`);
+
+        Dialogs.showModalDialog(
+            DefaultDialogs.DIALOG_ID_INFO,
+            StringUtils.format(Strings.MIGRATE_MOVING_TITLE, Constants.LEGACY_DOMAIN_NAME),
+            _buildMessage(),
+            _buildButtons()
+        ).done(function (buttonId) {
+            if (buttonId === BTN_GO_NEW_SITE) {
+                Metrics.countEvent(Metrics.EVENT_TYPE.PLATFORM, "migrateAssist", "sunsetGoNewSite");
+                window.location = Constants.getNewOrigin();
+            } else if (buttonId === BTN_UPDATE_APP) {
+                Metrics.countEvent(Metrics.EVENT_TYPE.PLATFORM, "migrateAssist", "sunsetUpdateApp");
+                window.open(Constants.TWA_STORE_URL, "_blank", "noopener");
+            } else {
+                Metrics.countEvent(Metrics.EVENT_TYPE.PLATFORM, "migrateAssist", `sunsetStay.${variant}`);
+            }
+        });
+    }
+
+    exports.show = show;
+});

--- a/src/extensionsIntegrated/loader.js
+++ b/src/extensionsIntegrated/loader.js
@@ -47,5 +47,6 @@ define(function (require, exports, module) {
     require("./CollapseFolders/main");
     require("./Terminal/main");
     require("./JSONSupport/main");
+    require("./MigrateAssist/main");
     require("./pro-loader");
 });

--- a/src/migrateAssist.html
+++ b/src/migrateAssist.html
@@ -1,0 +1,357 @@
+<!DOCTYPE html>
+<!--
+ * GNU AGPL-3.0 License
+ *
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
+-->
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Phoenix Code data migration helper</title>
+</head>
+<body>
+<!--
+    Migration helper, served from the origin that is being retired.
+
+    web.phcode.dev embeds this page in a hidden iframe to read the projects, preferences and
+    extensions that live in this origin's IndexedDB and cannot otherwise cross the origin boundary.
+    This works because phcode.dev and web.phcode.dev are the same site (eTLD+1), so the frame is
+    same-site rather than third party and browsers do not partition its storage.
+
+    SECURITY: this page hands the user's entire browser filesystem to whoever embeds it, and the
+    origin check below is the only thing standing in the way. Exact string matching only, on every
+    single message, and replies always go to the validated origin, never "*". Reads are confined to
+    the three roots in ALLOWED_ROOTS.
+
+    It deliberately does not boot Phoenix. virtualfs.js is a self contained IIFE that gives us
+    window.fs over the same Filer IndexedDB, which is all we need.
+-->
+<script src="phoenix/virtualfs.js"></script>
+<script src="thirdparty/jszip.js"></script>
+<script>
+    (function () {
+        const TRUSTED_PARENT_ORIGINS = [
+            "https://web.phcode.dev",
+            "http://localhost:8000",
+            "http://127.0.0.1:8000",
+            "http://localhost:5000",
+            "http://127.0.0.1:5000"
+        ];
+
+        const PROJECTS_ROOT = "/fs/local";
+        const APP_ROOT = "/fs/app";
+        const EXTENSIONS_USER = APP_ROOT + "/extensions/user";
+        const EXTENSIONS_DISABLED = APP_ROOT + "/extensions/disabled";
+        const PREFS_FILE = APP_ROOT + "/phcode.json";
+
+        // Only these roots may ever be zipped and handed out. Anything else, including /mnt (which
+        // holds real disc folders the user picked), is refused.
+        const ALLOWED_ROOTS = [PROJECTS_ROOT, EXTENSIONS_USER, EXTENSIONS_DISABLED];
+
+        // Auto created on both origins, so their presence proves nothing about the user having data.
+        // They are still migrated when something else triggers the run, since they may be edited.
+        const NOT_EVIDENCE_OF_DATA = ["default project", "explore"];
+
+        // Extension folders carrying this marker are already tombstoned for deletion at next boot.
+        const DELETED_EXTENSION_MARKER = "_phcode_extension_marked_for_delete";
+
+        const PHSTORE_DB = "PhStore";
+        const PHSTORE_STORE = "KVStore";
+        const PHSTORE_KEYS = ["extensions.disabled", "STATE_recentProjects"];
+
+        const CHUNK_SIZE = 8 * 1024 * 1024;
+
+        let parentOrigin = null;
+
+        function isTrustedOrigin(origin) {
+            // Exact match only. A startsWith test here would let https://web.phcode.dev.evil.com
+            // through, which would hand a stranger every file the user owns.
+            return TRUSTED_PARENT_ORIGINS.indexOf(origin) !== -1;
+        }
+
+        function reply(message, transfer) {
+            if (!parentOrigin) {
+                return;
+            }
+            window.parent.postMessage(message, parentOrigin, transfer || []);
+        }
+
+        function fail(id, err) {
+            console.error("migrateAssist: failed", id, err);
+            reply({ type: "MIGRATE_ERROR", id: id, message: (err && err.message) || String(err) });
+        }
+
+        function readdir(dir) {
+            return new Promise((resolve) => {
+                fs.readdir(dir, { withFileTypes: true }, (err, entries) => {
+                    resolve(err ? [] : (entries || []));
+                });
+            });
+        }
+
+        function readFileBytes(filePath) {
+            return new Promise((resolve, reject) => {
+                fs.readFile(filePath, fs.BYTE_ARRAY_ENCODING, (err, data) => {
+                    if (err) {
+                        reject(err);
+                        return;
+                    }
+                    resolve(data);
+                });
+            });
+        }
+
+        function readFileText(filePath) {
+            return new Promise((resolve) => {
+                fs.readFile(filePath, "utf8", (err, data) => {
+                    resolve(err ? null : data);
+                });
+            });
+        }
+
+        /**
+         * Walks a directory and returns every file in it as {path, relativePath, size}.
+         */
+        async function walk(rootDir, currentDir, out) {
+            const entries = await readdir(currentDir);
+            for (const entry of entries) {
+                const fullPath = currentDir + "/" + entry.name;
+                if (entry.isDirectory()) {
+                    await walk(rootDir, fullPath, out);
+                } else {
+                    out.push({
+                        path: fullPath,
+                        relativePath: fullPath.substring(rootDir.length + 1),
+                        size: entry.size || 0
+                    });
+                }
+            }
+            return out;
+        }
+
+        function isAllowedFolder(folderPath) {
+            if (folderPath.indexOf("..") !== -1) {
+                return false;
+            }
+            for (const root of ALLOWED_ROOTS) {
+                // Either the root itself, or a direct child of it. Nothing deeper and nothing else.
+                if (folderPath === root) {
+                    return true;
+                }
+                if (folderPath.startsWith(root + "/") && folderPath.indexOf("/", root.length + 1) === -1) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        function readPhStore() {
+            return new Promise((resolve) => {
+                const values = {};
+                let request;
+                try {
+                    request = indexedDB.open(PHSTORE_DB);
+                } catch (e) {
+                    resolve(values);
+                    return;
+                }
+                request.onerror = () => resolve(values);
+                request.onsuccess = () => {
+                    const db = request.result;
+                    if (!db.objectStoreNames.contains(PHSTORE_STORE)) {
+                        db.close();
+                        resolve(values);
+                        return;
+                    }
+                    const store = db.transaction(PHSTORE_STORE, "readonly").objectStore(PHSTORE_STORE);
+                    let pending = PHSTORE_KEYS.length;
+                    const done = () => {
+                        pending = pending - 1;
+                        if (pending === 0) {
+                            db.close();
+                            resolve(values);
+                        }
+                    };
+                    for (const key of PHSTORE_KEYS) {
+                        const get = store.get(key);
+                        get.onsuccess = () => {
+                            // PhStore wraps every value as {t: mtime, v: jsonString}.
+                            const entry = get.result;
+                            if (entry && typeof entry.v === "string") {
+                                try {
+                                    values[key] = JSON.parse(entry.v);
+                                } catch (e) {
+                                    console.warn("migrateAssist: unparsable PhStore value", key);
+                                }
+                            }
+                            done();
+                        };
+                        get.onerror = done;
+                    }
+                };
+                // A brand new database created by the open above has no store and no data, which the
+                // contains() check above already handles.
+                request.onupgradeneeded = () => { /* nothing to do, we only ever read */ };
+            });
+        }
+
+        async function collectBundles() {
+            const bundles = [];
+            let hasRealProject = false;
+
+            const projectDirs = await readdir(PROJECTS_ROOT);
+            for (const entry of projectDirs) {
+                if (!entry.isDirectory()) {
+                    continue;
+                }
+                const dir = PROJECTS_ROOT + "/" + entry.name;
+                const files = await walk(dir, dir, []);
+                if (!files.length) {
+                    continue;
+                }
+                bundles.push({
+                    id: dir,
+                    dest: dir,
+                    fileCount: files.length,
+                    bytes: files.reduce((sum, f) => sum + f.size, 0)
+                });
+                if (NOT_EVIDENCE_OF_DATA.indexOf(entry.name) === -1) {
+                    hasRealProject = true;
+                }
+            }
+
+            let extensionCount = 0;
+            for (const extRoot of [EXTENSIONS_USER, EXTENSIONS_DISABLED]) {
+                const extDirs = await readdir(extRoot);
+                const keep = [];
+                for (const entry of extDirs) {
+                    if (!entry.isDirectory()) {
+                        continue;
+                    }
+                    const markerPath = extRoot + "/" + entry.name + "/" + DELETED_EXTENSION_MARKER;
+                    const marker = await readFileText(markerPath);
+                    if (marker !== null) {
+                        continue; // already marked for delete, do not carry it over
+                    }
+                    keep.push(entry.name);
+                }
+                if (!keep.length) {
+                    continue;
+                }
+                if (extRoot === EXTENSIONS_USER) {
+                    extensionCount = keep.length;
+                }
+                const files = await walk(extRoot, extRoot, []);
+                const kept = files.filter((f) => keep.indexOf(f.relativePath.split("/")[0]) !== -1);
+                if (!kept.length) {
+                    continue;
+                }
+                bundles.push({
+                    id: extRoot,
+                    dest: extRoot,
+                    fileCount: kept.length,
+                    bytes: kept.reduce((sum, f) => sum + f.size, 0)
+                });
+            }
+
+            const prefsText = await readFileText(PREFS_FILE);
+            let hasPrefs = false;
+            if (prefsText) {
+                try {
+                    const parsed = JSON.parse(prefsText);
+                    hasPrefs = !!parsed && Object.keys(parsed).length > 0;
+                } catch (e) {
+                    hasPrefs = false;
+                }
+            }
+
+            return {
+                bundles: bundles,
+                prefs: hasPrefs ? prefsText : null,
+                hasData: hasRealProject || hasPrefs || extensionCount > 0
+            };
+        }
+
+        async function handleScan() {
+            const scan = await collectBundles();
+            const phStore = await readPhStore();
+            reply({
+                type: "MIGRATE_SCAN_RESULT",
+                hasData: scan.hasData,
+                bundles: scan.bundles,
+                prefs: scan.prefs,
+                phStore: phStore
+            });
+        }
+
+        async function handleBundle(id) {
+            if (typeof id !== "string" || !isAllowedFolder(id)) {
+                fail(id, new Error("Refused: folder is outside the migratable roots"));
+                return;
+            }
+            const zip = new JSZip();
+            const files = await walk(id, id, []);
+            for (const file of files) {
+                if (file.relativePath.endsWith(DELETED_EXTENSION_MARKER)) {
+                    continue;
+                }
+                const bytes = await readFileBytes(file.path);
+                zip.file(file.relativePath, bytes);
+            }
+            const buffer = await zip.generateAsync({ type: "arraybuffer" });
+            const chunkCount = Math.max(1, Math.ceil(buffer.byteLength / CHUNK_SIZE));
+            reply({ type: "MIGRATE_BUNDLE_META", id: id, totalBytes: buffer.byteLength, chunkCount: chunkCount });
+            for (let index = 0; index < chunkCount; index++) {
+                const start = index * CHUNK_SIZE;
+                const chunk = buffer.slice(start, Math.min(start + CHUNK_SIZE, buffer.byteLength));
+                reply({
+                    type: "MIGRATE_CHUNK",
+                    id: id,
+                    index: index,
+                    chunk: chunk,
+                    last: index === chunkCount - 1
+                }, [chunk]);
+            }
+        }
+
+        window.addEventListener("message", function (event) {
+            // Re-checked on every message, not just the handshake.
+            if (!isTrustedOrigin(event.origin) || event.origin !== parentOrigin) {
+                return;
+            }
+            const data = event.data;
+            if (!data || typeof data !== "object") {
+                return;
+            }
+            if (data.type === "MIGRATE_SCAN") {
+                handleScan().catch((err) => fail("scan", err));
+            } else if (data.type === "MIGRATE_BUNDLE") {
+                handleBundle(data.id).catch((err) => fail(data.id, err));
+            }
+        });
+
+        const requestedParent = new URLSearchParams(window.location.search || "").get("parentOrigin");
+        if (isTrustedOrigin(requestedParent)) {
+            parentOrigin = requestedParent;
+            reply({ type: "MIGRATE_READY" });
+        } else {
+            // Stay silent. Never post to an unvalidated origin, not even to say no.
+            console.error("migrateAssist: refusing to run, untrusted parent origin", requestedParent);
+        }
+    }());
+</script>
+</body>
+</html>

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -2916,6 +2916,32 @@ define({
     "DEMO_JS_BUTTON_ONE_MORE": "One more thing",
     "DEMO_JS_BUTTON_START_AGAIN": "Start Again",
     "DEMO_JS_CARD_COUNT_TEMPLATE": "{NUM_DONE}/3 cards",
-    "DEMO_JS_DELETE_COUNT_TEMPLATE": "{NUM_DONE}/1 deleted"
+    "DEMO_JS_DELETE_COUNT_TEMPLATE": "{NUM_DONE}/1 deleted",
     // demo end
+
+    // Migration off the legacy web origin onto the new home
+    "MIGRATE_MOVING_TITLE": "{0} is moving",
+    "MIGRATE_MOVING_MESSAGE": "{APP_NAME} on {0} is moving to a new home at <strong>{1}</strong>. Everything works the same, only the address changes.",
+    "MIGRATE_SUNSET_COUNTDOWN": "You have <strong>{0} days</strong> left before {1} stops working.",
+    "MIGRATE_SUNSET_COUNTDOWN_ONE": "You have <strong>{0} day</strong> left before {1} stops working.",
+    "MIGRATE_DATA_SAFE_NOTE": "Your projects, settings and extensions will be copied over for you the first time you open {0}. Nothing is deleted from this site.",
+    "MIGRATE_MANUAL_DOWNLOAD_NOTE": "Automatic transfer is not available in this browser. If you have projects saved here, please download them before the date above so you can open them again on the new site.",
+    "MIGRATE_TWA_UPDATE_NOTE": "Please update the app when you can. Nothing stops working today, and you can keep using this version in the meantime.",
+    "MIGRATE_TWA_BROWSER_LINK": "If you cannot update right now, you can also <a href=\'{0}\'>continue in a browser at {1}</a>.",
+    "MIGRATE_GO_TO_NEW_SITE": "Take me to the new site",
+    "MIGRATE_UPDATE_APP": "Update the app",
+    "MIGRATE_STAY_HERE": "Stay here",
+    "MIGRATE_PROGRESS_TITLE": "Bringing your data over",
+    "MIGRATE_PROGRESS_INTRO": "Copying your projects, settings and extensions from {0}. This only happens once.",
+    "MIGRATE_PROGRESS_PREPARING": "Preparing {0} ({1} of {2})\u2026",
+    "MIGRATE_PROGRESS_STATUS": "Copying {0} ({1} of {2})\u2026",
+    "MIGRATE_DONE_TITLE": "All done.",
+    "MIGRATE_DONE_MESSAGE": "{0} files were copied over. Reload to start using them.",
+    "MIGRATE_DONE_PARTIAL": "These could not be copied and are still available on the old site: {0}",
+    "MIGRATE_RELOAD_NOW": "Reload",
+    "MIGRATE_NOTHING_TITLE": "Nothing to bring over",
+    "MIGRATE_NOTHING_MESSAGE": "We could not find any projects, settings or extensions on {0} that need copying.",
+    "MIGRATE_UNREACHABLE_TITLE": "Could not reach the old site",
+    "MIGRATE_UNREACHABLE_MESSAGE": "{APP_NAME} could not connect to {0} to check for your data. Please check your connection and try again.",
+    "CMD_MIGRATE_DATA": "Migrate My Data\u2026"
 });

--- a/src/styles/Extn-MigrateAssist.less
+++ b/src/styles/Extn-MigrateAssist.less
@@ -1,0 +1,66 @@
+/*
+ * GNU AGPL-3.0 License
+ *
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
+ *
+ */
+
+// Progress dialog for the one time migration off the legacy web origin.
+// The progress bar itself reuses the shared .progress-bar-* classes from brackets.less, so only the
+// dialog specific spacing lives here.
+.migrate-assist-dialog {
+
+    .migrate-assist-intro {
+        margin-bottom: 12px;
+    }
+
+    .progress-bar-container {
+        margin: 4px 0 10px 0;
+    }
+
+    // Shown while the other origin is still zipping a folder. There is no progress to report during
+    // that phase, and a bar frozen at 0% reads as a hang on the largest and slowest folders.
+    .migrate-assist-bar-indeterminate {
+        width: 100% !important;
+        background: repeating-linear-gradient(
+                to right,
+                #003366 0%, #004c99 10%, #0066cc 20%, #007bff 30%, #3399ff 40%,
+                #66b2ff 50%, #3399ff 60%, #007bff 70%, #0066cc 80%, #004c99 90%, #003366 100%
+        );
+        background-size: 200% auto;
+        animation: migrate-assist-pulse 2s linear infinite;
+    }
+
+    .migrate-assist-status {
+        margin: 0;
+        opacity: 0.8;
+    }
+
+    .migrate-assist-detail {
+        margin: 8px 0 0 0;
+        font-size: 0.9em;
+        opacity: 0.7;
+    }
+}
+
+@keyframes migrate-assist-pulse {
+    0% {
+        background-position: 0 0;
+    }
+    100% {
+        background-position: -200% 0;
+    }
+}

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -46,6 +46,7 @@
 @import "Extn-CSSColorPreview.less";
 @import "Extn-CustomSnippets.less";
 @import "Extn-CollapseFolders.less";
+@import "Extn-MigrateAssist.less";
 @import "Extn-SidebarTabs.less";
 @import "Extn-BottomPanelTabs.less";
 @import "Extn-AIChatPanel.less";

--- a/test/UnitTestSuite.js
+++ b/test/UnitTestSuite.js
@@ -142,6 +142,7 @@ define(function (require, exports, module) {
     require("spec/Extn-JSONSupport-test");
     require("spec/Extn-JSONSupport-integ-test");
     require("spec/Extn-CollapseFolders-integ-test");
+    require("spec/Extn-MigrateAssist-test");
     require("spec/Extn-Tabbar-integ-test");
     require("spec/Extn-CustomSnippets-test");
     require("spec/Extn-CustomSnippets-integ-test");

--- a/test/spec/Extn-MigrateAssist-test.js
+++ b/test/spec/Extn-MigrateAssist-test.js
@@ -22,6 +22,14 @@
 
 define(function (require, exports, module) {
 
+    // The migration off the legacy web origin is browser only. The desktop app never runs any of it,
+    // and its origin is phtauri://localhost, which migrateAssist.html refuses by design since a
+    // native shell has no business reading a web origin's filesystem. Nothing here is meaningful in
+    // the desktop test runner, so the whole suite sits this one out.
+    if (Phoenix.isNativeApp) {
+        return;
+    }
+
     const Constants = require("extensionsIntegrated/MigrateAssist/constants"),
         ZipUtils = require("utils/ZipUtils");
 

--- a/test/spec/Extn-MigrateAssist-test.js
+++ b/test/spec/Extn-MigrateAssist-test.js
@@ -115,7 +115,15 @@ define(function (require, exports, module) {
 
             const HELPER_URL = `${Phoenix.baseURL}migrateAssist.html`;
             const SANDBOX = "/temp/migrate-assist-spec";
-            const SEEDED_PROJECT = `${SANDBOX}/seeded`;
+            const OUTSIDE_ROOTS = `${SANDBOX}/not-a-migratable-root`;
+
+            // A project of our own under /fs/local, which is one of the roots the helper serves. The
+            // suite must not depend on whatever projects happen to already exist: a fresh CI checkout
+            // has none, so reading bundles[0] there found nothing at all.
+            const SEEDED_PROJECT = "/fs/local/__migrate_assist_spec__";
+            const TEXT_CONTENT = "hello from the old origin\n";
+            // Includes NUL and 0xFF so a byte exact copy can be told apart from a text round trip.
+            const BINARY_BYTES = new Uint8Array([0x00, 0x01, 0xFF, 0xFE, 0x7F, 0x80, 0x00, 0x42]);
 
             let frames = [];
 
@@ -162,14 +170,19 @@ define(function (require, exports, module) {
             }
 
             beforeAll(async function () {
-                // A project of our own under /temp, so the assertions do not depend on whatever the
-                // machine running the tests happens to have in /fs/local.
                 await Phoenix.VFS.unlinkAsync(SANDBOX).catch(() => {});
-                await Phoenix.VFS.ensureExistsDirAsync(SEEDED_PROJECT);
+                await Phoenix.VFS.unlinkAsync(SEEDED_PROJECT).catch(() => {});
+                await Phoenix.VFS.ensureExistsDirAsync(`${SEEDED_PROJECT}/nested`);
+                await Phoenix.VFS.ensureExistsDirAsync(OUTSIDE_ROOTS);
+                await Phoenix.VFS.writeFileAsync(`${SEEDED_PROJECT}/index.html`, TEXT_CONTENT, "utf8");
+                await Phoenix.VFS.writeFileAsync(`${SEEDED_PROJECT}/nested/deep.txt`, TEXT_CONTENT, "utf8");
+                await Phoenix.VFS.writeFileAsync(`${SEEDED_PROJECT}/image.bin`,
+                    window.Filer.Buffer.from(BINARY_BYTES), window.fs.BYTE_ARRAY_ENCODING);
             });
 
             afterAll(async function () {
                 await Phoenix.VFS.unlinkAsync(SANDBOX).catch(() => {});
+                await Phoenix.VFS.unlinkAsync(SEEDED_PROJECT).catch(() => {});
             });
 
             afterEach(function () {
@@ -241,7 +254,8 @@ define(function (require, exports, module) {
                     "/fs/app",
                     "/fs/local/../../mnt",
                     "/fs/app/extensions/user/../../aiHistory",
-                    SEEDED_PROJECT
+                    OUTSIDE_ROOTS,
+                    `${SEEDED_PROJECT}/nested`
                 ];
                 escapes.forEach((id) => send(helper, {type: "MIGRATE_BUNDLE", id: id}));
                 await awaitsFor(function () {
@@ -259,8 +273,12 @@ define(function (require, exports, module) {
                 }, "scan result", 20000);
 
                 const scan = lastOfType(helper.received, "MIGRATE_SCAN_RESULT");
-                const bundle = scan.bundles[0];
+                // Our own seeded project, not whatever happened to be lying around. It also counts as
+                // real user data, so the helper must report there is something worth migrating.
+                expect(scan.hasData).toBe(true);
+                const bundle = scan.bundles.find((b) => b.dest === SEEDED_PROJECT);
                 expect(bundle).toBeTruthy();
+                expect(bundle.fileCount).toBe(3);
 
                 send(helper, {type: "MIGRATE_BUNDLE", id: bundle.id});
                 await awaitsFor(function () {
@@ -281,9 +299,11 @@ define(function (require, exports, module) {
                     offset = offset + c.chunk.byteLength;
                 });
 
-                // Pre-seed the destination the way the new origin would already look.
+                // Pre-seed the destination the way the receiving origin would already look: one file
+                // that collides with the incoming bundle, and one that exists only here.
                 const dest = `${SANDBOX}/restored`;
                 await Phoenix.VFS.ensureExistsDirAsync(dest);
+                await Phoenix.VFS.writeFileAsync(`${dest}/index.html`, "I am the stale local copy", "utf8");
                 await Phoenix.VFS.writeFileAsync(`${dest}/only-here.txt`, "keep me", "utf8");
 
                 const ticks = [];
@@ -295,9 +315,15 @@ define(function (require, exports, module) {
                 expect(ticks.length).toBeGreaterThan(0);
                 expect(ticks[ticks.length - 1].done).toBe(ticks[ticks.length - 1].totalCount);
 
-                // The file that only existed on the receiving side must survive the merge.
-                const survivor = await Phoenix.VFS.readFileAsync(`${dest}/only-here.txt`, "utf8");
-                expect(survivor).toBe("keep me");
+                // Source wins on a collision, and a file only present on the receiving side survives.
+                expect(await Phoenix.VFS.readFileAsync(`${dest}/index.html`, "utf8")).toBe(TEXT_CONTENT);
+                expect(await Phoenix.VFS.readFileAsync(`${dest}/only-here.txt`, "utf8")).toBe("keep me");
+                // Nested paths keep their shape.
+                expect(await Phoenix.VFS.readFileAsync(`${dest}/nested/deep.txt`, "utf8")).toBe(TEXT_CONTENT);
+                // Binary survives byte for byte, NUL and high bytes included.
+                const restoredBytes = new Uint8Array(
+                    await Phoenix.VFS.readFileAsync(`${dest}/image.bin`, window.fs.BYTE_ARRAY_ENCODING));
+                expect(Array.from(restoredBytes)).toEqual(Array.from(BINARY_BYTES));
             });
         });
     });

--- a/test/spec/Extn-MigrateAssist-test.js
+++ b/test/spec/Extn-MigrateAssist-test.js
@@ -1,0 +1,296 @@
+/*
+ * GNU AGPL-3.0 License
+ *
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
+ *
+ */
+
+/*global describe, it, expect, beforeAll, afterAll, afterEach, awaitsFor */
+
+define(function (require, exports, module) {
+
+    const Constants = require("extensionsIntegrated/MigrateAssist/constants"),
+        ZipUtils = require("utils/ZipUtils");
+
+    describe("unit:MigrateAssist", function () {
+
+        const DAY = 24 * 60 * 60 * 1000;
+
+        describe("constants", function () {
+
+            describe("daysToSunset", function () {
+
+                it("should count whole days remaining", function () {
+                    expect(Constants.daysToSunset(Constants.SUNSET_DATE - (10 * DAY))).toBe(10);
+                    expect(Constants.daysToSunset(Constants.SUNSET_DATE - DAY)).toBe(1);
+                });
+
+                it("should round a part day up, so the last day never reads as zero", function () {
+                    expect(Constants.daysToSunset(Constants.SUNSET_DATE - 1)).toBe(1);
+                    expect(Constants.daysToSunset(Constants.SUNSET_DATE - (DAY + 1))).toBe(2);
+                });
+
+                it("should floor at zero on and after the sunset date", function () {
+                    expect(Constants.daysToSunset(Constants.SUNSET_DATE)).toBe(0);
+                    expect(Constants.daysToSunset(Constants.SUNSET_DATE + DAY)).toBe(0);
+                });
+            });
+
+            describe("isPastSunset", function () {
+
+                it("should be false before the date and true on or after it", function () {
+                    expect(Constants.isPastSunset(Constants.SUNSET_DATE - 1)).toBe(false);
+                    expect(Constants.isPastSunset(Constants.SUNSET_DATE)).toBe(true);
+                    expect(Constants.isPastSunset(Constants.SUNSET_DATE + DAY)).toBe(true);
+                });
+            });
+
+            describe("origins", function () {
+
+                it("should ignore the dev override inside test windows", function () {
+                    // The override exists so the flow can be exercised locally. It must never apply in
+                    // a test window, otherwise a stray localStorage value could repoint a real
+                    // migration.
+                    expect(Constants.getLegacyOrigin()).toBe("https://staging.phcode.dev");
+                    expect(Constants.getNewOrigin()).toBe("https://web.phcode.dev");
+                });
+
+                it("should not treat the spec runner as either migration origin", function () {
+                    expect(Constants.isLegacyOrigin()).toBe(false);
+                    expect(Constants.isNewOrigin()).toBe(false);
+                });
+            });
+
+            describe("getMigrateAssistURL", function () {
+
+                it("should point at the legacy origin", function () {
+                    expect(Constants.getMigrateAssistURL().startsWith(Constants.getLegacyOrigin())).toBe(true);
+                });
+
+                it("should mirror the current path prefix rather than assuming the origin root", function () {
+                    // Production serves the app at "/", but the dev server serves it under "/src/" and
+                    // the spec runner under "/test/". Hardcoding "/" would 404 in both of those.
+                    const pathname = location.pathname;
+                    const prefix = pathname.substring(0, pathname.lastIndexOf("/") + 1);
+                    expect(Constants.getMigrateAssistURL())
+                        .toBe(`${Constants.getLegacyOrigin()}${prefix}migrateAssist.html`);
+                });
+            });
+
+            describe("browser support", function () {
+
+                it("should exclude Safari and iOS and include everything else", function () {
+                    const expected = !(Phoenix.browser.desktop.isSafari || Phoenix.browser.mobile.isIos);
+                    expect(Constants.isMigrationSupportedBrowser()).toBe(expected);
+                });
+            });
+        });
+
+        // migrateAssist.html is the half of the migration that runs on the origin being retired. It
+        // is a standalone page rather than part of the app, so the only way to test it honestly is to
+        // load it and speak the real protocol to it. The iframe here is that page, not an embedded
+        // Phoenix instance, so this belongs in the unit category.
+        describe("helper page", function () {
+
+            const HELPER_URL = `${Phoenix.baseURL}migrateAssist.html`;
+            const SANDBOX = "/temp/migrate-assist-spec";
+            const SEEDED_PROJECT = `${SANDBOX}/seeded`;
+
+            let frames = [];
+
+            /**
+             * Loads the helper page and collects everything it posts back.
+             */
+            function openHelper(parentOrigin) {
+                const received = [];
+                const iframe = document.createElement("iframe");
+                iframe.style.display = "none";
+                const ready = new Promise((resolve) => {
+                    function onMessage(event) {
+                        if (event.source !== iframe.contentWindow) {
+                            return;
+                        }
+                        received.push(event.data);
+                        if (event.data && event.data.type === "MIGRATE_READY") {
+                            resolve();
+                        }
+                    }
+                    window.addEventListener("message", onMessage);
+                    iframe._cleanup = function () {
+                        window.removeEventListener("message", onMessage);
+                        iframe.remove();
+                    };
+                });
+                iframe.src = `${HELPER_URL}?parentOrigin=${encodeURIComponent(parentOrigin)}`;
+                document.body.appendChild(iframe);
+                frames.push(iframe);
+                return { iframe, received, ready };
+            }
+
+            function send(helper, message) {
+                helper.iframe.contentWindow.postMessage(message, location.origin);
+            }
+
+            function lastOfType(received, type) {
+                for (let i = received.length - 1; i >= 0; i--) {
+                    if (received[i] && received[i].type === type) {
+                        return received[i];
+                    }
+                }
+                return null;
+            }
+
+            beforeAll(async function () {
+                // A project of our own under /temp, so the assertions do not depend on whatever the
+                // machine running the tests happens to have in /fs/local.
+                await Phoenix.VFS.unlinkAsync(SANDBOX).catch(() => {});
+                await Phoenix.VFS.ensureExistsDirAsync(SEEDED_PROJECT);
+            });
+
+            afterAll(async function () {
+                await Phoenix.VFS.unlinkAsync(SANDBOX).catch(() => {});
+            });
+
+            afterEach(function () {
+                frames.forEach((frame) => frame._cleanup && frame._cleanup());
+                frames = [];
+            });
+
+            /**
+             * Proving a negative needs a bound on "long enough". Rather than sleeping for an arbitrary
+             * period, run a trusted helper alongside the untrusted one and wait for the trusted one to
+             * complete a full handshake and scan. Once that has happened, the untrusted page has
+             * demonstrably had more than enough time to answer, and its silence means something.
+             */
+            async function expectSilenceWhile(untrusted, forgedMessages) {
+                const control = openHelper(location.origin);
+                await control.ready;
+                forgedMessages.forEach((message) => send(untrusted, message));
+                send(control, {type: "MIGRATE_SCAN"});
+                await awaitsFor(function () {
+                    return !!lastOfType(control.received, "MIGRATE_SCAN_RESULT");
+                }, "the trusted control to finish a full exchange", 20000);
+                expect(untrusted.received.length).toBe(0);
+            }
+
+            it("should hand nothing at all to an untrusted parent origin", async function () {
+                const helper = openHelper("https://web.phcode.dev.evil.example");
+                await expectSilenceWhile(helper, [
+                    {type: "MIGRATE_SCAN"},
+                    {type: "MIGRATE_BUNDLE", id: "/fs/local"}
+                ]);
+            });
+
+            it("should refuse an origin that only shares a prefix with a trusted one", async function () {
+                // A startsWith check would let this through and hand over every file the user owns.
+                const helper = openHelper(`${location.origin}.evil.example`);
+                await expectSilenceWhile(helper, [{type: "MIGRATE_SCAN"}]);
+            });
+
+            it("should complete the handshake for a trusted parent origin", async function () {
+                const helper = openHelper(location.origin);
+                await helper.ready;
+                expect(lastOfType(helper.received, "MIGRATE_READY")).not.toBe(null);
+            });
+
+            it("should report a scan describing the projects, prefs and extensions", async function () {
+                const helper = openHelper(location.origin);
+                await helper.ready;
+                send(helper, {type: "MIGRATE_SCAN"});
+                await awaitsFor(function () {
+                    return !!lastOfType(helper.received, "MIGRATE_SCAN_RESULT");
+                }, "scan result", 20000);
+
+                const scan = lastOfType(helper.received, "MIGRATE_SCAN_RESULT");
+                expect(typeof scan.hasData).toBe("boolean");
+                expect(Array.isArray(scan.bundles)).toBe(true);
+                for (const bundle of scan.bundles) {
+                    // Every bundle must name a real destination and be one of the roots we allow.
+                    expect(typeof bundle.dest).toBe("string");
+                    expect(bundle.dest.startsWith("/fs/")).toBe(true);
+                    expect(bundle.fileCount).toBeGreaterThan(0);
+                }
+            });
+
+            it("should refuse to zip anything outside the migratable roots", async function () {
+                const helper = openHelper(location.origin);
+                await helper.ready;
+                const escapes = [
+                    "/mnt",
+                    "/fs/app",
+                    "/fs/local/../../mnt",
+                    "/fs/app/extensions/user/../../aiHistory",
+                    SEEDED_PROJECT
+                ];
+                escapes.forEach((id) => send(helper, {type: "MIGRATE_BUNDLE", id: id}));
+                await awaitsFor(function () {
+                    return helper.received.filter((m) => m.type === "MIGRATE_ERROR").length === escapes.length;
+                }, "every escaping path to be rejected", 10000);
+                expect(lastOfType(helper.received, "MIGRATE_CHUNK")).toBe(null);
+            });
+
+            it("should round trip a real folder, overwriting collisions and keeping extras", async function () {
+                const helper = openHelper(location.origin);
+                await helper.ready;
+                send(helper, {type: "MIGRATE_SCAN"});
+                await awaitsFor(function () {
+                    return !!lastOfType(helper.received, "MIGRATE_SCAN_RESULT");
+                }, "scan result", 20000);
+
+                const scan = lastOfType(helper.received, "MIGRATE_SCAN_RESULT");
+                const bundle = scan.bundles[0];
+                expect(bundle).toBeTruthy();
+
+                send(helper, {type: "MIGRATE_BUNDLE", id: bundle.id});
+                await awaitsFor(function () {
+                    const last = lastOfType(helper.received, "MIGRATE_CHUNK");
+                    return !!last && last.last === true;
+                }, "all chunks to arrive", 60000);
+
+                const chunks = helper.received.filter((m) => m.type === "MIGRATE_CHUNK" && m.id === bundle.id);
+                const meta = lastOfType(helper.received, "MIGRATE_BUNDLE_META");
+                expect(chunks.length).toBe(meta.chunkCount);
+
+                const total = chunks.reduce((sum, c) => sum + c.chunk.byteLength, 0);
+                expect(total).toBe(meta.totalBytes);
+                const merged = new Uint8Array(total);
+                let offset = 0;
+                chunks.sort((a, b) => a.index - b.index).forEach((c) => {
+                    merged.set(new Uint8Array(c.chunk), offset);
+                    offset = offset + c.chunk.byteLength;
+                });
+
+                // Pre-seed the destination the way the new origin would already look.
+                const dest = `${SANDBOX}/restored`;
+                await Phoenix.VFS.ensureExistsDirAsync(dest);
+                await Phoenix.VFS.writeFileAsync(`${dest}/only-here.txt`, "keep me", "utf8");
+
+                const ticks = [];
+                await ZipUtils.unzipBinDataToLocation(merged.buffer, dest, false, function (done, totalCount) {
+                    ticks.push({done, totalCount});
+                    return true;
+                });
+
+                expect(ticks.length).toBeGreaterThan(0);
+                expect(ticks[ticks.length - 1].done).toBe(ticks[ticks.length - 1].totalCount);
+
+                // The file that only existed on the receiving side must survive the merge.
+                const survivor = await Phoenix.VFS.readFileAsync(`${dest}/only-here.txt`, "utf8");
+                expect(survivor).toBe("keep me");
+            });
+        });
+    });
+});


### PR DESCRIPTION
Browser storage is per-origin, so a user landing on web.phcode.dev sees an empty editor while their projects, preferences, theme and extensions stay behind on the old origin, invisible to the new one.

On the origin being retired, every boot announces the move with a live countdown to the sunset date. On web.phcode.dev, a hidden iframe pointed at the old origin reports whether anything is worth moving. If there is nothing, absolutely nothing happens - no dialog, no interruption, normal boot. If there is, a progress modal runs the transfer once and sets a flag so it never runs again; after that it only happens if the user asks from Help > Migrate My Data.

This works at all because phcode.dev, staging.phcode.dev and web.phcode.dev are the same site (eTLD+1). Browsers partition third party storage by site rather than by origin, so the helper frame is same-site and reads real unpartitioned IndexedDB. Had the new home been on a different registrable domain this would have silently reported "nothing to migrate" everywhere.

src/migrateAssist.html is deliberately standalone. It loads only virtualfs.js and jszip.js rather than booting Phoenix, and zips one top level folder at a time so peak memory is one folder rather than the whole filesystem. The receiving side hands each zip to ZipUtils.unzipBinDataToLocation, which writes without unlinking first, so files from the old origin win on collision while files that only exist on the new side survive. That is the collision rule we want, with no extra code.

Extensions are copied rather than reinstalled from the registry. Both origins serve the byte identical build, so a folder that worked on one is compatible with the other, and copying also preserves extensions that were sideloaded or have since been unpublished.

That page hands out the user's entire browser filesystem to whoever embeds it, so the origin allowlist is exact match only, checked on every message and not just the handshake, replies always go to the validated origin rather than "*", and reads are confined to three known roots.

Safari and iOS are out of scope by product decision, not because the mechanism would fail there. Those users still get the dialog, with a line asking them to download projects manually, rather than losing data without being told.

Android and ChromeOS users launched from our Trusted Web Activity are offered an app update instead of the new site, because the shipped APK only trusts phcode.dev and navigating it elsewhere surfaces a browser URL bar inside what looks like an app. "Stay here" is a real choice there: managed school fleets can have the Play Store blocked entirely, so the update button may be a dead end through no fault of the user.

The legacy origin is staging.phcode.dev while this is validated end to end. Switching it to phcode.dev is a one line change in constants.js.
