### PR TITLE
docs: fix misspellings in JSDoc and the generated API reference

### DIFF
--- a/docs/API-Reference/command/KeyBindingManager.md
+++ b/docs/API-Reference/command/KeyBindingManager.md
@@ -224,7 +224,7 @@ to display the shortcut selection dialog
 <a name="canAssignBinding"></a>
 
 ## canAssignBinding(commandId) ⇒ <code>boolean</code>
-Returns true the given command id can be overriden by user.
+Returns true the given command id can be overridden by user.
 
 **Kind**: global function  
 

--- a/docs/API-Reference/features/QuickViewManager.md
+++ b/docs/API-Reference/features/QuickViewManager.md
@@ -186,6 +186,6 @@ is called or document changes.
 <a name="module_features/QuickViewManager..unlockQuickView"></a>
 
 ### features/QuickViewManager.unlockQuickView() : <code>function</code>
-unlocks the current QuickView locked by `lockQuickView` fucntion.
+unlocks the current QuickView locked by `lockQuickView` function.
 
 **Kind**: inner method of [<code>features/QuickViewManager</code>](#module_features/QuickViewManager)  

--- a/docs/API-Reference/preferences/StateManager.md
+++ b/docs/API-Reference/preferences/StateManager.md
@@ -61,7 +61,7 @@ Convenience function that sets a view state and then saves the file
 <a name="definePreferenceInternal"></a>
 
 ## definePreferenceInternal(id, type, initial, options) ⇒ <code>Object</code>
-returns a preference instance that can be listened `.on("change", cbfn(changeType))` . The callback fucntion will be called
+returns a preference instance that can be listened `.on("change", cbfn(changeType))` . The callback function will be called
 whenever there is a change in the supplied id with a changeType argument. The change type can be one of the two:
 CHANGE_TYPE_INTERNAL - if change is made within the current app window/browser tap
 CHANGE_TYPE_EXTERNAL - if change is made in a different app window/browser tab

--- a/docs/API-Reference/utils/EventManager.md
+++ b/docs/API-Reference/utils/EventManager.md
@@ -90,7 +90,7 @@ EventManager.triggerEvent("closeDialogueHandler", "someEvent", "param1", "param2
 | --- | --- | --- |
 | handlerName | <code>string</code> |  |
 | eventName |  | the event name as recognised by the handler. this is usually a string. |
-| ...eventParams |  | Can be a comma seperated list of args or a single argument. |
+| ...eventParams |  | Can be a comma separated list of args or a single argument. |
 
 <a name="module_utils/EventManager..setTrustedOrigin"></a>
 

--- a/docs/API-Reference/view/Pane.md
+++ b/docs/API-Reference/view/Pane.md
@@ -586,7 +586,7 @@ Removes the view and opens the next view
 <a name="module_view/Pane..Pane+removeViews"></a>
 
 #### pane.removeViews(list) ⇒ <code>Array.&lt;File&gt;</code>
-Removes the specifed file from all internal lists, destroys the view of the file (if there is one)
+Removes the specified file from all internal lists, destroys the view of the file (if there is one)
  and shows the interstitial page if the current view is destroyed.
 
 **Kind**: instance method of [<code>Pane</code>](#module_view/Pane..Pane)  

--- a/docs/API-Reference/widgets/PopUpManager.md
+++ b/docs/API-Reference/widgets/PopUpManager.md
@@ -20,7 +20,7 @@ Add Esc key handling for a popup DOM element.
 | --- | --- | --- |
 | $popUp | <code>jQuery</code> | jQuery object for the DOM element pop-up |
 | removeHandler | <code>function</code> | Pop-up specific remove (e.g. display:none or DOM removal) |
-| autoRemove | <code>Boolean</code> | Specify true to indicate the PopUpManager should      remove the popup from the _popUps array when the popup is closed. Specify false      when the popup is always persistant in the _popUps array. |
+| autoRemove | <code>Boolean</code> | Specify true to indicate the PopUpManager should      remove the popup from the _popUps array when the popup is closed. Specify false      when the popup is always persistent in the _popUps array. |
 | options | <code>object</code> |  |
 | [options.popupManagesFocus] | <code>boolean</code> | set to true if the popup manages focus restore on close |
 | [options.closeCurrentPopups] | <code>boolean</code> | set to true if you want to dismiss all exiting popups before              adding this. Useful when this should be the only popup visible. |

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -2163,7 +2163,7 @@ define(function (require, exports, module) {
     }
 
     /**
-     * Returns true the given command id can be overriden by user.
+     * Returns true the given command id can be overridden by user.
      *
      * @param commandId
      * @return {boolean}

--- a/src/editor/CodeHintList.js
+++ b/src/editor/CodeHintList.js
@@ -64,7 +64,7 @@ define(function (require, exports, module) {
         this.selectedIndex = -1;
 
         /**
-         * The maximum number of hints to display. Can be overriden via maxCodeHints pref
+         * The maximum number of hints to display. Can be overridden via maxCodeHints pref
          *
          * @type {number}
          */

--- a/src/features/QuickViewManager.js
+++ b/src/features/QuickViewManager.js
@@ -794,7 +794,7 @@ define(function (require, exports, module) {
     }
 
     /**
-     * unlocks the current QuickView locked by `lockQuickView` fucntion.
+     * unlocks the current QuickView locked by `lockQuickView` function.
      *
      * @type {function}
      */

--- a/src/preferences/PreferencesManager.js
+++ b/src/preferences/PreferencesManager.js
@@ -226,7 +226,7 @@ define(function (require, exports, module) {
      *
      * This function is used internally to set the current language of the document.
      * Both at the moment of opening the file and when the language is manually
-     * overriden.
+     * overridden.
      *
      * @param {string} newLanguageId The id of the language of the current editor.
      */

--- a/src/preferences/StateManager.js
+++ b/src/preferences/StateManager.js
@@ -159,7 +159,7 @@ define(function (require, exports, module) {
     }
 
     /**
-     * returns a preference instance that can be listened `.on("change", cbfn(changeType))` . The callback fucntion will be called
+     * returns a preference instance that can be listened `.on("change", cbfn(changeType))` . The callback function will be called
      * whenever there is a change in the supplied id with a changeType argument. The change type can be one of the two:
      * CHANGE_TYPE_INTERNAL - if change is made within the current app window/browser tap
      * CHANGE_TYPE_EXTERNAL - if change is made in a different app window/browser tab

--- a/src/utils/EventManager.js
+++ b/src/utils/EventManager.js
@@ -103,7 +103,7 @@ define(function (require, exports, module) {
      *
      * @param {string} handlerName
      * @param eventName the event name as recognised by the handler. this is usually a string.
-     * @param eventParams Can be a comma seperated list of args or a single argument.
+     * @param eventParams Can be a comma separated list of args or a single argument.
      * @type {function}
      */
     function triggerEvent(handlerName, eventName, ...eventParams) {

--- a/src/view/Pane.js
+++ b/src/view/Pane.js
@@ -925,7 +925,7 @@ define(function (require, exports, module) {
     };
 
     /**
-     * Removes the specifed file from all internal lists, destroys the view of the file (if there is one)
+     * Removes the specified file from all internal lists, destroys the view of the file (if there is one)
      *  and shows the interstitial page if the current view is destroyed
      * @private
      * @param {!File} file - file to remove
@@ -1391,7 +1391,7 @@ define(function (require, exports, module) {
     };
 
     /**
-     * Removes the specifed file from all internal lists, destroys the view of the file (if there is one)
+     * Removes the specified file from all internal lists, destroys the view of the file (if there is one)
      *  and shows the interstitial page if the current view is destroyed.
      * @param {!Array.<File>}  list - Array of files to remove
      * @return {!Array.<File>} Array of File objects removed from the working set.

--- a/src/view/ThemeManager.js
+++ b/src/view/ThemeManager.js
@@ -237,7 +237,7 @@ define(function (require, exports, module) {
         if(!devThemePaths){
             return null;
         }
-        devThemePaths = devThemePaths.split(","); // paths are a comma seperated list
+        devThemePaths = devThemePaths.split(","); // paths are a comma separated list
         for(let themeID of Object.keys(loadedThemes)){
             let themeFilePath = ExtensionLoader.getSourcePathForExtension(loadedThemes[themeID].file.fullPath);
             for(let devThemePath of devThemePaths){

--- a/src/widgets/PopUpManager.js
+++ b/src/widgets/PopUpManager.js
@@ -44,7 +44,7 @@ define(function (require, exports, module) {
      * @param {function} removeHandler Pop-up specific remove (e.g. display:none or DOM removal)
      * @param {?Boolean} autoRemove - Specify true to indicate the PopUpManager should
      *      remove the popup from the _popUps array when the popup is closed. Specify false
-     *      when the popup is always persistant in the _popUps array.
+     *      when the popup is always persistent in the _popUps array.
      * @param {object} options
      * @param {boolean} [options.popupManagesFocus] - set to true if the popup manages focus restore on close
      * @param {boolean} [options.closeCurrentPopups] - set to true if you want to dismiss all exiting popups before


### PR DESCRIPTION
Fixes five misspellings that appear in both the JSDoc comments and the API reference generated from them.

| Typo | → | Source files |
|---|---|---|
| `overriden` | `overridden` | `src/command/KeyBindingManager.js`, `src/preferences/PreferencesManager.js`, `src/editor/CodeHintList.js` |
| `fucntion` | `function` | `src/features/QuickViewManager.js`, `src/preferences/StateManager.js` |
| `seperated` | `separated` | `src/utils/EventManager.js`, `src/view/ThemeManager.js` |
| `specifed` | `specified` | `src/view/Pane.js` (×2) |
| `persistant` | `persistent` | `src/widgets/PopUpManager.js` |

`docs/API-Reference/**` is generated from these JSDoc blocks, so fixing only the markdown would be undone on the next docs build. Each correction is therefore applied to the source comment **and** to the corresponding generated page (`KeyBindingManager.md`, `QuickViewManager.md`, `StateManager.md`, `EventManager.md`, `Pane.md`, `PopUpManager.md`) so the committed tree matches what the generator would now emit.

Comments and documentation only — no identifiers, APIs, or behaviour touched. I skipped the same spelling in `src/styles/bootstrap/`, which is vendored third-party code.

If you'd rather regenerate the docs yourselves, I can drop those six files and leave just the source comments.
