### PR TITLE
Fix: Sidebar resizer appearing in the editor area

### DIFF
--- a/src/utils/Resizer.js
+++ b/src/utils/Resizer.js
@@ -394,9 +394,13 @@ define(function (require, exports, module) {
         // reposition it if the element size changes externally
         function repositionResizer(elementSize) {
             var resizerPosition = elementSize || 1;
-            if (position === POSITION_RIGHT || position === POSITION_BOTTOM) {
-                $resizer.css(resizerCSSPosition, resizerPosition);
+            if (position !== POSITION_RIGHT && position !== POSITION_BOTTOM) {
+                return;
             }
+            if (collapsible && !isVisible($element)) {
+                return;
+            }
+            $resizer.css(resizerCSSPosition, resizerPosition);
         }
 
         $element.data("removeSizable", function () {

--- a/src/view/CentralControlBar.js
+++ b/src/view/CentralControlBar.js
@@ -213,7 +213,8 @@ define(function (require, exports, module) {
         if (targetWidth < minLPToolbarWidth) {
             targetWidth = minLPToolbarWidth;
         }
-        if (sidebarWidth + BAR_WIDTH + targetWidth + MIN_EDITOR_WIDTH > window.innerWidth) {
+        if (SidebarView.isVisible() &&
+                sidebarWidth + BAR_WIDTH + targetWidth + MIN_EDITOR_WIDTH > window.innerWidth) {
             const trimmedSidebar = Math.max(30, window.innerWidth - BAR_WIDTH - targetWidth - MIN_EDITOR_WIDTH);
             $sidebar.width(trimmedSidebar);
             // jQuery .width() sidesteps Resizer — manually reposition its handle so

--- a/src/view/WorkspaceManager.js
+++ b/src/view/WorkspaceManager.js
@@ -608,7 +608,7 @@ define(function (require, exports, module) {
             return;
         }
         var $sb = $("#sidebar");
-        if (!$sb.length || $sb[0].offsetWidth === 0) {
+        if (!$sb.length || !Resizer.isVisible($sb) || $sb[0].offsetWidth === 0) {
             return;
         }
         var toolbarW = $mainToolbar.is(":visible") ? $mainToolbar.width() : 0;

--- a/test/spec/CentralControlBar-integ-test.js
+++ b/test/spec/CentralControlBar-integ-test.js
@@ -230,6 +230,36 @@ define(function (require, exports, module) {
                 SidebarView.show();
                 await awaitsFor(function () { return SidebarView.isVisible(); }, "sidebar to show again", 2000);
             });
+
+            it("should keep the handle parked at the CCB edge when the layout is clamped while hidden",
+                async function () {
+                    await openLivePreview();
+                    SidebarView.hide();
+                    await awaitsFor(function () { return !SidebarView.isVisible(); }, "sidebar to hide", 2000);
+
+                    const toolbarWidth = _$("#main-toolbar").is(":visible") ? _$("#main-toolbar").width() : 0;
+                    const maxSidebar = testWindow.innerWidth - CCB_WIDTH - toolbarWidth - 100;
+                    const overLimitWidth = maxSidebar + 50;
+                    expect(overLimitWidth).toBeLessThan(testWindow.innerWidth);
+                    _$("#sidebar").width(overLimitWidth);
+
+                    testWindow.dispatchEvent(new testWindow.Event("resize"));
+
+                    const $resizer = _$(".main-view > .horz-resizer");
+                    expect($resizer.length).toBe(1);
+                    expect(Math.round($resizer[0].getBoundingClientRect().left)).toBe(CCB_WIDTH);
+                    expect(_$("#sidebar")[0].offsetWidth).toBe(overLimitWidth);
+
+                    SidebarView.show();
+                    await awaitsFor(function () { return SidebarView.isVisible(); }, "sidebar to show again", 2000);
+                    const sidebarWidth = _$("#sidebar")[0].offsetWidth;
+                    expect(sidebarWidth).toBeLessThan(overLimitWidth);
+                    const $shownResizer = _$("#sidebar > .horz-resizer");
+                    expect(Math.round($shownResizer[0].getBoundingClientRect().left))
+                        .toBe(sidebarWidth + CCB_WIDTH);
+
+                    SidebarView.resize(200);
+                });
         });
 
         describe("2. CCB buttons", function () {


### PR DESCRIPTION
When the sidebar was collapsed, its drag handle could get left floating in the middle of the editor / live preview area sometimes. To repro: widen the sidebar → collapse it → open live preview → resize the window. 
**Visual reference of bug**
<img width="1367" height="902" alt="Screenshot 2026-08-23 at 11 37 57 PM" src="https://github.com/user-attachments/assets/bb571c04-a5f5-459e-8b12-93ef5d04b7ab" />


**Fix** - Now, we don't move the handle while the sidebar is collapsed, and don't resize a sidebar that isn't on screen. The sidebar is now sized when it's expanded instead.