### PR TITLE
Fix: submenu is occluded by the central control bar

### DIFF
--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -763,9 +763,9 @@ define(function (require, exports, module) {
                 // This is to prevent size jumps when the keyboard
                 // icon hides and shows as selection changes
                 $menuAnchor.addClass("use-invisible-for-width-compute");
-                const currentWidth = $(this).width(); // Get the current width
+                const currentWidth = window.getComputedStyle(this).width;
                 $menuAnchor.removeClass("use-invisible-for-width-compute");
-                $(this).css('min-width', currentWidth + 'px');
+                $(this).css('min-width', currentWidth);
                 self.closeSubMenu();
                 // now show selection
                 $menuItem.parent().find(".menuAnchor").removeClass("selected");
@@ -937,9 +937,9 @@ define(function (require, exports, module) {
         let self = this;
         $menuItem.on("mouseenter", function (e) {
             $menuAnchor.addClass("use-invisible-for-width-compute");
-            const currentWidth = $(this).width(); // Get the current width
+            const currentWidth = window.getComputedStyle(this).width;
             $menuAnchor.removeClass("use-invisible-for-width-compute");
-            $(this).css('min-width', currentWidth + 'px'); // Set min-width to the current width
+            $(this).css('min-width', currentWidth);
             if (self.openSubMenu && self.openSubMenu.id === menu.id) {
                 return;
             }

--- a/src/styles/CentralControlBar.less
+++ b/src/styles/CentralControlBar.less
@@ -28,7 +28,7 @@
     height: 100%;
     width: @central-control-bar-width;
     left: @sidebar-width; /* updated dynamically when sidebar resizes */
-    z-index: @z-index-brackets-main-content + 1;
+    z-index: @z-index-brackets-main-content - 1;
     display: flex;
     flex-direction: column;
     align-items: stretch;

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -335,7 +335,7 @@ a, img {
         left: (@sidebar-width + 30px);  // changed dynamically via Resizer + CentralControlBar
         right: @main-toolbar-width;
         z-index: @z-index-brackets-main-content;
-        border-left: 2px solid rgba(255, 255, 255, 0.10);
+        border-left: 2px solid transparent;
         border-right: 2px solid rgba(255, 255, 255, 0.10);
     }
 

--- a/src/styles/brackets_variables.less
+++ b/src/styles/brackets_variables.less
@@ -22,7 +22,7 @@
 
 /* Brackets Variables */
 :root {
- /* Above the central control bar (@z-index-brackets-main-content + 1 = 20) so the
+ /* Above the central control bar (@z-index-brackets-main-content - 1 = 18) so the
     parameter hint is never occluded by it when it sits near the editor's left edge. */
  --z-index-parameter-hints: 21;
  --editor-line-height: 1.5;


### PR DESCRIPTION
This PR fixes 2 small problems: 1. submenu being occluded by the CCB. (visuals attached).....2. on mouseenter (hover) over the dropdowns, the dropdowns width slightly shifted, because of jquery width rounding.

**Before**
<img width="509" height="391" alt="Screenshot 2026-08-26 at 12 43 13 AM" src="https://github.com/user-attachments/assets/fadcc71c-e033-4bbb-bd21-e68b3a2bc129" />

**After**
<img width="470" height="361" alt="Screenshot 2026-08-26 at 12 42 12 AM" src="https://github.com/user-attachments/assets/cf3738b2-048b-4ef0-a58f-9db52908f31c" />
